### PR TITLE
Closes #743: Fix logo issues

### DIFF
--- a/dataverse-webapp/src/main/webapp/resources/vecler/theme.scss
+++ b/dataverse-webapp/src/main/webapp/resources/vecler/theme.scss
@@ -1329,6 +1329,7 @@ $navbar-height: 6.8em;
 		display: table;
 
 		font-size: 1em;
+		text-shadow: none;
 
 		#site-logo {
 			top: 0.188em;


### PR DESCRIPTION
Closes #743 
Removed a leftover `text-shadow` property that caused a faint shadow of the default logo to be displayed over the new logo