### PR TITLE
Closes #716: Relative paths for all resource files referenced in unit tests

### DIFF
--- a/dataverse-webapp/src/test/java/edu/harvard/iq/dataverse/UnitTestUtils.java
+++ b/dataverse-webapp/src/test/java/edu/harvard/iq/dataverse/UnitTestUtils.java
@@ -18,11 +18,7 @@ public class UnitTestUtils {
      * @return the requested String
      */
     public static String readFileToString(String relResourcePath) throws IOException {
-        if (relResourcePath.startsWith("src/") || relResourcePath.startsWith("./src/")) {
-            String message = String.format("A relative resource path cannot start with src/; got: %s", relResourcePath);
-            throw new IllegalArgumentException(message);
-        }
-
+        throwExceptionIfPathNotRelative(relResourcePath);
         return IOUtils.resourceToString(relResourcePath, StandardCharsets.UTF_8, UnitTestUtils.class.getClassLoader());
     }
 
@@ -38,11 +34,14 @@ public class UnitTestUtils {
      * @return the requested byte array
      */
     public static byte[] readFileToByteArray(String relResourcePath) throws IOException {
-        if (relResourcePath.startsWith("src/") || relResourcePath.startsWith("./src/")) {
-            String message = String.format("A relative resource path cannot start with src/; got: %s", relResourcePath);
+        throwExceptionIfPathNotRelative(relResourcePath);
+        return IOUtils.resourceToByteArray(relResourcePath, UnitTestUtils.class.getClassLoader());
+    }
+
+    private static void throwExceptionIfPathNotRelative(String path) {
+        if (path.startsWith("src/") || path.startsWith("./src/")) {
+            String message = String.format("A relative resource path cannot start with src/; got: %s", path);
             throw new IllegalArgumentException(message);
         }
-
-        return IOUtils.resourceToByteArray(relResourcePath, UnitTestUtils.class.getClassLoader());
     }
 }

--- a/dataverse-webapp/src/test/java/edu/harvard/iq/dataverse/UnitTestUtils.java
+++ b/dataverse-webapp/src/test/java/edu/harvard/iq/dataverse/UnitTestUtils.java
@@ -16,13 +16,33 @@ public class UnitTestUtils {
      * 
      * @param relResourcePath relative path of the desired resource
      * @return the requested String
-     * @throws IOException
      */
     public static String readFileToString(String relResourcePath) throws IOException {
         if (relResourcePath.startsWith("src/") || relResourcePath.startsWith("./src/")) {
-            throw new IllegalArgumentException("Resource path must be relative");
+            String message = String.format("A relative resource path cannot start with src/; got: %s", relResourcePath);
+            throw new IllegalArgumentException(message);
         }
 
         return IOUtils.resourceToString(relResourcePath, StandardCharsets.UTF_8, UnitTestUtils.class.getClassLoader());
+    }
+
+    /**
+     * Gets the contents of a classpath resource as a byte array.
+     * 
+     * <p>
+     * The path to unit test resources should be relative, because the path changes when the application
+     * is packaged into distributed format (e.g. JAR or WAR).
+     * </p>
+     * 
+     * @param relResourcePath relative path of the desired resource
+     * @return the requested byte array
+     */
+    public static byte[] readFileToByteArray(String relResourcePath) throws IOException {
+        if (relResourcePath.startsWith("src/") || relResourcePath.startsWith("./src/")) {
+            String message = String.format("A relative resource path cannot start with src/; got: %s", relResourcePath);
+            throw new IllegalArgumentException(message);
+        }
+
+        return IOUtils.resourceToByteArray(relResourcePath, UnitTestUtils.class.getClassLoader());
     }
 }

--- a/dataverse-webapp/src/test/java/edu/harvard/iq/dataverse/UnitTestUtils.java
+++ b/dataverse-webapp/src/test/java/edu/harvard/iq/dataverse/UnitTestUtils.java
@@ -1,0 +1,28 @@
+package edu.harvard.iq.dataverse;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.commons.io.IOUtils;
+
+public class UnitTestUtils {
+    /**
+     * Gets the contents of a classpath resource as a String using UTF-8 encoding.
+     * 
+     * <p>
+     * The path to unit test resources should be relative, because the path changes when the application
+     * is packaged into distributed format (e.g. JAR or WAR).
+     * </p>
+     * 
+     * @param relResourcePath relative path of the desired resource
+     * @return the requested String
+     * @throws IOException
+     */
+    public static String readFileToString(String relResourcePath) throws IOException {
+        if (relResourcePath.startsWith("src/") || relResourcePath.startsWith("./src/")) {
+            throw new IllegalArgumentException("Resource path must be relative");
+        }
+
+        return IOUtils.resourceToString(relResourcePath, StandardCharsets.UTF_8, UnitTestUtils.class.getClassLoader());
+    }
+}

--- a/dataverse-webapp/src/test/java/edu/harvard/iq/dataverse/authorization/providers/oauth2/impl/OrcidOAuth2APTest.java
+++ b/dataverse-webapp/src/test/java/edu/harvard/iq/dataverse/authorization/providers/oauth2/impl/OrcidOAuth2APTest.java
@@ -1,22 +1,24 @@
 package edu.harvard.iq.dataverse.authorization.providers.oauth2.impl;
 
-import edu.harvard.iq.dataverse.authorization.providers.oauth2.AbstractOAuth2AuthenticationProvider;
-import edu.harvard.iq.dataverse.authorization.providers.oauth2.OAuth2Exception;
-import edu.harvard.iq.dataverse.persistence.user.AuthenticatedUserDisplayInfo;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import java.util.Arrays;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import org.junit.Test;
+
+import edu.harvard.iq.dataverse.UnitTestUtils;
+import edu.harvard.iq.dataverse.authorization.providers.oauth2.AbstractOAuth2AuthenticationProvider;
+import edu.harvard.iq.dataverse.authorization.providers.oauth2.OAuth2Exception;
+import edu.harvard.iq.dataverse.persistence.user.AuthenticatedUserDisplayInfo;
 
 /**
  * @author michael
  * @author pameyer
  */
 public class OrcidOAuth2APTest extends OrcidOAuth2AP {
-    private static final String PERSON_FILE = "src/test/resources/xml/oauth2/orcid/v20_person.xml";
-    private static final String ACTIVITIES_FILE = "src/test/resources/xml/oauth2/orcid/v20_activities.xml";
+    private static final String PERSON_FILE = "xml/oauth2/orcid/v20_person.xml";
+    private static final String ACTIVITIES_FILE = "xml/oauth2/orcid/v20_activities.xml";
     private static final String PERSON;
     private static final String ACTIVITIES;
 
@@ -36,8 +38,7 @@ public class OrcidOAuth2APTest extends OrcidOAuth2AP {
     private static String loadResponseXML(String fname) {
         String txt = null;
         try {
-            java.io.File inp = new java.io.File(fname);
-            txt = org.apache.commons.io.FileUtils.readFileToString(inp);
+            txt = UnitTestUtils.readFileToString(fname);
         } catch (java.io.IOException ie) {
             // no-op; assert that the needed strings are not null in tests
         }

--- a/dataverse-webapp/src/test/java/edu/harvard/iq/dataverse/datavariable/VariableMetadataDDIParserTest.java
+++ b/dataverse-webapp/src/test/java/edu/harvard/iq/dataverse/datavariable/VariableMetadataDDIParserTest.java
@@ -1,23 +1,27 @@
 package edu.harvard.iq.dataverse.datavariable;
 
-import edu.harvard.iq.dataverse.persistence.datafile.datavariable.CategoryMetadata;
-import edu.harvard.iq.dataverse.persistence.datafile.datavariable.DataVariable;
-import edu.harvard.iq.dataverse.persistence.datafile.datavariable.VarGroup;
-import edu.harvard.iq.dataverse.persistence.datafile.datavariable.VariableMetadata;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
-import javax.xml.stream.XMLInputFactory;
-import javax.xml.stream.XMLStreamException;
-import javax.xml.stream.XMLStreamReader;
-import java.io.FileInputStream;
+import java.io.Reader;
+import java.io.StringReader;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+
+import org.junit.Test;
+
+import edu.harvard.iq.dataverse.UnitTestUtils;
+import edu.harvard.iq.dataverse.persistence.datafile.datavariable.CategoryMetadata;
+import edu.harvard.iq.dataverse.persistence.datafile.datavariable.DataVariable;
+import edu.harvard.iq.dataverse.persistence.datafile.datavariable.VarGroup;
+import edu.harvard.iq.dataverse.persistence.datafile.datavariable.VariableMetadata;
 
 public class VariableMetadataDDIParserTest {
 
@@ -27,12 +31,13 @@ public class VariableMetadataDDIParserTest {
      */
     public void testDDIReader() {
 
-        String fileName = "src/test/resources/xml/dct.xml";
         XMLStreamReader xmlr = null;
 
         XMLInputFactory factory = XMLInputFactory.newInstance();
         try {
-            xmlr = factory.createXMLStreamReader(new FileInputStream(fileName));
+            String text = UnitTestUtils.readFileToString("xml/dct.xml");
+            Reader stringReader = new StringReader(text);
+            xmlr = factory.createXMLStreamReader(stringReader);
         } catch (Exception e) {
             xmlr = null;
             assertNotNull(xmlr);

--- a/dataverse-webapp/src/test/java/edu/harvard/iq/dataverse/export/ExportServiceTest.java
+++ b/dataverse-webapp/src/test/java/edu/harvard/iq/dataverse/export/ExportServiceTest.java
@@ -1,7 +1,36 @@
 package edu.harvard.iq.dataverse.export;
 
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.ws.rs.core.MediaType;
+
 import com.google.common.collect.Lists;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.Assert;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
 import edu.harvard.iq.dataverse.DatasetFieldServiceBean;
+import edu.harvard.iq.dataverse.UnitTestUtils;
 import edu.harvard.iq.dataverse.common.DatasetFieldConstant;
 import edu.harvard.iq.dataverse.error.DataverseError;
 import edu.harvard.iq.dataverse.export.spi.Exporter;
@@ -15,36 +44,10 @@ import edu.harvard.iq.dataverse.persistence.dataset.FieldType;
 import edu.harvard.iq.dataverse.persistence.dataset.MetadataBlock;
 import edu.harvard.iq.dataverse.persistence.dataverse.Dataverse;
 import edu.harvard.iq.dataverse.settings.SettingsServiceBean;
-import edu.harvard.iq.dataverse.UnitTestUtils;
 import edu.harvard.iq.dataverse.util.SystemConfig;
 import edu.harvard.iq.dataverse.util.json.JsonParseException;
 import edu.harvard.iq.dataverse.util.json.JsonParser;
 import io.vavr.control.Either;
-import org.apache.commons.io.IOUtils;
-import org.junit.Assert;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
-
-import javax.json.Json;
-import javax.json.JsonObject;
-import javax.ws.rs.core.MediaType;
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.sql.Timestamp;
-import java.time.LocalDate;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.when;
 
 
 @ExtendWith(MockitoExtension.class)

--- a/dataverse-webapp/src/test/java/edu/harvard/iq/dataverse/export/ExportServiceTest.java
+++ b/dataverse-webapp/src/test/java/edu/harvard/iq/dataverse/export/ExportServiceTest.java
@@ -15,6 +15,7 @@ import edu.harvard.iq.dataverse.persistence.dataset.FieldType;
 import edu.harvard.iq.dataverse.persistence.dataset.MetadataBlock;
 import edu.harvard.iq.dataverse.persistence.dataverse.Dataverse;
 import edu.harvard.iq.dataverse.settings.SettingsServiceBean;
+import edu.harvard.iq.dataverse.UnitTestUtils;
 import edu.harvard.iq.dataverse.util.SystemConfig;
 import edu.harvard.iq.dataverse.util.json.JsonParseException;
 import edu.harvard.iq.dataverse.util.json.JsonParser;
@@ -36,7 +37,6 @@ import javax.ws.rs.core.MediaType;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.util.Collection;
@@ -88,7 +88,7 @@ public class ExportServiceTest {
                 exportService.exportDatasetVersionAsString(datasetVersion, ExporterType.DATACITE);
 
         //then
-        Assert.assertEquals(readFileToString("exportdata/testDatacite.xml"), exportedDataset.get());
+        Assert.assertEquals(UnitTestUtils.readFileToString("exportdata/testDatacite.xml"), exportedDataset.get());
     }
 
     @Test
@@ -103,7 +103,7 @@ public class ExportServiceTest {
                 exportService.exportDatasetVersionAsString(datasetVersion, ExporterType.DCTERMS);
 
         //then
-        Assert.assertEquals(readFileToString("exportdata/dcterms.xml"), exportedDataset.get());
+        Assert.assertEquals(UnitTestUtils.readFileToString("exportdata/dcterms.xml"), exportedDataset.get());
     }
 
     @Test
@@ -118,7 +118,7 @@ public class ExportServiceTest {
                 exportService.exportDatasetVersionAsString(datasetVersion, ExporterType.DDI);
 
         //then
-        Assert.assertEquals(readFileToString("exportdata/ddi.xml"), exportedDataset.get());
+        Assert.assertEquals(UnitTestUtils.readFileToString("exportdata/ddi.xml"), exportedDataset.get());
 
         System.out.println(exportedDataset.get());
     }
@@ -137,7 +137,7 @@ public class ExportServiceTest {
                 exportService.exportDatasetVersionAsString(datasetVersion, ExporterType.DDI);
 
         //then
-        Assert.assertEquals(readFileToString("exportdata/ddiWithoutEmail.xml"), exportedDataset.get());
+        Assert.assertEquals(UnitTestUtils.readFileToString("exportdata/ddiWithoutEmail.xml"), exportedDataset.get());
     }
 
     @Test
@@ -152,7 +152,7 @@ public class ExportServiceTest {
                 exportService.exportDatasetVersionAsString(datasetVersion, ExporterType.JSON);
 
         //then
-        Assert.assertEquals(readFileToString("exportdata/datasetInJson.json"), exportedDataset.get());
+        Assert.assertEquals(UnitTestUtils.readFileToString("exportdata/datasetInJson.json"), exportedDataset.get());
     }
 
     @Test
@@ -167,7 +167,7 @@ public class ExportServiceTest {
                 exportService.exportDatasetVersionAsString(datasetVersion, ExporterType.OAIORE);
 
         //then
-        Assert.assertEquals(readFileToString("exportdata/oai_ore.json"), exportedDataset.get());
+        Assert.assertEquals(UnitTestUtils.readFileToString("exportdata/oai_ore.json"), exportedDataset.get());
     }
 
     @Test
@@ -182,7 +182,7 @@ public class ExportServiceTest {
                 exportService.exportDatasetVersionAsString(datasetVersion, ExporterType.SCHEMADOTORG);
 
         //then
-        Assert.assertEquals(readFileToString("exportdata/schemaorg.json"), exportedDataset.get());
+        Assert.assertEquals(UnitTestUtils.readFileToString("exportdata/schemaorg.json"), exportedDataset.get());
     }
 
     @Test
@@ -197,7 +197,7 @@ public class ExportServiceTest {
                 exportService.exportDatasetVersionAsString(datasetVersion, ExporterType.OPENAIRE);
 
         //then
-        Assert.assertEquals(readFileToString("exportdata/openaire.xml"), exportedDataset.get());
+        Assert.assertEquals(UnitTestUtils.readFileToString("exportdata/openaire.xml"), exportedDataset.get());
     }
 
     @Test
@@ -212,7 +212,7 @@ public class ExportServiceTest {
                 exportService.exportDatasetVersionAsString(datasetVersion, ExporterType.DUBLINCORE);
 
         //then
-        Assert.assertEquals(readFileToString("exportdata/dublincore.xml"), exportedDataset.get());
+        Assert.assertEquals(UnitTestUtils.readFileToString("exportdata/dublincore.xml"), exportedDataset.get());
     }
 
     @Test
@@ -500,9 +500,5 @@ public class ExportServiceTest {
 
         when(datasetFieldService.findByNameOpt(eq("depositor"))).thenReturn(depositorFieldType);
         when(datasetFieldService.findByNameOpt(eq("dateOfDeposit"))).thenReturn(dateOfDepositFieldType);
-    }
-
-    private String readFileToString(String resourcePath) throws IOException {
-        return IOUtils.resourceToString(resourcePath, StandardCharsets.UTF_8, getClass().getClassLoader());
     }
 }

--- a/dataverse-webapp/src/test/java/edu/harvard/iq/dataverse/export/SchemaDotOrgExporterTest.java
+++ b/dataverse-webapp/src/test/java/edu/harvard/iq/dataverse/export/SchemaDotOrgExporterTest.java
@@ -1,5 +1,30 @@
 package edu.harvard.iq.dataverse.export;
 
+import static org.junit.Assert.assertEquals;
+
+import java.io.PrintWriter;
+import java.io.StringReader;
+import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import edu.harvard.iq.dataverse.UnitTestUtils;
 import edu.harvard.iq.dataverse.persistence.MocksFactory;
 import edu.harvard.iq.dataverse.persistence.datafile.DataFile;
 import edu.harvard.iq.dataverse.persistence.datafile.FileMetadata;
@@ -12,31 +37,6 @@ import edu.harvard.iq.dataverse.persistence.dataset.TermsOfUseAndAccess;
 import edu.harvard.iq.dataverse.persistence.dataverse.Dataverse;
 import edu.harvard.iq.dataverse.util.json.JsonParser;
 import edu.harvard.iq.dataverse.util.json.JsonUtil;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
-import javax.json.Json;
-import javax.json.JsonObject;
-import javax.json.JsonReader;
-import java.io.File;
-import java.io.PrintWriter;
-import java.io.StringReader;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.sql.Timestamp;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * For docs see {@link SchemaDotOrgExporter}.
@@ -229,8 +229,7 @@ public class SchemaDotOrgExporterTest {
     @Test
     public void testExportDataset() throws Exception {
         System.out.println("exportDataset");
-        File datasetVersionJson = new File("src/test/resources/json/dataset-finch2.json");
-        String datasetVersionAsJson = new String(Files.readAllBytes(Paths.get(datasetVersionJson.getAbsolutePath())));
+        String datasetVersionAsJson = UnitTestUtils.readFileToString("json/dataset-finch2.json");
 
         JsonReader jsonReader1 = Json.createReader(new StringReader(datasetVersionAsJson));
         JsonObject json1 = jsonReader1.readObject();

--- a/dataverse-webapp/src/test/java/edu/harvard/iq/dataverse/ingest/IngestFrequencyTest.java
+++ b/dataverse-webapp/src/test/java/edu/harvard/iq/dataverse/ingest/IngestFrequencyTest.java
@@ -1,21 +1,23 @@
 package edu.harvard.iq.dataverse.ingest;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collection;
+
+import org.junit.Test;
+
+import edu.harvard.iq.dataverse.UnitTestUtils;
 import edu.harvard.iq.dataverse.ingest.tabulardata.TabularDataFileReader;
 import edu.harvard.iq.dataverse.ingest.tabulardata.TabularDataIngest;
 import edu.harvard.iq.dataverse.persistence.datafile.DataFile;
 import edu.harvard.iq.dataverse.persistence.datafile.DataTable;
 import edu.harvard.iq.dataverse.persistence.datafile.datavariable.VariableCategory;
-import org.junit.Test;
-
-import java.io.BufferedInputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.util.Collection;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 public class IngestFrequencyTest {
 
@@ -27,9 +29,7 @@ public class IngestFrequencyTest {
      */
 
     public void testFrequency()  {
-
-        String fileNameSav = "src/test/resources/sav/frequency-test.sav";
-        DataFile dataFile = readFileCalcFreq(fileNameSav , "application/x-spss-sav" );
+        DataFile dataFile = readFileCalcFreq("sav/frequency-test.sav" , "application/x-spss-sav" );
 
         assertNotNull(dataFile);
 
@@ -48,7 +48,7 @@ public class IngestFrequencyTest {
         assertEquals(cats3.size(),2);
         thirdVariableTest(cats3);
 
-        DataFile dataFileDta = readFileCalcFreq("src/test/resources/dta/test_cat_values.dta" , "application/x-stata-14" );
+        DataFile dataFileDta = readFileCalcFreq("dta/test_cat_values.dta" , "application/x-stata-14");
         assertNotNull(dataFileDta);
 
         long varQuantDta = dataFileDta.getDataTable().getVarQuantity();
@@ -83,8 +83,9 @@ public class IngestFrequencyTest {
         BufferedInputStream fileInputStream = null;
 
         try {
-            fileInputStream = new BufferedInputStream(new FileInputStream(new File(fileName)));
-        } catch (FileNotFoundException notfoundEx) {
+            InputStream inputStream = new ByteArrayInputStream(UnitTestUtils.readFileToByteArray(fileName));
+            fileInputStream = new BufferedInputStream(inputStream);
+        } catch (IOException notfoundEx) {
             System.out.println("Cannot find file " + fileName);
             fileInputStream = null;
             assertNotNull(fileInputStream);

--- a/dataverse-webapp/src/test/java/edu/harvard/iq/dataverse/util/json/DatasetVersionDTOTest.java
+++ b/dataverse-webapp/src/test/java/edu/harvard/iq/dataverse/util/json/DatasetVersionDTOTest.java
@@ -8,7 +8,6 @@ package edu.harvard.iq.dataverse.util.json;
 import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -16,13 +15,13 @@ import java.util.List;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 
-import org.apache.commons.io.IOUtils;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import edu.harvard.iq.dataverse.UnitTestUtils;
 import edu.harvard.iq.dataverse.api.dto.DatasetVersionDTO;
 import edu.harvard.iq.dataverse.api.dto.FieldDTO;
 
@@ -52,7 +51,7 @@ public class DatasetVersionDTOTest {
 
     @Test
     public void testReadDataSet() throws IOException {
-        String text = readFileToString("txt/util/JsonDatasetVersion.txt");
+        String text = UnitTestUtils.readFileToString("txt/util/JsonDatasetVersion.txt");
         Gson gson = new Gson();
         DatasetVersionDTO dto = gson.fromJson(text, DatasetVersionDTO.class);
 
@@ -84,9 +83,5 @@ public class DatasetVersionDTOTest {
         JsonElement result = gson.toJsonTree(authorDTO);
 
         assertEquals(expected, result);
-    }
-
-    private String readFileToString(String resourcePath) throws IOException {
-        return IOUtils.resourceToString(resourcePath, StandardCharsets.UTF_8, getClass().getClassLoader());
     }
 }


### PR DESCRIPTION
There still a few paths to be corrected, but please let me know if you agree with the general idea. This PR is arose from a remark at https://github.com/CeON/dataverse/pull/702#discussion_r385021271.

## Related Issues

- connects to #716 

## Pull Request Checklist

- [x] Unit [tests][] completed
- [x] Integration [tests][]: None
- [x] Deployment requirements, [SQL updates][], [Solr updates][], etc.: None
- [x] [Documentation][docs] completed
- [x] Merged latest from "develop" [branch][] and resolved conflicts

[tests]: http://guides.dataverse.org/en/latest/developers/testing.html
[SQL updates]: http://guides.dataverse.org/en/latest/developers/sql-upgrade-scripts.html
[Solr updates]: https://github.com/IQSS/dataverse/blob/develop/conf/solr/7.3.0/schema.xml
[docs]: http://guides.dataverse.org/en/latest/developers/documentation.html
[branch]: http://guides.dataverse.org/en/latest/developers/branching-strategy.html
