### PR TITLE
Closes #665: Fix too big table on managing file access permissions modals

### DIFF
--- a/dataverse-webapp/src/main/webapp/resources/vecler/theme.scss
+++ b/dataverse-webapp/src/main/webapp/resources/vecler/theme.scss
@@ -949,10 +949,10 @@ div[id$="notifications"].ui-tabs-panel {
 		}
 	}
 
-	.ui-datatable-odd {
+	&:not(.no-alternating-row-colors) .ui-datatable-odd {
 		background: none;
 
-		td {
+		 td {
 			background: $search-result-desc-color;
 
 			.ui-chkbox-box::before, .ui-chkbox-icon::before {
@@ -1079,6 +1079,15 @@ tr.ui-state-highlight a:not(.btn), .ui-widget-content tr.ui-state-highlight a:no
 		table.table {
 			margin-bottom: 0;
 		}
+	}
+}
+
+.ui-datatable-scrollable-body {
+	height: auto !important;
+	max-height: 300px;
+
+	tbody td.ui-selection-column {
+		padding: 14px 20px;
 	}
 }
 
@@ -1599,7 +1608,7 @@ div[id$="versionsTable"] td {
 	padding: 14px 20px;
 }
 
-.ui-datatable.ui-widget.no-alternating-row-colors .ui-datatable-odd td {
+.ui-datatable.ui-widget.no-alternating-row-colors .ui-datatable-odd:not(.ui-state-highlight):not(:hover) td {
 	background: #fff;
 }
 
@@ -1761,6 +1770,21 @@ div.filesTable {
 
 	.form-horizontal .form-group {
 		margin-right: -14px;
+	}
+
+	/* Fixed bottom button placement */
+	padding-bottom: 100px;
+	box-sizing: content-box;
+
+	.ui-dialog-content {
+		position: static;
+
+		.button-block {
+			position: absolute;
+			left: 15px;
+			right: 15px;
+			bottom: 0;
+		}
 	}
 }
 


### PR DESCRIPTION
Closes #665 

Also fixes:
- changed the bottom modal button row to be always on the bottom, ie. outside the scrolling area;
- fixed non-working selected/hover background in tables which don't have different coloured odd/even rows, eg. the table in the dataset Version tab;

The issue with incorrect modal height after resizing (that I spoke to you about today) was fixed, in the end that just involved changing the modal's `box-sizing` attribute from default `border-box` to `content-box`. This change causes jQuery `.height()` method to include element padding in the result, which makes the modal height calculations correct.