### PR TITLE
Fixed tooltips not working in dataset tabs.

### DIFF
--- a/dataverse-webapp/src/main/webapp/createDataset.xhtml
+++ b/dataverse-webapp/src/main/webapp/createDataset.xhtml
@@ -62,7 +62,7 @@
                                 
                                 <p:ajax event="change" update="@form"
                                         listener="#{CreateDatasetPage.updateSelectedTemplate}"
-                                        oncomplete="javascript:bind_bsui_components();"/>
+                                        />
                             </p:selectOneMenu>
                         </div>
                     </div>
@@ -117,7 +117,7 @@
                                      value="#{bundle['file.addBtn']}"
                                      action="#{CreateDatasetPage.save}"
                                      update="@form,:messagePanel"
-                                     oncomplete="javascript:bind_bsui_components();$(document).scrollTop(0);"
+                                     oncomplete="$(document).scrollTop(0);"
                                      />
                     <p:button id="cancelCreate" value="#{bundle.cancel}"
                               outcome="/dataverse.xhtml?alias=#{CreateDatasetPage.dataset.owner.alias}" />

--- a/dataverse-webapp/src/main/webapp/createEditDataverse.xhtml
+++ b/dataverse-webapp/src/main/webapp/createEditDataverse.xhtml
@@ -173,7 +173,7 @@
                                                             styleClass="btn btn-default btn-sm bootstrap-button-tooltip"
                                                             title="#{bundle.add}"
                                                             actionListener="#{CreateEditDataversePage.dataverse.addDataverseContact(valCount.index + 1)}"
-                                                            oncomplete="javascript:bind_bsui_components();">
+                                                            >
                                                         <f:param name="SKIP_VALIDATION" value="true"/>
                                                         <h:outputText styleClass="glyphicon glyphicon-plus no-text"/>
                                                     </p:commandLink>
@@ -182,7 +182,7 @@
                                                             title="#{bundle.delete}"
                                                             rendered="#{CreateEditDataversePage.dataverse.dataverseContacts.size() > 1}"
                                                             actionListener="#{CreateEditDataversePage.dataverse.removeDataverseContact(valCount.index)}"
-                                                            oncomplete="javascript:bind_bsui_components();">
+                                                            >
                                                         <f:param name="SKIP_VALIDATION" value="true"/>
                                                         <h:outputText styleClass="glyphicon glyphicon-minus no-text"/>
                                                     </p:commandLink>
@@ -284,7 +284,7 @@
                                                                rendered="#{!CreateEditDataversePage.mdbOptions.isShowDatasetFieldTypes(mdb.id)
                                                                and (CreateEditDataversePage.mdbOptions.mdbViewOptions.get(mdb.id).selected or mdb.isCitationMetaBlock()) and !CreateEditDataversePage.mdbOptions.inheritMetaBlocksFromParent}"
                                                                actionListener="#{CreateEditDataversePage.showEditableDatasetFieldTypes(mdb.id)}"
-                                                               oncomplete="javascript:bind_bsui_components();">
+                                                               >
                                                     <h:outputText value="#{bundle['dataverse.field.set.tip']}"/>
                                                 </p:commandLink>
                                                 <p:commandLink id="viewUnEditableDSFT" style="margin-left:1em;"
@@ -293,7 +293,7 @@
                                                                rendered="#{!CreateEditDataversePage.mdbOptions.isShowDatasetFieldTypes(mdb.id)
                                                                 and (!CreateEditDataversePage.mdbOptions.mdbViewOptions.get(mdb.id).selected or CreateEditDataversePage.mdbOptions.inheritMetaBlocksFromParent)}"
                                                                actionListener="#{CreateEditDataversePage.showUnEditableDatasetFieldTypes(mdb.id)}"
-                                                               oncomplete="javascript:bind_bsui_components();">
+                                                               >
                                                     <h:outputText value="#{bundle['dataverse.field.set.view']}"/>
                                                 </p:commandLink>
                                             </label>
@@ -350,7 +350,7 @@
                                                            update="@widgetVar(optionBlock)"
                                                            actionListener="#{CreateEditDataversePage.hideDatasetFieldTypes(mdb.id)}"
                                                            immediate="true"
-                                                           oncomplete="javascript:bind_bsui_components();"
+
                                                            rendered="#{CreateEditDataversePage.mdbOptions.isShowDatasetFieldTypes(mdb.id) }">
                                                 <h:outputText value="#{bundle.done}"/>
                                             </p:commandLink>

--- a/dataverse-webapp/src/main/webapp/dataset-deaccession-dialog.xhtml
+++ b/dataverse-webapp/src/main/webapp/dataset-deaccession-dialog.xhtml
@@ -14,7 +14,7 @@
             process="@this"
             update="@none"
             action="#{datasetDeaccessionDialog.reloadAndRenderDialog()}"
-            oncomplete="PF('deaccessDatasetDialog').show();bind_bsui_components();" />
+            oncomplete="PF('deaccessDatasetDialog').show();" />
 
     <p:outputPanel id="deaccessionContentPanel">
         <p:autoUpdate />

--- a/dataverse-webapp/src/main/webapp/dataset-widgets.xhtml
+++ b/dataverse-webapp/src/main/webapp/dataset-widgets.xhtml
@@ -43,7 +43,7 @@
                                             <h:graphicImage value="#{DatasetWidgetsPage.datasetThumbnail.base64image}" rendered="#{DatasetWidgetsPage.datasetThumbnail != null}"/>
                                         </p>
                                         <span class="text-muted" jsf:rendered="#{DatasetWidgetsPage.datasetThumbnail == null}"><em>#{bundle['dataset.thumbnailsAndWidget.thumbnailImage.default']}</em></span>
-                                        <p:commandButton update="@all" value="#{bundle.remove}" action="#{DatasetWidgetsPage.flagDatasetThumbnailForRemoval()}" rendered="#{DatasetWidgetsPage.datasetThumbnail != null and DatasetWidgetsPage.datasetThumbnail.fromDataFile != true}" oncomplete="bind_bsui_components();"/>
+                                        <p:commandButton update="@all" value="#{bundle.remove}" action="#{DatasetWidgetsPage.flagDatasetThumbnailForRemoval()}" rendered="#{DatasetWidgetsPage.datasetThumbnail != null and DatasetWidgetsPage.datasetThumbnail.fromDataFile != true}" />
                                         <div jsf:rendered="#{DatasetWidgetsPage.datasetThumbnail.fromDataFile == true}">
                                             <button type="button" class="btn btn-default" onclick="PF('confrmRemove').show()">#{bundle.remove}</button>
                                         </div>
@@ -67,7 +67,7 @@
                                             </label>
                                             <p:fileUpload invalidFileMessage="#{bundle['dataset.thumbnailsAndWidget.thumbnailImage.upload.invalidMsg']}" id="changelogo" allowTypes="/(\.|\/)(jpg|jpeg|tff|png|gif)$/" update="@all" 
                                                           sizeLimit="#{systemConfig.uploadLogoSizeLimit}" 
-                                                          oncomplete="bind_bsui_components();" dragDropSupport="true" auto="true" multiple="false" 
+                                                           dragDropSupport="true" auto="true" multiple="false"
                                                           fileUploadListener="#{DatasetWidgetsPage.handleImageFileUpload}" label="#{bundle['dataset.thumbnailsAndWidget.thumbnailImage.upload']}"/>
                                         </div>
                                     </div>

--- a/dataverse-webapp/src/main/webapp/dataset.xhtml
+++ b/dataverse-webapp/src/main/webapp/dataset.xhtml
@@ -619,7 +619,7 @@
                     </p:fragment>
 
                     <p:tabView id="tabView" widgetVar="content" activeIndex="#{DatasetPage.selectedTabIndex}"
-                                   dynamic="true">
+                                   dynamic="true" onTabShow="bind_bsui_components();">
 
                         <p:tab id="dataFilesTab" title="#{bundle.files}" rendered="#{!DatasetPage.workingVersion.deaccessioned or
                                                               (DatasetPage.workingVersion.deaccessioned and DatasetPage.canUpdateDataset())}">

--- a/dataverse-webapp/src/main/webapp/dataset.xhtml
+++ b/dataverse-webapp/src/main/webapp/dataset.xhtml
@@ -170,7 +170,7 @@
                                 <p:commandLink
                                         rendered="#{dataverseSession.user.authenticated and !DatasetPage.workingVersion.deaccessioned and DatasetPage.dataset.released}"
                                         type="button" styleClass="btn btn-default btn-access"
-                                        oncomplete="PF('linkDatasetForm').show();bind_bsui_components();"
+                                        oncomplete="PF('linkDatasetForm').show();"
                                         update="linkDatasetForm">
                                     <span class="glyphicon glyphicon-link"/> #{bundle['link']}
                                 </p:commandLink>
@@ -619,7 +619,7 @@
                     </p:fragment>
 
                     <p:tabView id="tabView" widgetVar="content" activeIndex="#{DatasetPage.selectedTabIndex}"
-                                   dynamic="true" onTabShow="bind_bsui_components();">
+                                   dynamic="true">
 
                         <p:tab id="dataFilesTab" title="#{bundle.files}" rendered="#{!DatasetPage.workingVersion.deaccessioned or
                                                               (DatasetPage.workingVersion.deaccessioned and DatasetPage.canUpdateDataset())}">

--- a/dataverse-webapp/src/main/webapp/dataverse_template.xhtml
+++ b/dataverse-webapp/src/main/webapp/dataverse_template.xhtml
@@ -117,6 +117,13 @@
                 bind_bsui_components();
             });
 
+            var originalPrimeFacesAjaxUtilsSend = PrimeFaces.ajax.Request.send;
+            PrimeFaces.ajax.Request.send = function(cfg) {
+                if (!cfg.oncomplete) {
+                    cfg.oncomplete = bind_bsui_components();
+                }
+                originalPrimeFacesAjaxUtilsSend.apply(this, arguments);
+            };
             
             //]]>
         </script>

--- a/dataverse-webapp/src/main/webapp/dataverse_template.xhtml
+++ b/dataverse-webapp/src/main/webapp/dataverse_template.xhtml
@@ -36,7 +36,7 @@
         <link type="text/css" rel="stylesheet" href="#{resource['css/socicon.css']}?version=#{systemConfig.getVersion()}" />
         <link type="text/css" rel="stylesheet" href="#{resource['css/structure.css']}?version=#{systemConfig.getVersion()}" />
         <link type="text/css" rel="stylesheet" href="#{resource['vecler/theme.css']}?version=#{systemConfig.getVersion()}" />
-        <link type="text/css" rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,700&amp;display=swap" /> 
+        <link type="text/css" rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,700&amp;display=swap" />
         <ui:fragment rendered="#{!widgetWrapper.widgetView}">
             <script>
                 // Break out of iframe
@@ -52,7 +52,7 @@
     </h:head>
     <h:body styleClass="#{widgetWrapper.widgetView ? 'widget-view' : ''}">
         <f:loadBundle basename="Bundle" var="bundle"/>
-	<a href="#content" class="sr-only">#{bundle['body.skip']}</a>                
+	<a href="#content" class="sr-only">#{bundle['body.skip']}</a>
         <ui:include src="dataverse_header.xhtml">
             <ui:param name="dataverse" value="#{dataverse != null ? dataverse : dataverseServiceBean.findRootDataverse()}"/>
             <ui:param name="showDataverseHeader" value="#{showDataverseHeader != null ? showDataverseHeader : true}"/>
@@ -92,8 +92,8 @@
         <script type="text/javascript" defer="defer" src="#{resource['js/dv_rebind_bootstrap_ui.js']}?version=#{systemConfig.getVersion()}"></script>
         <script type="text/javascript" defer="defer" src="#{resource['js/owl.carousel.js']}?version=#{systemConfig.getVersion()}"></script>
         <script type="text/javascript" defer="defer" src="#{resource['js/jquery.matchHeight.js']}?version=#{systemConfig.getVersion()}"></script>
-        <script type="text/javascript" defer="defer" src="#{resource['js/jquery.sharrre.js']}?version=#{systemConfig.getVersion()}"></script>  
-        <script type="text/javascript" defer="defer" src="#{resource['js/clipboard.min.js']}?version=#{systemConfig.getVersion()}"></script>          
+        <script type="text/javascript" defer="defer" src="#{resource['js/jquery.sharrre.js']}?version=#{systemConfig.getVersion()}"></script>
+        <script type="text/javascript" defer="defer" src="#{resource['js/clipboard.min.js']}?version=#{systemConfig.getVersion()}"></script>
         <ui:fragment rendered="#{settingsWrapper.shibPassiveLoginEnabled}">
             <script type="text/javascript" language="javascript" src="#{resource['js/shib/isPassive.js']}"></script>
         </ui:fragment>
@@ -113,18 +113,13 @@
                     ;
                 });
 
-                // Rebind bootstrap UI components
                 bind_bsui_components();
+
+                $(document).on('pfAjaxComplete', function () {
+                    bind_bsui_components();
+                })
             });
 
-            var originalPrimeFacesAjaxUtilsSend = PrimeFaces.ajax.Request.send;
-            PrimeFaces.ajax.Request.send = function(cfg) {
-                if (!cfg.oncomplete) {
-                    cfg.oncomplete = bind_bsui_components();
-                }
-                originalPrimeFacesAjaxUtilsSend.apply(this, arguments);
-            };
-            
             //]]>
         </script>
     </h:body>

--- a/dataverse-webapp/src/main/webapp/dataverseuser.xhtml
+++ b/dataverse-webapp/src/main/webapp/dataverseuser.xhtml
@@ -53,13 +53,13 @@
                                 <ui:fragment rendered="#{DataverseUserPage.passwordEditable or DataverseUserPage.accountDetailsEditable}">
                                     <li>
                                         <p:commandLink id="editAccount" rendered="#{DataverseUserPage.accountDetailsEditable}"
-                                                       actionListener="#{DataverseUserPage.edit}" update="@form" oncomplete="javascript:bind_bsui_components();">
+                                                       actionListener="#{DataverseUserPage.edit}" update="@form" >
                                             <h:outputText value="#{bundle['account.info']}" />
                                         </p:commandLink>
                                     </li>
                                     <li>
                                         <p:commandLink id="changePassword" rendered="#{DataverseUserPage.passwordEditable}" 
-                                                       actionListener="#{DataverseUserPage.changePassword}" update="@form" oncomplete="javascript:bind_bsui_components();">
+                                                       actionListener="#{DataverseUserPage.changePassword}" update="@form" >
                                             <h:outputText value="#{bundle.passwd}" />
                                         </p:commandLink>
                                     </li>
@@ -73,7 +73,7 @@
                     </p:panel>
 
                     <p:tabView id="dataRelatedToMeView" activeIndex="#{DataverseUserPage.activeIndex}" dynamic="true" rendered="#{empty DataverseUserPage.editMode}">
-                        <p:ajax event="tabChange" listener="#{DataverseUserPage.onTabChange}" update="@all" oncomplete="javascript:bind_bsui_components();" />
+                        <p:ajax event="tabChange" listener="#{DataverseUserPage.onTabChange}" update="@all"  />
                         <p:tab id="myData" title="#{bundle['user.dataRelatedToMe']}">
                             <ui:include src="mydata_fragment.xhtml"></ui:include>
                         </p:tab>
@@ -325,7 +325,7 @@
                                         <div class="notification-item-cell">
                                             <p:commandLink title="#{bundle.removeNotification}" styleClass="bootstrap-button-tooltip"
                                                            action="#{DataverseUserPage.remove(item.id)}" update="@form"
-                                                           oncomplete="bind_bsui_components();">
+                                                           >
                                                 <span class="glyphicon glyphicon-remove"></span>
                                             </p:commandLink>
                                         </div>

--- a/dataverse-webapp/src/main/webapp/editDatasetMetadata.xhtml
+++ b/dataverse-webapp/src/main/webapp/editDatasetMetadata.xhtml
@@ -72,7 +72,7 @@
                                          style="display:none"
                                          update=":editMetadataForm,:messagePanel"
                                          onclick="PF('lockEditMetadataForm').show();"
-                                         oncomplete="javascript:bind_bsui_components();$(document).scrollTop(0);"
+                                         oncomplete="$(document).scrollTop(0);"
                                          action="#{editDatasetMetadataPage.save}" />
                     </div>
 

--- a/dataverse-webapp/src/main/webapp/editFilesFragment.xhtml
+++ b/dataverse-webapp/src/main/webapp/editFilesFragment.xhtml
@@ -134,7 +134,7 @@
                                   process="filesTable" 
                                   update=":datasetForm:filesTable, @([id$=filesButtons])"
                                   label="#{bundle['file.selectToAddBtn']}"
-                                  oncomplete="javascript:bind_bsui_components();uploadFinished(PF('fileUploadWidget'));"
+                                  oncomplete="uploadFinished(PF('fileUploadWidget'));"
                                   onstart="javascript:uploadWidgetDropRemoveMsg();uploadStarted();"
                                   onerror="javascript:uploadFailure();"
                                   sizeLimit="#{EditDatafilesPage.getMaxFileUploadSizeInBytes()}"
@@ -449,7 +449,7 @@
                                     <li class="#{lockedFromEdits  ? 'disabled' : ''}">
                                         <p:commandLink id="fileProvenanceButton"
                                                    update=":datasetForm:editProvenancePopup"
-                                                   oncomplete="PF('editProvenancePopup').show();bind_bsui_components();">
+                                                   oncomplete="PF('editProvenancePopup').show();">
                                             <f:actionListener binding="#{provPopupFragmentBean.updatePopupStateAndDataset(fileMetadata, EditDatafilesPage.dataset)}" />
                                                     #{bundle['file.provenance']} 
                                         </p:commandLink>    
@@ -460,7 +460,7 @@
                                     <p:commandLink id="fileCategoriesButton"
                                                actionListener="#{EditDatafilesPage.refreshTagsPopUp(fileMetadata)}"
                                                update=":datasetForm:editFileTagsPopup"
-                                               oncomplete="PF('editFileTagsPopup').show();bind_bsui_components();">
+                                               oncomplete="PF('editFileTagsPopup').show();">
                                                 #{bundle['file.tags']} 
                                     </p:commandLink>
                                 </li>

--- a/dataverse-webapp/src/main/webapp/editMetadata.xhtml
+++ b/dataverse-webapp/src/main/webapp/editMetadata.xhtml
@@ -54,7 +54,7 @@
                                                                                    styleClass="btn btn-default btn-sm bootstrap-button-tooltip #{dsf.datasetFieldType.compound ? 'compound-field-btn' : ''}"
                                                                                    actionListener="#{dsf.addDatasetFieldValue(valCount.index + 1)}"
                                                                                    update=":#{p:resolveClientIds('@id(editPrimitiveValueFragment)', view)}"
-                                                                                   oncomplete="javascript:bind_bsui_components();">
+                                                                                   >
                                                                         <span class="glyphicon glyphicon-plus no-text"/>
                                                                     </p:commandLink>
                                                                     <p:commandLink tabindex="#{block.index+1}" title="#{bundle.delete}"
@@ -62,7 +62,7 @@
                                                                                    rendered="#{dsf.datasetFieldValues.size() > 1}"
                                                                                    actionListener="#{dsf.removeDatasetFieldValue(valCount.index)}"
                                                                                    update=":#{p:resolveClientIds('@id(editPrimitiveValueFragment)', view)}"
-                                                                                   oncomplete="javascript:bind_bsui_components();">
+                                                                                   >
                                                                         <span class="glyphicon glyphicon-minus no-text"/>
                                                                     </p:commandLink>
                                                                 </div>
@@ -144,7 +144,7 @@
                                                                        styleClass="btn btn-default btn-sm bootstrap-button-tooltip #{dsf.datasetFieldType.compound ? 'compound-field-btn' : ''}"
                                                                        actionListener="#{dsf.addDatasetFieldCompoundValue(valCount.index + 1)}"   
                                                                        update=":#{p:resolveClientIds('@id(editCompoundValueFragment)', view)}"
-                                                                       oncomplete="javascript:bind_bsui_components();">
+                                                                       >
                                                             <span class="glyphicon glyphicon-plus no-text"/>
                                                         </p:commandLink>
                                                         <p:commandLink tabindex="#{block.index+1}" title="#{bundle.delete}"
@@ -152,7 +152,7 @@
                                                                        rendered="#{dsf.datasetFieldCompoundValues.size() > 1}"
                                                                        actionListener="#{dsf.removeDatasetFieldCompoundValue(valCount.index)}"
                                                                        update=":#{p:resolveClientIds('@id(editCompoundValueFragment)', view)}"
-                                                                       oncomplete="javascript:bind_bsui_components();">
+                                                                       >
                                                             <span class="glyphicon glyphicon-minus no-text"/>
                                                         </p:commandLink>
                                                     </div>

--- a/dataverse-webapp/src/main/webapp/editdatafiles.xhtml
+++ b/dataverse-webapp/src/main/webapp/editdatafiles.xhtml
@@ -62,12 +62,12 @@
                                             onclick="PF('blockFileForm').show();"
                                             action="#{EditDatafilesPage.save}"
                                             update="@form,:messagePanel"
-                                            oncomplete="javascript:bind_bsui_components();$(document).scrollTop(0);" />
-                                    <p:commandButton tabindex="1000" id="cancel" value="#{bundle.cancel}" action="#{EditDatafilesPage.cancel}" process="@this" update="@form" oncomplete="javascript:bind_bsui_components();">
+                                            oncomplete="$(document).scrollTop(0);" />
+                                    <p:commandButton tabindex="1000" id="cancel" value="#{bundle.cancel}" action="#{EditDatafilesPage.cancel}" process="@this" update="@form" >
                                     </p:commandButton>
                                 </div>
                                 <div jsf:rendered="#{empty EditDatafilesPage.fileMetadatas and (datasetPage || EditDatafilesPage.showFileUploadFragment())}">
-                                    <p:commandButton tabindex="1000" id="doneFilesButton" value="#{bundle.done}" action="#{EditDatafilesPage.cancel}" process="@this" update="@form" oncomplete="javascript:bind_bsui_components();">
+                                    <p:commandButton tabindex="1000" id="doneFilesButton" value="#{bundle.done}" action="#{EditDatafilesPage.cancel}" process="@this" update="@form" >
                                     </p:commandButton>
 
                                 </div>

--- a/dataverse-webapp/src/main/webapp/file-download-button-fragment.xhtml
+++ b/dataverse-webapp/src/main/webapp/file-download-button-fragment.xhtml
@@ -251,7 +251,7 @@
                                disabled="#{(fileMetadata.dataFile.ingestInProgress  or lockedFromDownload or empty fileMetadata.dataFile.id) ? 'disabled' : ''}"
                                actionListener="#{guestbookResponseService.modifyDatafileAndFormat(guestbookResponse,fileMetadata, 'subset')}"
                                update="@widgetVar(downloadDataSubsetPopup)"
-                               oncomplete="PF('downloadDataSubsetPopup').show();bind_bsui_components();"
+                               oncomplete="PF('downloadDataSubsetPopup').show();"
                                value="#{bundle['file.downloadBtn.format.datasubset']}"
                                />
                 <p:commandLink id="fileDowloadDataSubsetButtonPopupReq" rendered="#{downloadPopupRequired

--- a/dataverse-webapp/src/main/webapp/file.xhtml
+++ b/dataverse-webapp/src/main/webapp/file.xhtml
@@ -115,7 +115,7 @@
                                                 <li class="#{FilePage.lockedFromEdits  ? 'disabled' : ''}">
                                                     <p:commandLink id="fileProvenanceButton"
                                                                update="editProvenancePopup"
-                                                               oncomplete="PF('editProvenancePopup').show();bind_bsui_components();">
+                                                               oncomplete="PF('editProvenancePopup').show();">
                                                                <f:actionListener binding="#{provPopupFragmentBean.updatePopupState(fileMetadata, true)}" /> <!--clearProvenanceUpdates() -->
                                                                 #{bundle['file.provenance']} 
                                                     </p:commandLink>
@@ -370,7 +370,7 @@
                     <div id="contentTabs">
                         <!-- Metadata -->
                         <p:tabView id="tabView" widgetVar="content" activeIndex="#{FilePage.selectedTabIndex}">
-                            <p:ajax event="tabChange" listener="#{FilePage.tabChanged}" oncomplete="bind_bsui_components();" update="@this" />
+                            <p:ajax event="tabChange" listener="#{FilePage.tabChanged}"  update="@this" />
                             <p:tab id="accessTab" class="padding-none" title="#{bundle['file.dataFilesTab.dataAccess']}"
                                    rendered="#{settingsWrapper.rsyncDownload and FilePage.fileMetadata.dataFile.filePackage and systemConfig.rsyncDownload
                                         and !FilePage.fileMetadata.getDataFile().getOwner().getStorageIdentifier().startsWith('s3://') }">

--- a/dataverse-webapp/src/main/webapp/filesFragment.xhtml
+++ b/dataverse-webapp/src/main/webapp/filesFragment.xhtml
@@ -268,7 +268,7 @@
                                     type="button" styleClass="btn btn-default btn-download"
                                     disabled="#{false and DatasetPage.lockedFromDownload}"
                                     action="#{DatasetPage.validateFilesForDownload(true, false)}"
-                                    update="@form" oncomplete="">
+                                    update="@form" >
                         <span class="glyphicon glyphicon-download-alt"/> #{bundle.download}
                     </p:commandLink>
                 </div>
@@ -291,7 +291,7 @@
                                 <p:commandLink rendered="#{DatasetPage.downloadPopupRequired}"
                                                 disabled="#{false and DatasetPage.lockedFromDownload}"
                                                 action="#{DatasetPage.validateFilesForDownload(true, true)}"
-                                                update="@form" oncomplete="">
+                                                update="@form" >
                                     #{bundle.downloadOriginal}
                                 </p:commandLink>
                             </li>
@@ -306,7 +306,7 @@
                                 <p:commandLink rendered="#{DatasetPage.downloadPopupRequired}"
                                                 disabled="#{false and DatasetPage.lockedFromDownload}"
                                                 action="#{DatasetPage.validateFilesForDownload(true, false)}"
-                                                update="@form" oncomplete="">
+                                                update="@form" >
                                     #{bundle.downloadArchival}
                                 </p:commandLink>
                             </li>

--- a/dataverse-webapp/src/main/webapp/guestbook.xhtml
+++ b/dataverse-webapp/src/main/webapp/guestbook.xhtml
@@ -136,7 +136,7 @@
                                                                     styleClass="btn btn-default btn-sm bootstrap-button-tooltip nolabel-field-btn"
                                                                     title="#{bundle.add}"
                                                                     update=":guestbookForm:customQuestions"
-                                                                    oncomplete="javascript:bind_bsui_components();"
+
                                                                     actionListener="#{GuestbookPage.addCustomQuestionValue(cq, resCount.index + 1)}">
                                                                 <span class="glyphicon glyphicon-plus no-text"/>
                                                             </p:commandLink>
@@ -145,7 +145,7 @@
                                                                     title="#{bundle.delete}"
                                                                     rendered="#{cq.customQuestionValues.size() > 1}"
                                                                     update=":guestbookForm:customQuestions"
-                                                                    oncomplete="javascript:bind_bsui_components();"
+
                                                                     actionListener="#{GuestbookPage.removeCustomQuestionValue(cq, resCount.index)}">
                                                                 <span class="glyphicon glyphicon-minus no-text"/>
                                                             </p:commandLink>
@@ -164,7 +164,7 @@
                                             <p:commandLink
                                                     styleClass="btn btn-default btn-sm bootstrap-button-tooltip compound-field-btn"
                                                     title="#{bundle.add}" update=":guestbookForm:customQuestions"
-                                                    oncomplete="javascript:bind_bsui_components();"
+
                                                     actionListener="#{GuestbookPage.addCustomQuestion(valCount.index + 1 )}">
                                                 <span class="glyphicon glyphicon-plus no-text"/>
                                             </p:commandLink>
@@ -172,7 +172,7 @@
                                                     styleClass="btn btn-default btn-sm bootstrap-button-tooltip compound-field-btn"
                                                     rendered="#{GuestbookPage.guestbook.customQuestions.size() > 1}"
                                                     title="#{bundle.delete}" update=":guestbookForm:customQuestions"
-                                                    oncomplete="javascript:bind_bsui_components();"
+
                                                     actionListener="#{GuestbookPage.removeCustomQuestion(valCount.index)}">
                                                 <span class="glyphicon glyphicon-minus no-text"/>
                                             </p:commandLink>

--- a/dataverse-webapp/src/main/webapp/harvestclients.xhtml
+++ b/dataverse-webapp/src/main/webapp/harvestclients.xhtml
@@ -31,7 +31,7 @@
                                 <p:commandLink type="button" id="addClientEmpty" styleClass="btn btn-default margin-bottom"
                                                actionListener="#{harvestingClientsPage.initNewClient}"
                                                update=":harvestingClientsForm:newHarvestingClientDialog"
-                                               oncomplete="PF('newHarvestingClientForm').show();handleResizeDialog('newHarvestingClientDialog');bind_bsui_components();">
+                                               oncomplete="PF('newHarvestingClientForm').show();handleResizeDialog('newHarvestingClientDialog');">
                                     <span class="glyphicon glyphicon-plus"/> #{bundle['harvestclients.btn.add']}
                                 </p:commandLink>
                             </div>
@@ -88,7 +88,7 @@
                                         <p:commandLink style="margin-left:1em;" type="button" id="addClient" styleClass="btn btn-default"
                                                         actionListener="#{harvestingClientsPage.initNewClient}"
                                                         update=":harvestingClientsForm:newHarvestingClientDialog"
-                                                        oncomplete="PF('newHarvestingClientForm').show();handleResizeDialog('newHarvestingClientDialog');bind_bsui_components();">
+                                                        oncomplete="PF('newHarvestingClientForm').show();handleResizeDialog('newHarvestingClientDialog');">
                                              <span class="glyphicon glyphicon-plus"/> #{bundle['harvestclients.btn.add']}
                                          </p:commandLink>
                                     </div>
@@ -125,7 +125,7 @@
                                     <p:commandLink type="button" styleClass="btn btn-default bootstrap-button-tooltip"
                                                    disabled="#{harvestClient.harvestingNow or harvestClient.deleteInProgress}"
                                                    action="#{harvestingClientsPage.editClient(harvestClient)}"
-                                                   oncomplete="PF('newHarvestingClientForm').show();handleResizeDialog('newHarvestingClientDialog');bind_bsui_components();"
+                                                   oncomplete="PF('newHarvestingClientForm').show();handleResizeDialog('newHarvestingClientDialog');"
                                                    update=":harvestingClientsForm,:harvestingClientsForm:newHarvestingClientDialog"
                                                    title="#{bundle['harvestclients.tab.header.action.btn.edit']}">
                                         <span class="glyphicon glyphicon-pencil no-text"></span>
@@ -133,7 +133,7 @@
                                     <p:commandLink type="button" styleClass="btn btn-default bootstrap-button-tooltip"
                                                    disabled="#{harvestClient.harvestingNow or harvestClient.deleteInProgress}"
                                                    action="#{harvestingClientsPage.setClientForDelete(harvestClient)}"
-                                                   oncomplete="PF('deleteConfirmation').show();bind_bsui_components();"
+                                                   oncomplete="PF('deleteConfirmation').show();"
                                                    update=":harvestingClientsForm, :messagePanel,:harvestingClientsForm:clientsTable, :harvestingClientsForm:deleteConfirmation, :harvestingClientsForm:newHarvestingClientDialog"
                                                    title="#{bundle['harvestclients.tab.header.action.btn.delete']}">
                                         <span class="glyphicon glyphicon-trash no-text"></span>
@@ -281,7 +281,7 @@
                                         <p:commandLink type="button" rendered="#{!harvestingClientsPage.initialSettingsValidated}"
                                                         id="validateInitialSettingsBtn"
                                                         styleClass="btn btn-default"
-                                                        oncomplete="PF('newHarvestingClientForm').show();bind_bsui_components();"
+                                                        oncomplete="PF('newHarvestingClientForm').show();"
                                                         update=":harvestingClientsForm:newHarvestingClientDialog"
                                                         action="#{harvestingClientsPage.validateInitialSettings()}">
                                             <span class="glyphicon glyphicon-menu-right"/> #{bundle.next}
@@ -361,7 +361,7 @@
                                                         id="createStepTwoPrevious"
                                                         styleClass="btn btn-default"
                                                         update=":harvestingClientsForm:newHarvestingClientDialog"
-                                                        oncomplete="PF('newHarvestingClientForm').show();bind_bsui_components();"
+                                                        oncomplete="PF('newHarvestingClientForm').show();"
                                                         action="#{harvestingClientsPage.backToStepOne()}">
                                             <span class="glyphicon glyphicon-menu-left"/> #{bundle.previous}
                                         </p:commandLink>
@@ -369,7 +369,7 @@
                                                         id="createStepTwoNext"
                                                         styleClass="btn btn-default"
                                                         update=":harvestingClientsForm:newHarvestingClientDialog"
-                                                        oncomplete="PF('newHarvestingClientForm').show();bind_bsui_components();"
+                                                        oncomplete="PF('newHarvestingClientForm').show();"
                                                         action="#{harvestingClientsPage.goToStepThree()}">
                                             <f:param name="DO_VALIDATION" value="true"/>
                                             <span class="glyphicon glyphicon-menu-right"/> #{bundle.next}
@@ -457,7 +457,7 @@
                                                         id="createStepThreePrevious"
                                                         styleClass="btn btn-default"
                                                         update=":harvestingClientsForm:newHarvestingClientDialog"
-                                                        oncomplete="PF('newHarvestingClientForm').show();bind_bsui_components();"
+                                                        oncomplete="PF('newHarvestingClientForm').show();"
                                                         action="#{harvestingClientsPage.backToStepTwo()}">
                                             <span class="glyphicon glyphicon-menu-left"/> #{bundle.previous}
                                         </p:commandLink>
@@ -465,7 +465,7 @@
                                                         id="createStepThreeNext"
                                                         styleClass="btn btn-default"
                                                         update=":harvestingClientsForm:newHarvestingClientDialog"
-                                                        oncomplete="PF('newHarvestingClientForm').show();bind_bsui_components();"
+                                                        oncomplete="PF('newHarvestingClientForm').show();"
                                                         action="#{harvestingClientsPage.goToStepFour()}">
                                             <span class="glyphicon glyphicon-menu-right"/> #{bundle.next}
                                         </p:commandLink>
@@ -531,7 +531,7 @@
                                                         id="createStepFourPrevious"
                                                         styleClass="btn btn-default"
                                                         update=":harvestingClientsForm:newHarvestingClientDialog"
-                                                        oncomplete="PF('newHarvestingClientForm').show();bind_bsui_components();"
+                                                        oncomplete="PF('newHarvestingClientForm').show();"
                                                         action="#{harvestingClientsPage.backToStepThree()}">
                                             <span class="glyphicon glyphicon-menu-left"/> #{bundle.previous}
                                         </p:commandLink>
@@ -541,7 +541,7 @@
                                                        value="#{bundle['harvestclients.newClientDialog.btn.create']}"
                                                        update="newHarvestingClientDialogContent :messagePanel :harvestingClientsForm clientsTable emptyClientsTable"
                                                        actionListener="#{harvestingClientsPage.createClient}"
-                                                       oncomplete="if (args &amp;&amp; !args.validationFailed) PF('newHarvestingClientForm').hide(); else PF('newHarvestingClientForm').show();bind_bsui_components();">
+                                                       oncomplete="if (args &amp;&amp; !args.validationFailed) PF('newHarvestingClientForm').hide(); else PF('newHarvestingClientForm').show();">
                                             <f:param name="DO_VALIDATION" value="true"/>
                                         </p:commandLink>
                                         <p:commandLink type="button" styleClass="btn btn-default"
@@ -549,7 +549,7 @@
                                                        value="#{bundle['harvestclients.viewEditDialog.btn.save']}"
                                                        update="newHarvestingClientDialogContent :messagePanel :harvestingClientsForm clientsTable emptyClientsTable"
                                                        actionListener="#{harvestingClientsPage.saveClient}"
-                                                       oncomplete="if (args &amp;&amp; !args.validationFailed) PF('newHarvestingClientForm').hide(); else PF('newHarvestingClientForm').show();bind_bsui_components();"/>
+                                                       oncomplete="if (args &amp;&amp; !args.validationFailed) PF('newHarvestingClientForm').hide(); else PF('newHarvestingClientForm').show();"/>
                                         <button type="button" jsf:rendered="#{harvestingClientsPage.initialSettingsValidated}" class="btn btn-default" onclick="PF('newHarvestingClientForm').hide()" value="#{bundle.cancel}">#{bundle.cancel}</button>
                                     </div>
                                 </div>

--- a/dataverse-webapp/src/main/webapp/harvestsets.xhtml
+++ b/dataverse-webapp/src/main/webapp/harvestsets.xhtml
@@ -57,7 +57,7 @@
                                 <p:commandLink type="button" id="addSetEmpty" styleClass="btn btn-default margin-bottom"
                                                actionListener="#{harvestingSetsPage.initNewSet}"
                                                update=":harvestingSetsForm:newOAISetDialog"
-                                               oncomplete="PF('newOAISetForm').show();handleResizeDialog('newOAISetDialog');bind_bsui_components();">
+                                               oncomplete="PF('newOAISetForm').show();handleResizeDialog('newOAISetDialog');">
                                     <span class="glyphicon glyphicon-plus"/> #{bundle['harvestserver.btn.add']}
                                 </p:commandLink>
                             </div>
@@ -111,7 +111,7 @@
                                         <p:commandLink type="button" id="addSet" styleClass="btn btn-default"
                                                        actionListener="#{harvestingSetsPage.initNewSet}"
                                                        update=":harvestingSetsForm:newOAISetDialog"
-                                                       oncomplete="PF('newOAISetForm').show();handleResizeDialog('newOAISetDialog');bind_bsui_components();">
+                                                       oncomplete="PF('newOAISetForm').show();handleResizeDialog('newOAISetDialog');">
                                             <span class="glyphicon glyphicon-plus"/> #{bundle['harvestserver.btn.add']}
                                         </p:commandLink>
                                     </div>
@@ -157,7 +157,7 @@
                                     <p:commandLink type="button" styleClass="btn btn-default bootstrap-button-tooltip"
                                                    disabled="#{oaiSet.updateInProgress or oaiSet.deleteInProgress}"
                                                    action="#{harvestingSetsPage.editSet(oaiSet)}"
-                                                   oncomplete="PF('newOAISetForm').show();handleResizeDialog('newOAISetDialog');bind_bsui_components();"
+                                                   oncomplete="PF('newOAISetForm').show();handleResizeDialog('newOAISetDialog');"
                                                    update=":harvestingSetsForm:newOAISetDialog"
                                                    title="#{bundle['harvestserver.tab.header.action.btn.edit']}">
                                         <span class="glyphicon glyphicon-pencil no-text"></span>
@@ -165,7 +165,7 @@
                                     <p:commandLink type="button" styleClass="btn btn-default bootstrap-button-tooltip"
                                                    disabled="#{oaiSet.defaultSet or oaiSet.updateInProgress or oaiSet.deleteInProgress}"
                                                    action="#{harvestingSetsPage.setSelectedSet(oaiSet)}"
-                                                   oncomplete="PF('deleteConfirmation').show();bind_bsui_components();"
+                                                   oncomplete="PF('deleteConfirmation').show();"
                                                    update=":harvestingSetsForm,:harvestingSetsForm:deleteConfirmation,:harvestingSetsForm:newOAISetDialog"
                                                    title="#{bundle['harvestserver.tab.header.action.btn.delete']}">
                                         <span class="glyphicon glyphicon-trash no-text"></span>
@@ -245,7 +245,7 @@
                                         <p:commandLink type="button" 
                                                          id="validateSetQueryBtn"
                                                          styleClass="btn btn-default"
-                                                         oncomplete="PF('newOAISetForm').show();bind_bsui_components();"
+                                                         oncomplete="PF('newOAISetForm').show();"
                                                          update=":harvestingSetsForm:newOAISetDialog"
                                                          action="#{harvestingSetsPage.validateSetQuery()}">
                                             <span class="glyphicon glyphicon-menu-right"/> #{bundle.next}
@@ -300,7 +300,7 @@
                                                         id="backToQuery"
                                                         styleClass="btn btn-default"
                                                         update=":harvestingSetsForm:newOAISetDialog"
-                                                        oncomplete="PF('newOAISetForm').show();bind_bsui_components();"
+                                                        oncomplete="PF('newOAISetForm').show();"
                                                         action="#{harvestingSetsPage.backToQuery()}">
                                             <span class="glyphicon glyphicon-menu-left"/> #{bundle.previous}
                                             </p:commandLink>
@@ -309,7 +309,7 @@
                                                            value="#{bundle['harvestserver.newSetDialog.btn.create']}"
                                                            update="newOAISetDialogContent :messagePanel :harvestingSetsForm setsTable emptySetsTable"
                                                            actionListener="#{harvestingSetsPage.createSet}"
-                                                           oncomplete="if (args &amp;&amp; !args.validationFailed) PF('newOAISetForm').hide(); else PF('newOAISetForm').show();bind_bsui_components();">
+                                                           oncomplete="if (args &amp;&amp; !args.validationFailed) PF('newOAISetForm').hide(); else PF('newOAISetForm').show();">
                                                 <f:param name="DO_VALIDATION" value="true"/>
                                             </p:commandLink>
                                             <p:commandLink type="button" styleClass="btn btn-default"
@@ -317,7 +317,7 @@
                                                            value="#{bundle['harvestserver.viewEditDialog.btn.save']}"
                                                            update="newOAISetDialogContent :messagePanel :harvestingSetsForm setsTable emptySetsTable"
                                                            actionListener="#{harvestingSetsPage.saveSet}"
-                                                           oncomplete="if (args &amp;&amp; !args.validationFailed) PF('newOAISetForm').hide(); else PF('newOAISetForm').show();bind_bsui_components();"/>
+                                                           oncomplete="if (args &amp;&amp; !args.validationFailed) PF('newOAISetForm').hide(); else PF('newOAISetForm').show();"/>
                                             <button type="button" jsf:rendered="#{harvestingSetsPage.setQueryValidated}" class="btn btn-default" onclick="PF('newOAISetForm').hide()" value="#{bundle.cancel}">#{bundle.cancel}</button>
                                         </div>
                                     </div>

--- a/dataverse-webapp/src/main/webapp/manage-groups.xhtml
+++ b/dataverse-webapp/src/main/webapp/manage-groups.xhtml
@@ -32,7 +32,7 @@
                         <div class="pull-right">
                             <p:commandLink type="button" id="createGroup" styleClass="btn btn-default"
                                            actionListener="#{manageGroupsPage.initExplicitGroupDialog}"
-                                           update="explicitGroupNewDialog" oncomplete="PF('explicitGroupForm').show();handleResizeDialog('explicitGroupNewDialog');bind_bsui_components();">
+                                           update="explicitGroupNewDialog" oncomplete="PF('explicitGroupForm').show();handleResizeDialog('explicitGroupNewDialog');">
                                 <span class="glyphicon glyphicon-plus"/> #{bundle['dataverse.manageGroups.createBtn']}
                             </p:commandLink>
                         </div>
@@ -78,7 +78,7 @@
                                     <div class="btn-group" role="group">
                                         <p:commandLink type="button" styleClass="btn btn-default bootstrap-button-tooltip"
                                                        action="#{manageGroupsPage.viewSelectedGroup(explicitGroup)}"
-                                                       oncomplete="PF('viewGroup').show();bind_bsui_components();"
+                                                       oncomplete="PF('viewGroup').show();"
                                                        update=":manageGroupsForm"
                                                        title="#{bundle['dataverse.manageGroups.tab.action.btn.edit']}">
                                             <span class="glyphicon glyphicon-edit"></span>

--- a/dataverse-webapp/src/main/webapp/manage-guestbooks.xhtml
+++ b/dataverse-webapp/src/main/webapp/manage-guestbooks.xhtml
@@ -113,7 +113,7 @@
                                     <div class="btn-group" role="group">
                                         <p:commandLink type="button" styleClass="btn btn-default bootstrap-button-tooltip"
                                                        action="#{manageGuestbooksPage.viewSelectedGuestbook(guestbook)}"
-                                                       oncomplete="PF('viewGuestbook').show();bind_bsui_components();"
+                                                       oncomplete="PF('viewGuestbook').show();"
                                                        update=":manageGuestbooksForm"
                                                        title="#{bundle['dataset.manageGuestbooks.tab.action.btn.view']}">
                                             <span class="glyphicon glyphicon-eye-open no-text"></span>
@@ -132,7 +132,7 @@
                                         <p:commandLink type="button" styleClass="btn btn-default bootstrap-button-tooltip"
                                                        action="#{manageGuestbooksPage.setSelectedGuestbook(guestbook)}"
                                                        rendered="#{manageGuestbooksPage.dataverse.id eq guestbook.dataverse.id and guestbook.deletable}"
-                                                       oncomplete="PF('deleteConfirmation').show();bind_bsui_components();"
+                                                       oncomplete="PF('deleteConfirmation').show();"
                                                        title="#{bundle['dataset.manageGuestbooks.tab.action.btn.delete']}">
                                             <span class="glyphicon glyphicon-trash no-text"></span>
                                         </p:commandLink>

--- a/dataverse-webapp/src/main/webapp/manage-templates.xhtml
+++ b/dataverse-webapp/src/main/webapp/manage-templates.xhtml
@@ -88,20 +88,20 @@
                                                rendered="#{manageTemplatesPage.dataverse.defaultTemplate != template}"
                                                actionListener="#{manageTemplatesPage.makeDefault(template)}"
                                                update="@form,:messagePanel"
-                                               oncomplete="bind_tooltip_popover();bind_bsui_components();"/>
+                                               oncomplete="bind_tooltip_popover();"/>
                                 <p:commandLink type="button" styleClass="btn btn-default"
                                                value="#{bundle['dataset.manageTemplates.tab.action.btn.default']}"
                                                rendered="#{manageTemplatesPage.dataverse.defaultTemplate == template}"
                                                actionListener="#{manageTemplatesPage.unselectDefault(template)}"
                                                update="@form,:messagePanel"
-                                               oncomplete="bind_tooltip_popover();bind_bsui_components();">
+                                               oncomplete="bind_tooltip_popover();">
                                     <span class="glyphicon glyphicon-eye-open"/>
                                 </p:commandLink>
                                 <div class="btn-group" role="group">
                                     <p:commandLink type="button" styleClass="btn btn-default bootstrap-button-tooltip"
                                                    title="#{bundle['dataset.manageTemplates.tab.action.btn.view']}"
                                                    action="#{manageTemplatesPage.viewSelectedTemplate(template)}"
-                                                   oncomplete="PF('viewTemplate').show();bind_tooltip_popover();bind_bsui_components();"
+                                                   oncomplete="PF('viewTemplate').show();bind_tooltip_popover();"
                                                    update=":manageTemplatesForm">
                                         <span class="glyphicon glyphicon-eye-open"/>
                                     </p:commandLink>
@@ -109,7 +109,7 @@
                                                    title="#{bundle['dataset.manageTemplates.tab.action.btn.copy']}"
                                                    action="#{manageTemplatesPage.cloneTemplate(template)}"
                                                    update="@form"
-                                                   oncomplete="bind_tooltip_popover();bind_bsui_components();">
+                                                   oncomplete="bind_tooltip_popover();">
                                         <span class="glyphicon glyphicon-duplicate"/>
                                     </p:commandLink>
                                     <div class="btn-group" jsf:rendered="#{manageTemplatesPage.dataverse.id eq template.dataverse.id}">
@@ -132,7 +132,7 @@
                                                    update="@form,:messagePanel"
                                                    action="#{manageTemplatesPage.setSelectedTemplate(template)}"
                                                    rendered="#{manageTemplatesPage.dataverse.id eq template.dataverse.id}"
-                                                   oncomplete="PF('deleteConfirmation').show();bind_tooltip_popover();bind_bsui_components();">
+                                                   oncomplete="PF('deleteConfirmation').show();bind_tooltip_popover();">
                                         <span class="glyphicon glyphicon-trash"/>
                                     </p:commandLink>
                                 </div>

--- a/dataverse-webapp/src/main/webapp/permissions-manage-files.xhtml
+++ b/dataverse-webapp/src/main/webapp/permissions-manage-files.xhtml
@@ -47,7 +47,7 @@
                                         <p:commandLink type="button" id="userGroupsAdd" styleClass="btn btn-default"
                                                        actionListener="#{manageFilePermissionsPage.initAssignDialog}"
                                                        update="assignDialog"
-                                                       oncomplete="PF('assignWidget').show();handleResizeDialog('assignDialog');bind_bsui_components();">
+                                                       oncomplete="PF('assignWidget').show();handleResizeDialog('assignDialog');">
                                             <span class="glyphicon glyphicon-user"/> #{bundle['dataverse.permissionsFiles.usersOrGroups.assignBtn']}
                                         </p:commandLink>
                                     </div>
@@ -83,7 +83,7 @@
                                                                        update=":#{p:resolveClientId('rolesPermissionsForm:userGroups', view)} :#{p:resolveClientId('rolesPermissionsForm:restrictedFiles', view)} :#{p:resolveClientId('rolesPermissionsForm:fileAccessRequests', view)}                                                                       
                                                                        :#{p:resolveClientId('rolesPermissionsForm:userGroupsRequests', view)}
                                                                        :#{p:resolveClientId('rolesPermissionsForm:userGroupMessages', view)} @([id$=Messages])"
-                                                                       oncomplete="bind_bsui_components();">
+                                                                       >
                                                             <span class="glyphicon glyphicon-ok"/> #{bundle['dataverse.permissionsFiles.assignDialog.grantBtn']}
                                                         </p:commandLink>
                                                         <p:commandLink type="button" styleClass="btn btn-default"
@@ -91,7 +91,7 @@
                                                                        update=":#{p:resolveClientId('rolesPermissionsForm:userGroups', view)} :#{p:resolveClientId('rolesPermissionsForm:restrictedFiles', view)} :#{p:resolveClientId('rolesPermissionsForm:fileAccessRequests', view)}                                                                       
                                                                        :#{p:resolveClientId('rolesPermissionsForm:userGroupsRequests', view)}
                                                                        :#{p:resolveClientId('rolesPermissionsForm:userGroupMessages', view)} @([id$=Messages])"
-                                                                       oncomplete="bind_bsui_components();">
+                                                                       >
                                                             <span class="glyphicon glyphicon-ban-circle"/> #{bundle['dataverse.permissionsFiles.assignDialog.rejectBtn']}
                                                         </p:commandLink>
                                                     </div>
@@ -116,7 +116,7 @@
                                                     <p:commandLink id="viewUserGroups"
                                                                    actionListener="#{manageFilePermissionsPage.initViewRemoveDialogByRoleAssignee(ra.key, ra.value)}"
                                                                    update=":#{p:resolveClientId('rolesPermissionsForm:viewRemoveDialog', view)}"
-                                                                   oncomplete="PF('viewRemoveWidget').show(); bind_bsui_components();">
+                                                                   oncomplete="PF('viewRemoveWidget').show(); ">
                                                         <h:outputText value="#{ra.value.size()} #{ra.value.size() eq 1 ?  bundle['dataverse.permissionsFiles.usersOrGroups.file'] : bundle['dataverse.permissionsFiles.usersOrGroups.files']}"/>
                                                     </p:commandLink>
                                                 </p:column>
@@ -192,7 +192,7 @@
                                             <p:commandLink type="button" styleClass="btn btn-default"
                                                            actionListener="#{manageFilePermissionsPage.initAssignDialogByFile(fileEntry.key)}"
                                                            update=":#{p:resolveClientId('rolesPermissionsForm:assignDialog', view)}"
-                                                           oncomplete="PF('assignWidget').show();handleResizeDialog('assignDialog');bind_bsui_components();"><span class="glyphicon glyphicon-plus"/> #{bundle['dataverse.permissionsFiles.files.assignBtn']}</p:commandLink>
+                                                           oncomplete="PF('assignWidget').show();handleResizeDialog('assignDialog');"><span class="glyphicon glyphicon-plus"/> #{bundle['dataverse.permissionsFiles.files.assignBtn']}</p:commandLink>
                                         </p:column>
                                     </p:dataTable>
                                 </div>

--- a/dataverse-webapp/src/main/webapp/permissions-manage.xhtml
+++ b/dataverse-webapp/src/main/webapp/permissions-manage.xhtml
@@ -110,7 +110,7 @@
                                         <p:commandLink type="button" id="userGroupsAdd" styleClass="btn btn-default"
                                                        actionListener="#{managePermissionsPage.initAssigneeDialog}"
                                                        update="userGroupDialog"
-                                                       oncomplete="PF('userGroupsForm').show();handleResizeDialog('userGroupDialog');bind_bsui_components();">
+                                                       oncomplete="PF('userGroupsForm').show();handleResizeDialog('userGroupDialog');">
                                             <span class="glyphicon glyphicon-user"/> #{bundle['dataverse.permissions.usersOrGroups.assignBtn']}
                                         </p:commandLink>
                                     </div>
@@ -168,7 +168,7 @@
                                                        rendered="#{managePermissionsPage.dvObject.instanceofDataverse and permissionsWrapper.canManagePermissions(managePermissionsPage.dvObject)
                                                                     and dataverseSession.user.superuser}"
                                                        actionListener="#{managePermissionsPage.createNewRole}"
-                                                       oncomplete="PF('roleForm').show();handleResizeDialog('rolesPermissionsDialog');bind_bsui_components();"
+                                                       oncomplete="PF('roleForm').show();handleResizeDialog('rolesPermissionsDialog');"
                                                        update=":#{p:resolveClientId('rolesPermissionsForm:editRolePanel', view)}">
                                             <span class="glyphicon glyphicon-plus"/> #{bundle['dataverse.permissions.roles.add']}
                                         </p:commandLink>

--- a/dataverse-webapp/src/main/webapp/provenance-popups-fragment.xhtml
+++ b/dataverse-webapp/src/main/webapp/provenance-popups-fragment.xhtml
@@ -54,7 +54,7 @@
                                           label="#{bundle['file.editProvenanceDialog.selectToAddBtn']}"
                                           onstart="javascript:uploadStarted();"
                                           onerror="javascript:uploadFailure();"
-                                          oncomplete="bind_bsui_components();"
+
                                           fileLimit="1" 
                                           invalidSizeMessage="#{bundle['file.edit.error.file_exceeds_limit']}"/>
                         </ui:fragment>

--- a/dataverse-webapp/src/main/webapp/replaceDatasetfiles.xhtml
+++ b/dataverse-webapp/src/main/webapp/replaceDatasetfiles.xhtml
@@ -114,7 +114,7 @@
                                                           fileUploadListener="#{ReplaceDatafilesPage.handleFileUpload}"
                                                           update="@form"
                                                           label="#{bundle['file.selectToAddBtn']}"
-                                                          oncomplete="javascript:bind_bsui_components();uploadFinished(PF('fileUploadWidget'));"
+                                                          oncomplete="uploadFinished(PF('fileUploadWidget'));"
                                                           onstart="#{ReplaceDatafilesPage.uploadStarted()}"
                                                           onerror="uploadFailure();"
                                                           sizeLimit="#{settingsWrapper.getEnumSettingValue(settingEnum.MaxFileUploadSizeInBytes)}"
@@ -341,7 +341,7 @@
                                                         <li class="#{ReplaceDatafilesPage.isLockedFromEdits()  ? 'disabled' : ''}">
                                                             <p:commandLink id="fileProvenanceButton"
                                                                            update="@form"
-                                                                           oncomplete="PF('editProvenancePopup').show();bind_bsui_components();">
+                                                                           oncomplete="PF('editProvenancePopup').show();">
                                                                 <f:actionListener
                                                                         binding="#{provPopupFragmentBean.updatePopupStateAndDataset(fileMetadata, ReplaceDatafilesPage.dataset)}"/>
                                                                 #{bundle['file.provenance']}
@@ -353,7 +353,7 @@
                                                         <p:commandLink id="fileCategoriesButton"
                                                                        actionListener="#{ReplaceDatafilesPage.refreshTagsPopUp(fileMetadata)}"
                                                                        update="@form"
-                                                                       oncomplete="PF('editFileTagsPopup').show();bind_bsui_components();">
+                                                                       oncomplete="PF('editFileTagsPopup').show();">
                                                             #{bundle['file.tags']}
                                                         </p:commandLink>
                                                     </li>
@@ -402,19 +402,19 @@
                                 <p:commandButton tabindex="1000" id="cancel" value="#{bundle.cancel}"
                                                  action="#{ReplaceDatafilesPage.returnToFileLandingPage()}"
                                                  process="@this" update="@form"
-                                                 oncomplete="javascript:bind_bsui_components();">
+                                                 >
                                 </p:commandButton>
                                 <p:commandButton value="#{bundle.saveChanges}" id="datasetSave"
                                                  update="@form,:messagePanel"
                                                  onclick="PF('blockFileForm').show();"
-                                                 oncomplete="javascript:bind_bsui_components();$(document).scrollTop(0);"
+                                                 oncomplete="$(document).scrollTop(0);"
                                                  action="#{ReplaceDatafilesPage.saveReplacement()}"/>
                             </div>
                             <div jsf:rendered="#{empty ReplaceDatafilesPage.fileMetadatas}">
                                 <p:commandButton tabindex="1000" id="doneFilesButton" value="#{bundle.done}"
                                                  action="#{ReplaceDatafilesPage.returnToFileLandingPage()}"
                                                  process="@this" update="@form"
-                                                 oncomplete="javascript:bind_bsui_components();">
+                                                 >
                                 </p:commandButton>
 
                             </div>

--- a/dataverse-webapp/src/main/webapp/selectGuestbook.xhtml
+++ b/dataverse-webapp/src/main/webapp/selectGuestbook.xhtml
@@ -81,7 +81,7 @@
                                                                        value="#{bundle['file.dataFilesTab.terms.list.guestbook.viewBtn']}"
                                                                        action="#{selectGuestbookPage.viewSelectedGuestbook(guestbook)}"
                                                                        update=":selectGuestbookForm"
-                                                                       oncomplete="PF('viewGuestbook').show();bind_bsui_components();"/>
+                                                                       oncomplete="PF('viewGuestbook').show();"/>
                                                     </p:column>
                                                 </p:dataTable>
                                             </ui:fragment>
@@ -120,7 +120,7 @@
                     <p:commandButton value="Direct" id="datasetSave"
                                      style="display:none"
                                      update=":selectGuestbookForm,:messagePanel"
-                                     oncomplete="javascript:bind_bsui_components();$(document).scrollTop(0);"
+                                     oncomplete="$(document).scrollTop(0);"
                                      action="#{selectGuestbookPage.save}" />
                 </div>
 

--- a/dataverse-webapp/src/main/webapp/themeAndWidgetsFragment.xhtml
+++ b/dataverse-webapp/src/main/webapp/themeAndWidgetsFragment.xhtml
@@ -24,7 +24,7 @@
                                         <h:selectBooleanCheckbox id="themeRoot" tabindex="7" styleClass="metadata-blocks-default" 
                                                                  rendered="#{themeWidgetFragment.editDv.owner != null}"
                                                                  value="#{themeWidgetFragment.inheritCustomization}" >
-                                            <p:ajax update="@widgetVar(content)" oncomplete="javascript:bind_bsui_components();" listener="#{themeWidgetFragment.checkboxListener()}"/>
+                                            <p:ajax update="@widgetVar(content)"  listener="#{themeWidgetFragment.checkboxListener()}"/>
                                         </h:selectBooleanCheckbox>
                                         <h:outputFormat value="#{bundle['dataverse.theme.inheritCustomization.checkbox']}">
                                             <f:param value="#{themeWidgetFragment.editDv.themeRootDataverseName}"/>
@@ -47,13 +47,13 @@
                                             <img jsf:rendered="#{themeWidgetFragment.uploadExists()}" class="logoPreview" src="/logos/temp/#{themeWidgetFragment.tempDirName}/#{themeWidgetFragment.editDv.dataverseTheme.logo}" alt="#{themeWidgetFragment.editDv.name}"/>
                                             <img jsf:rendered="#{not themeWidgetFragment.uploadExists()}" class="logoPreview" src="/logos/#{themeWidgetFragment.editDv.id}/#{themeWidgetFragment.editDv.dataverseTheme.logo}" alt="#{themeWidgetFragment.editDv.name}"/>
                                         </p>
-                                        <p:commandButton update=":themeWidgetsForm:themeWidgetsTabView" value="#{bundle.remove}" action="#{themeWidgetFragment.removeLogo()}" oncomplete="bind_bsui_components();"/>
+                                        <p:commandButton update=":themeWidgetsForm:themeWidgetsTabView" value="#{bundle.remove}" action="#{themeWidgetFragment.removeLogo()}" />
                                     </p:column>                              
-                                    <p:fileUpload invalidFileMessage="#{bundle['dataverse.theme.logo.image.invalidMsg']}" id="changelogo" allowTypes="/(\.|\/)(jpg|jpeg|tff|png|gif)$/" update=":themeWidgetsForm:themeWidgetsTabView" oncomplete="bind_bsui_components();" dragDropSupport="true" auto="true" multiple="false"
+                                    <p:fileUpload invalidFileMessage="#{bundle['dataverse.theme.logo.image.invalidMsg']}" id="changelogo" allowTypes="/(\.|\/)(jpg|jpeg|tff|png|gif)$/" update=":themeWidgetsForm:themeWidgetsTabView"  dragDropSupport="true" auto="true" multiple="false"
                                                   fileUploadListener="#{themeWidgetFragment.handleImageFileUpload}" label="#{bundle['dataverse.theme.logo.image.upload']}"/>
                                 </p:panelGrid>
                                 <p:panelGrid rendered="#{empty themeWidgetFragment.editDv.dataverseTheme.logo}" columns="2" styleClass="noBorders">
-                                    <p:fileUpload id="uploadlogo" invalidFileMessage="#{bundle['dataverse.theme.logo.image.invalidMsg']}" sizeLimit="#{systemConfig.uploadLogoSizeLimit}" allowTypes="/(\.|\/)(jpg|jpeg|tff|png|gif)$/" update=":themeWidgetsForm:themeWidgetsTabView" oncomplete="bind_bsui_components();" dragDropSupport="true" auto="true" multiple="false"
+                                    <p:fileUpload id="uploadlogo" invalidFileMessage="#{bundle['dataverse.theme.logo.image.invalidMsg']}" sizeLimit="#{systemConfig.uploadLogoSizeLimit}" allowTypes="/(\.|\/)(jpg|jpeg|tff|png|gif)$/" update=":themeWidgetsForm:themeWidgetsTabView"  dragDropSupport="true" auto="true" multiple="false"
                                                   fileUploadListener="#{themeWidgetFragment.handleImageFileUpload}" label="#{bundle['dataverse.theme.logo.image.uploadImgFile']}"/>
                                 </p:panelGrid>
                                 <ui:fragment rendered="#{not empty themeWidgetFragment.editDv.dataverseTheme.logo}">
@@ -67,7 +67,7 @@
                                             <p:selectOneRadio id="logoFormat" value="#{themeWidgetFragment.editDv.dataverseTheme.logoFormat}">
                                                 <f:selectItem itemLabel="#{bundle['dataverse.theme.logo.format.selectTab.square2']}" itemValue="SQUARE"/>
                                                 <f:selectItem itemLabel="#{bundle['dataverse.theme.logo.format.selectTab.rectangle2']}" itemValue="RECTANGLE"/>
-                                                <p:ajax update="@widgetVar(content)" oncomplete="bind_bsui_components();" />
+                                                <p:ajax update="@widgetVar(content)"  />
                                             </p:selectOneRadio>
                                             <p:message for="logoFormat" display="text"/>
                                         </div>
@@ -182,7 +182,7 @@
                     </ui:fragment>
                 </p:fragment>
                 <div class="button-block">
-                    <p:commandButton class="btn btn-default" value="#{bundle.saveChanges}" update=":#{p:resolveClientId('messagePanel', view)}, :themeWidgetsForm" action="#{themeWidgetFragment.save()}" oncomplete="bind_bsui_components();"/>
+                    <p:commandButton class="btn btn-default" value="#{bundle.saveChanges}" update=":#{p:resolveClientId('messagePanel', view)}, :themeWidgetsForm" action="#{themeWidgetFragment.save()}" />
                     <p:commandButton class="btn btn-default" action="#{themeWidgetFragment.cancel()}" immediate="true" id="themeCancel" value="#{bundle.cancel}"/>
                 </div>
             </p:tab>

--- a/dataverse-webapp/src/main/webapp/view-dataset-guestbook.xhtml
+++ b/dataverse-webapp/src/main/webapp/view-dataset-guestbook.xhtml
@@ -38,7 +38,7 @@
                                 <p class="form-control-static pull-left">#{DatasetGuestbookTab.guestbook.name}</p>
                                 <p:commandLink type="button" styleClass="btn btn-default pull-right"
                                                value="#{bundle['file.dataFilesTab.terms.list.guestbook.viewBtn']}"
-                                               update="@form" oncomplete="PF('viewGuestbook').show();bind_bsui_components();"/>
+                                               update="@form" oncomplete="PF('viewGuestbook').show();"/>
                             </div>
                         </div>
                     </ui:fragment>


### PR DESCRIPTION
- Added global ajax binding, which is not working for tabs.
- Fixed binding for individually. 

I suspect it is due to similar issue i encountered, which is that binding is happening before primefaces loads all components.
 In my test I added ajax button, so when tab was fully loaded ajax button was acting like binding reloader, which worked.