### PR TITLE
Closes #725: Minor front page fixes

### DIFF
--- a/dataverse-webapp/src/main/webapp/mydata_fragment.xhtml
+++ b/dataverse-webapp/src/main/webapp/mydata_fragment.xhtml
@@ -396,9 +396,9 @@
                                     </ui:repeat>
                                 </div>
                                 <h:outputLink value="#{!MyDataSearchFragment.rootDv and !result.isInTree ? dvUrl : widgetWrapper.wrapURL(dvUrl)}" target="#{!MyDataSearchFragment.rootDv and !result.isInTree and widgetWrapper.widgetView ? '_blank' : ''}">
-                                    <h:outputText value="#{result.name}" style="margin:4px 0;" rendered="#{result.nameHighlightSnippet == null}"/>
-                                    <h:outputText value="#{result.nameHighlightSnippet}" style="margin:4px 0;" rendered="#{result.nameHighlightSnippet != null}" escape="false"/>
-                                    <h:outputText value=" (#{result.entityId})" style="margin:4px 0;" rendered="#{MyDataSearchFragment.debug == true}"/>
+                                    <h:outputText value="#{result.name}" rendered="#{result.nameHighlightSnippet == null}"/>
+                                    <h:outputText value="#{result.nameHighlightSnippet}" rendered="#{result.nameHighlightSnippet != null}" escape="false"/>
+                                    <h:outputText value=" (#{result.entityId})" rendered="#{MyDataSearchFragment.debug == true}"/>
                                 </h:outputLink>
                                 <h:outputText value="(#{result.dataverseAffiliation})" styleClass="text-muted" style="margin-left: .5em;" rendered="#{!empty result.dataverseAffiliation and result.dataverseAffiliationHighlightSnippet == null}"/>
                                 <h:outputText value="(#{result.dataverseAffiliationHighlightSnippet})" styleClass="text-muted" style="margin-left: .5em;" rendered="#{result.dataverseAffiliationHighlightSnippet != null}" escape="false"/>
@@ -464,9 +464,9 @@
                                     </ui:repeat>
                                 </div>
                                 <a href="#{!MyDataSearchFragment.rootDv and !result.isInTree ? result.datasetUrl : widgetWrapper.wrapURL(result.datasetUrl)}" target="#{(!MyDataSearchFragment.rootDv and !result.isInTree and widgetWrapper.widgetView) or result.harvested ? '_blank' : ''}">
-                                    <h:outputText value="#{result.title}" style="margin:4px 0;" rendered="#{result.titleHighlightSnippet == null}"/>
-                                    <h:outputText value="#{result.titleHighlightSnippet}" style="margin:4px 0;" rendered="#{result.titleHighlightSnippet != null}" escape="false"/>
-                                    <h:outputText value=" (#{result.entityId})" style="margin:4px 0;" rendered="#{MyDataSearchFragment.debug == true}"/>
+                                    <h:outputText value="#{result.title}" rendered="#{result.titleHighlightSnippet == null}"/>
+                                    <h:outputText value="#{result.titleHighlightSnippet}" rendered="#{result.titleHighlightSnippet != null}" escape="false"/>
+                                    <h:outputText value=" (#{result.entityId})" rendered="#{MyDataSearchFragment.debug == true}"/>
                                 </a>
                             </div>
                            
@@ -539,9 +539,9 @@
                                     </ui:repeat>
                                 </div>
                                 <a href="#{!MyDataSearchFragment.rootDv and !result.isInTree ? (result.harvested ? result.fileDatasetUrl : result.fileUrl) : widgetWrapper.wrapURL(result.harvested ? result.fileDatasetUrl : result.fileUrl)}" target="#{(!MyDataSearchFragment.rootDv and !result.isInTree and widgetWrapper.widgetView) or result.harvested ? '_blank' : ''}">
-                                    <h:outputText value="#{result.name}" style="margin:4px 0;" rendered="#{result.nameHighlightSnippet == null}"/>
-                                    <h:outputText value="#{result.nameHighlightSnippet}" style="margin:4px 0;" rendered="#{result.nameHighlightSnippet != null}" escape="false"/>
-                                    <h:outputText value=" (#{result.entityId})" style="margin:4px 0;" rendered="#{MyDataSearchFragment.debug == true}"/>
+                                    <h:outputText value="#{result.name}" rendered="#{result.nameHighlightSnippet == null}"/>
+                                    <h:outputText value="#{result.nameHighlightSnippet}" rendered="#{result.nameHighlightSnippet != null}" escape="false"/>
+                                    <h:outputText value=" (#{result.entityId})" rendered="#{MyDataSearchFragment.debug == true}"/>
                                 </a>
                             </div>
     

--- a/dataverse-webapp/src/main/webapp/mydata_templates/cards_minimum.html
+++ b/dataverse-webapp/src/main/webapp/mydata_templates/cards_minimum.html
@@ -16,14 +16,14 @@
         <div class="card-title-icon-block" style="font-size: 110%;"> 
  {% if card_info.type == "dataverse" %}
             <span class="icon-dataverse text-brand pull-right" title="Dataverse"></span>
-            <a href="/dataverse/{{ card_info.identifier }}"><span style="margin:4px 0;">{{ card_info.name }}</span></a>
+            <a href="/dataverse/{{ card_info.identifier }}"><span>{{ card_info.name }}</span></a>
            {# <span class="text-muted">(<em>Affiliation</em>)</span>#}
  {% elif card_info.type == "dataset" %}
             <span class="icon-dataset text-info pull-right" title="Dataset"></span>
-            <a href="/dataset.xhtml?persistentId={{ card_info.global_id }}"><span style="margin:4px 0;">{{ card_info.name }}</span></a>
+            <a href="/dataset.xhtml?persistentId={{ card_info.global_id }}"><span>{{ card_info.name }}</span></a>
  {% elif card_info.type == "file" %}
             <span class="icon-file text-muted pull-right" title="File"></span>
-            <a href="/file.xhtml?fileId={{ card_info.entity_id }}"><span style="margin:4px 0;">{{ card_info.name }}</span></a>
+            <a href="/file.xhtml?fileId={{ card_info.entity_id }}"><span>{{ card_info.name }}</span></a>
  {% endif %}
         <!-- publication status -->
         {#({{ loop.index }})#} {% if card_info.is_draft_state %}<span class="label label-primary">Draft</span> {% endif %}

--- a/dataverse-webapp/src/main/webapp/resources/vecler/theme.scss
+++ b/dataverse-webapp/src/main/webapp/resources/vecler/theme.scss
@@ -138,7 +138,6 @@ body {
 
 	border-radius: 0 0 0.5em 0.5em;
 	border: 1px solid #fff;
-	outline: none;
 	
 	background: $icon-color;
 	color: #fff;
@@ -287,6 +286,16 @@ body {
 	}
 }
 
+@mixin offscreen-outline-fix {
+	position: absolute;
+	height: 1px;
+	width: 1px;
+	overflow: hidden;
+	clip: rect(1px 1px 1px 1px); /* IE compatibility */
+	clip: rect(1px, 1px, 1px, 1px);
+	text-indent: 0;
+}
+
 a,
 .pagination > li > a,
 .ui-widget-content a,
@@ -401,9 +410,16 @@ textarea,
 .ui-picklist-list,
 .ui-tabs-header,
 .ui-sortable-column,
-.select-scroll-block {
+.select-scroll-block,
+ul.pagination a {
 	&:focus {
 		outline-offset: -2px;
+	}
+}
+
+a[tabindex="-1"] {
+	&:focus {
+		outline: none !important;
 	}
 }
 
@@ -791,13 +807,7 @@ input.fancy-checkbox[type=checkbox] {
 					}
 
 					.ui-button-text.ui-c {
-						position: absolute;
-						height: 1px;
-						width: 1px;
-						overflow: hidden;
-						clip: rect(1px 1px 1px 1px); /* IE compatibility */
-						clip: rect(1px, 1px, 1px, 1px);
-						text-indent: 0;
+						@include offscreen-outline-fix;
 					}
 				}
 			}
@@ -1313,7 +1323,7 @@ $navbar-height: 6.8em;
 
 .navbar-default #topNavBar .navbar-nav {
 	> li,  > form {
-		a {
+		> a {
 			color: $main-text-color;
 			border-radius: $border-radius;
 
@@ -1422,6 +1432,15 @@ div.panelSearchForm input.search-input {
 .pagination > .active > a {
 	border-color: $main-color;
 	background-color: $main-color;
+}
+.ui-paginator-first,
+.ui-paginator-prev,
+.ui-paginator-next,
+.ui-paginator-last {
+	.ui-icon {
+		text-indent: 0;
+		visibility: hidden;
+	}
 }
 
 #metrics-block.col-sm-4 {
@@ -1645,10 +1664,6 @@ div[id$="facetCategoryList"] div li div.ui-widget {
 
 /* Search results */
 
-.card-content-container {
-	margin-left: 60px;
-}
-
 #resultsCountPaginatorBlock {
 	margin-bottom: 8px;
 
@@ -1684,17 +1699,43 @@ div.alert-info.bg-citation {
 }
 
 table[id$="resultsTable"] {
+	div[class*="Result"] {
+		font-size: inherit;
+		
+		> div.card-preview-icon-block {
+			font-size: inherit;
+		}
+	}
+
 	div.card-preview-icon-block {
-		margin-top: 6px;
+		width: unquote(calc(2em + 2px));
+		margin-top: 0.133em;
+		margin-left: 0.4em;
+
+		a {
+			height: auto;
+			line-height: inherit;
+
+			img {
+				margin-top: 0.133em;
+				width: 2em;
+			}
+		}
+
+		span[class^="icon"] {
+			font-size: 2em;
+		}
 	}
 
 	div.card-title-icon-block {
 		margin-top: -2px;
+		margin-bottom: -0.3em;
 
 		span[class^="icon"], span[class^="glyphicon"] {
 			position: relative;
 			top: -10px;
 			margin-left: 8px;
+			font-size: 1em;
 		}
 
 		span[class^="glyphicon"] {
@@ -1706,6 +1747,14 @@ table[id$="resultsTable"] {
 			color: $icon-color;
 		}
 	} 
+
+	.card-content-container {
+		margin-left: 3.333em;
+
+		> a, > span.text-muted {
+			font-size: 0.867em;
+		}
+	}
 
 	td  {
 		& > div {
@@ -1748,6 +1797,7 @@ table[id$="resultsTable"] {
 	}
 
 	.resultDatasetCitationBlock {
+		margin-top: 1em;
 		margin-left: 0;
 	}
 }

--- a/dataverse-webapp/src/main/webapp/search-include-fragment.xhtml
+++ b/dataverse-webapp/src/main/webapp/search-include-fragment.xhtml
@@ -463,8 +463,8 @@
                                 </div>
                                 <c:set var="dvUrl" value="/dataverse/#{result.dataverseAlias}"/>
                                 <h:outputLink value="#{!SearchIncludeFragment.rootDv and !result.isInTree ? dvUrl : widgetWrapper.wrapURL(dvUrl)}" target="#{!SearchIncludeFragment.rootDv and !result.isInTree and widgetWrapper.widgetView ? '_blank' : ''}">
-                                    <h:outputText value="#{result.name}" style="margin:4px 0;" rendered="#{result.nameHighlightSnippet == null}"/>
-                                    <h:outputText value="#{result.nameHighlightSnippet}" style="margin:4px 0;" rendered="#{result.nameHighlightSnippet != null}" escape="false"/>
+                                    <h:outputText value="#{result.name}" rendered="#{result.nameHighlightSnippet == null}"/>
+                                    <h:outputText value="#{result.nameHighlightSnippet}" rendered="#{result.nameHighlightSnippet != null}" escape="false"/>
                                 </h:outputLink>
                                 <h:outputText value="(#{result.dataverseAffiliation})" styleClass="text-muted" style="margin-left: .5em;" rendered="#{!empty result.dataverseAffiliation and result.dataverseAffiliationHighlightSnippet == null}"/>
                                 <h:outputText value="(#{result.dataverseAffiliationHighlightSnippet})" styleClass="text-muted" style="margin-left: .5em;" rendered="#{result.dataverseAffiliationHighlightSnippet != null}" escape="false"/>
@@ -527,8 +527,8 @@
                                     <h:outputText value="#{bundle['dataset.versionUI.deaccessioned']}" styleClass="label label-danger" rendered="#{result.deaccessionedState}"/>
                                 </div>
                                 <a href="#{!SearchIncludeFragment.rootDv and !result.isInTree ? result.datasetUrl : widgetWrapper.wrapURL(result.datasetUrl)}" target="#{(!SearchIncludeFragment.rootDv and !result.isInTree and widgetWrapper.widgetView) or result.harvested ? '_blank' : ''}">
-                                    <h:outputText value="#{result.title}" style="margin:4px 0;" rendered="#{result.titleHighlightSnippet == null}"/>
-                                    <h:outputText value="#{result.titleHighlightSnippet}" style="margin:4px 0;" rendered="#{result.titleHighlightSnippet != null}" escape="false"/>
+                                    <h:outputText value="#{result.title}" rendered="#{result.titleHighlightSnippet == null}"/>
+                                    <h:outputText value="#{result.titleHighlightSnippet}" rendered="#{result.titleHighlightSnippet != null}" escape="false"/>
                                 </a>
                             </div>
     
@@ -598,8 +598,8 @@
                                     <h:outputText value="#{result.userRole}" styleClass="label label-primary" rendered="#{!empty result.userRole}"/>
                                 </div>
                                 <a href="#{!SearchIncludeFragment.rootDv and !result.isInTree ? (result.harvested ? result.fileDatasetUrl : result.fileUrl) : widgetWrapper.wrapURL(result.harvested ? result.fileDatasetUrl : result.fileUrl)}" target="#{(!SearchIncludeFragment.rootDv and !result.isInTree and widgetWrapper.widgetView) or result.harvested ? '_blank' : ''}">
-                                    <h:outputText value="#{result.name}" style="margin:4px 0;" rendered="#{result.nameHighlightSnippet == null}"/>
-                                    <h:outputText value="#{result.nameHighlightSnippet}" style="margin:4px 0;" rendered="#{result.nameHighlightSnippet != null}" escape="false"/>
+                                    <h:outputText value="#{result.name}" rendered="#{result.nameHighlightSnippet == null}"/>
+                                    <h:outputText value="#{result.nameHighlightSnippet}" rendered="#{result.nameHighlightSnippet != null}" escape="false"/>
                                 </a>
                             </div>
     


### PR DESCRIPTION
Closes #725 

- fixed incorrect focus outline on some pagination elements;
- fixed incorrect outline visible when clicking on checkboxes on the main page;
- fixed incorrect border-radius in the header submenu list items;
- fixed font sizing in the search result panels to match the new design more closely (until now, some of the default styles override some font sizes to 110% and 90%);
