### PR TITLE
Closes #394: Adjust create guestbook page to our layout

### DIFF
--- a/dataverse-webapp/src/main/webapp/guestbook.xhtml
+++ b/dataverse-webapp/src/main/webapp/guestbook.xhtml
@@ -91,47 +91,78 @@
                                            varStatus="valCount">
                                     <div class="form-group">
                                         <!-- Sub Fields -->
-                                        <div class="col-sm-9">
-                                            <div class="col-sm-3">
-                                                <label class="control-label" jsf:for="questionOptions">
-                                                    #{bundle['dataset.manageGuestbooks.guestbook.customQuestions.questionType']}
-                                                </label>
-                                                <div>
-                                                        <h:selectOneMenu id="questionOptions" styleClass="form-control" value="#{cq.questionType}">
-                                                            <f:selectItem
-                                                                    itemLabel="#{bundle['dataset.manageGuestbooks.guestbook.customQuestions.questionType.text']}"
-                                                                    itemValue="text"/>
-                                                            <f:selectItem
-                                                                    itemLabel="#{bundle['dataset.manageGuestbooks.guestbook.customQuestions.questionType.multiple']}"
-                                                                    itemValue="options"/>
-                                                            <p:ajax process="responseOptions" update="responseOptions" />
-                                                        </h:selectOneMenu>
+                                        <div class="col-9">
+                                            <div class="row">
+                                                <div class="col-xs-6">
+                                                    <label class="control-label" jsf:for="questionOptions">
+                                                        #{bundle['dataset.manageGuestbooks.guestbook.customQuestions.questionType']}
+                                                    </label>
+                                                    </div>
+                                                <div class="col-xs-6 text-right">
+                                                    <input type="checkbox" jsf:id="cqRequiredCb" jsf:value="#{cq.required}"/>
+                                                    <label jsf:for="cqRequiredCb">
+                                                        #{bundle.requiredField}
+                                                    </label>
                                                 </div>
                                             </div>
-                                            <div class="col-sm-9">
-                                                <label class="control-label" jsf:for="questionText">
-                                                    #{bundle['dataset.manageGuestbooks.guestbook.customQuestions.questionText']}
-                                                </label>
-                                                <div>
-                                                        <p:inputText id="questionText" styleClass="form-control"
-                                                                     value="#{cq.questionString}" />
-                                                        <p:message for="questionText" display="text"/>
+                                            <div class="row">
+                                                <div class="col-xs-9">
+                                                    <p:selectOneMenu id="questionOptions" styleClass="form-control" value="#{cq.questionType}">
+                                                        <f:selectItem
+                                                                itemLabel="#{bundle['dataset.manageGuestbooks.guestbook.customQuestions.questionType.text']}"
+                                                                itemValue="text"/>
+                                                        <f:selectItem
+                                                                itemLabel="#{bundle['dataset.manageGuestbooks.guestbook.customQuestions.questionType.multiple']}"
+                                                                itemValue="options"/>
+                                                        <p:ajax process="responseOptions" update="responseOptions" />
+                                                    </p:selectOneMenu>
+                                                </div>
+                                                <div class="col-xs-3 field-add-delete">
+                                                    <p:commandLink
+                                                            styleClass="btn btn-default btn-access btn-sm bootstrap-button-tooltip compound-field-btn"
+                                                            title="#{bundle.add}" update=":guestbookForm:customQuestions"
+        
+                                                            actionListener="#{GuestbookPage.addCustomQuestion(valCount.index + 1 )}">
+                                                        <span class="glyphicon glyphicon-plus no-text"/>
+                                                    </p:commandLink>
+                                                    <p:commandLink
+                                                            styleClass="btn btn-default btn-access btn-sm bootstrap-button-tooltip compound-field-btn"
+                                                            rendered="#{GuestbookPage.guestbook.customQuestions.size() > 1}"
+                                                            title="#{bundle.delete}" update=":guestbookForm:customQuestions"
+        
+                                                            actionListener="#{GuestbookPage.removeCustomQuestion(valCount.index)}">
+                                                        <span class="glyphicon glyphicon-minus no-text"/>
+                                                    </p:commandLink>
                                                 </div>
                                             </div>
-                                            <h:panelGroup id="responseOptions" styleClass="col-sm-offset-3 col-sm-9 #{cq.questionType eq 'options' ? '' : 'hidden'}">
-                                                <label class="control-label">
-                                                    #{bundle['dataset.manageGuestbooks.guestbook.customQuestions.responseOptions']}
-                                                </label>
+                                            <div class="row">
+                                                <div class="col-xs-12">
+                                                    <label class="control-label" jsf:for="questionText">
+                                                        #{bundle['dataset.manageGuestbooks.guestbook.customQuestions.questionText']}
+                                                    </label>
+                                                    <div>
+                                                            <p:inputText id="questionText" styleClass="form-control"
+                                                                        value="#{cq.questionString}" />
+                                                            <p:message for="questionText" display="text"/>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                            <h:panelGroup id="responseOptions" styleClass="#{cq.questionType eq 'options' ? '' : 'hidden'}">
+                                                <div class="col-xs-offset-1 col-xs-8">
+                                                    <label class="control-label">
+                                                        #{bundle['dataset.manageGuestbooks.guestbook.customQuestions.responseOptions']}
+                                                    </label>
+                                                </div>
                                                 <ui:repeat value="#{cq.customQuestionValues}" varStatus="resCount"
                                                            var="value">
                                                     <div class="form-group">
-                                                        <div class="col-sm-8">
+                                                        <div class="col-xs-offset-1 col-xs-8">
                                                             <p:inputText id="responseText" styleClass="form-control"
                                                                          value="#{value.valueString}" >
                                                             </p:inputText>
                                                             <p:message for="responseText" display="text"/>
                                                         </div>
-                                                        <div class="col-sm-4 field-add-delete">
+                                                        <div class="col-xs-3 field-add-delete">
                                                             <p:commandLink
                                                                     styleClass="btn btn-default btn-access btn-sm bootstrap-button-tooltip nolabel-field-btn"
                                                                     title="#{bundle.add}"
@@ -153,29 +184,6 @@
                                                     </div>
                                                 </ui:repeat>
                                             </h:panelGroup>
-                                            <div class="col-sm-9 checkbox">
-                                                <label jsf:for="cqRequiredCb">
-                                                    <input type="checkbox" jsf:id="cqRequiredCb"
-                                                           jsf:value="#{cq.required}"/> #{bundle.requiredField}
-                                                </label>
-                                            </div>
-                                        </div>
-                                        <div class="col-sm-3 field-add-delete">
-                                            <p:commandLink
-                                                    styleClass="btn btn-default btn-access btn-sm bootstrap-button-tooltip compound-field-btn"
-                                                    title="#{bundle.add}" update=":guestbookForm:customQuestions"
-
-                                                    actionListener="#{GuestbookPage.addCustomQuestion(valCount.index + 1 )}">
-                                                <span class="glyphicon glyphicon-plus no-text"/>
-                                            </p:commandLink>
-                                            <p:commandLink
-                                                    styleClass="btn btn-default btn-access btn-sm bootstrap-button-tooltip compound-field-btn"
-                                                    rendered="#{GuestbookPage.guestbook.customQuestions.size() > 1}"
-                                                    title="#{bundle.delete}" update=":guestbookForm:customQuestions"
-
-                                                    actionListener="#{GuestbookPage.removeCustomQuestion(valCount.index)}">
-                                                <span class="glyphicon glyphicon-minus no-text"/>
-                                            </p:commandLink>
                                         </div>
                                     </div>
                                 </ui:repeat>

--- a/dataverse-webapp/src/main/webapp/resources/vecler/theme.scss
+++ b/dataverse-webapp/src/main/webapp/resources/vecler/theme.scss
@@ -247,22 +247,7 @@ a,
 	}
 }
 
-code {
-	font-family: $font-monospace;
-}
-
-input, textarea {
-	&, &.ui-inputfield, .ui-widget-content &.ui-inputfield {
-		border: 1px solid $gray-border-color;
-	}
-}
-
 #breadcrumbNavBlock .breadcrumbActive {
-	color: $main-text-color;
-}
-
-.form-horizontal .control-label {
-	padding-top: 5px;
 	color: $main-text-color;
 }
 
@@ -279,12 +264,83 @@ input, textarea {
 	}
 }
 
-.field-add-delete {
-	margin-left: -1.5em;
+/* Forms */
+
+.ui-selectonemenu {
+	border: 1px solid #e8e8e8;
+
+	.ui-selectonemenu-label {
+		padding-left: 15px;
+		background: #fff;
+		box-shadow: none;
+	}
+
+	.ui-selectonemenu-trigger.ui-state-default {
+		width: 44px;
+		top: -1px;
+		right: -1px;
+		padding-bottom: 32px;
+		border: 1px solid $gray-border-color;
+		border-radius: 4px;
+		background: #fff;
+
+		&:hover {
+			background: $gray-border-color;
+		}
+
+		span.ui-icon.ui-icon-triangle-1-s {
+			width: 42px;
+			margin-top: 7px;
+			background: none;
+			text-align: center;
+
+			&::before {
+				content: "\e252";
+				position: absolute;
+				left: 0;
+				right: 0;
+				font-family: "Glyphicons Halflings";
+				font-size: 0.8em;
+				color: $icon-color;
+				text-indent: 0;
+			}
+		}
+	}
+}
+
+div.field-add-delete {
+	margin-left: -1.2em;
+
+	a.btn {
+		margin-right: 0.6em;
+	}
+
 
 	.btn span.glyphicon.no-text {
 		margin: 0 1em;
 	}
+
+	@media (max-width: 991.98px) {
+		.btn span.glyphicon.no-text {
+			margin: 0 0.3em;
+		}
+	}
+}
+
+code {
+	font-family: $font-monospace;
+}
+
+input, textarea {
+	&, &.ui-inputfield, .ui-widget-content &.ui-inputfield {
+		border: 1px solid $gray-border-color;
+	}
+}
+
+.form-horizontal .control-label {
+	padding-top: 10px;
+	padding-bottom: 5px;
+	color: $main-text-color;
 }
 
 /* Labels */
@@ -406,6 +462,8 @@ input, textarea {
 		color: $main-text-color;
 
 		thead {
+			word-break: break-all;
+
 			th, th.ui-state-default {
 				padding: 14px 20px;
 				border-color: $gray-border-color;
@@ -888,6 +946,38 @@ div[id$="filesTable"] .ui-paginator {
 }
 
 /* Main page end */
+
+/* Guestbook */
+
+.form-horizontal #guestbookForm\:customQuestions > .form-group {
+	padding: 10px 15px 15px 15px;
+	border: 1px solid $gray-border-color;
+	border-radius: $border-radius;
+
+	.ui-selectonemenu .ui-selectonemenu-label {
+		background: none;
+	}
+
+	.col-xs-6.text-right  {
+		padding-top: 7px;
+		
+		label {
+			position: relative;
+			top: -3px;
+			margin-left: 8px;
+			font-weight: normal;
+		}
+	}
+
+	@media (max-width: 768px) {
+		margin-left: 0;
+		margin-right: 0;
+	}
+
+	div.field-add-delete a.btn.compound-field-btn {
+		margin-top: 0;
+	}
+}
 
 /* Modal */
 

--- a/dataverse-webapp/src/main/webapp/resources/vecler/theme.scss
+++ b/dataverse-webapp/src/main/webapp/resources/vecler/theme.scss
@@ -6,6 +6,14 @@ $font-main: "Roboto", "Helvetica Neue", Helvetica, Arial, sans-serif;
 $font-monospace: "Roboto Mono", Menlo, Monaco, Consolas, "Courier New", monospace;
 $border-radius: 7px;
 
+/* Responsive breakpoints */
+$screen-md:	992px;
+$screen-md-min:	$screen-md;
+$screen-sm-max:	($screen-md-min - 1);
+$screen-sm: 768px;
+$screen-sm-min: $screen-sm;
+$screen-xs-max: ($screen-sm-min - 1);
+
 /* Colors */
 
 $main-text-color: #4a4a4a;
@@ -320,7 +328,7 @@ div.field-add-delete {
 		margin: 0 1em;
 	}
 
-	@media (max-width: 991.98px) {
+	@media (max-width: $screen-sm-max) {
 		.btn span.glyphicon.no-text {
 			margin: 0 0.3em;
 		}
@@ -969,7 +977,7 @@ div[id$="filesTable"] .ui-paginator {
 		}
 	}
 
-	@media (max-width: 768px) {
+	@media (max-width: $screen-xs-max) {
 		margin-left: 0;
 		margin-right: 0;
 	}


### PR DESCRIPTION
Note:
+/- buttons are placed below each other when the device width gets below ~600px; this is an intended behavior, I thinks it's more usable than narrowing the buttons to fit them in the same line