### PR TITLE
Closes #779: Fix for always not passing validation on user preffered language

### DIFF
--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/Shib.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/Shib.java
@@ -570,7 +570,9 @@ public class Shib implements java.io.Serializable {
     }
 
     public String getPreferredNotificationsLanguage() {
-        return Option.of(preferredNotificationsLanguage).getOrElse(Locale.ROOT).getLanguage();
+        return Option.of(preferredNotificationsLanguage)
+                .map(locale -> locale.getLanguage())
+                .getOrNull();
     }
 
     public String getLocalizedPreferredNotificationsLanguage() {

--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/authorization/providers/builtin/DataverseUserPage.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/authorization/providers/builtin/DataverseUserPage.java
@@ -785,7 +785,9 @@ public class DataverseUserPage implements java.io.Serializable {
     }
 
     public String getPreferredNotificationsLanguage() {
-        return Option.of(preferredNotificationsLanguage).getOrElse(Locale.ROOT).getLanguage();
+        return Option.of(preferredNotificationsLanguage)
+                    .map(locale -> locale.getLanguage())
+                    .getOrNull();
     }
 
     public String getLocalizedPreferredNotificationsLanguage() {

--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/authorization/providers/oauth2/OAuth2FirstLoginPage.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/authorization/providers/oauth2/OAuth2FirstLoginPage.java
@@ -401,7 +401,9 @@ public class OAuth2FirstLoginPage implements java.io.Serializable {
     }
 
     public String getPreferredNotificationsLanguage() {
-        return Option.of(preferredNotificationsLanguage).getOrElse(Locale.ROOT).getLanguage();
+        return Option.of(preferredNotificationsLanguage)
+                .map(locale -> locale.getLanguage())
+                .getOrNull();
     }
 
     public String getLocalizedPreferredNotificationsLanguage() {

--- a/dataverse-webapp/src/main/webapp/createEditDataverse.xhtml
+++ b/dataverse-webapp/src/main/webapp/createEditDataverse.xhtml
@@ -92,12 +92,10 @@
                             </label>
                             <div class="col-sm-9 form-col-container">
                                 <p:selectOneMenu id="dataverseCategory" styleClass="form-control"
-                                                    value="#{CreateEditDataversePage.dataverse.dataverseType}"
-                                                    hideNoSelectionOption="true">
+                                                    value="#{CreateEditDataversePage.dataverse.dataverseType}">
                                     <f:selectItem id="dvSelect"
                                                     itemLabel="#{bundle['dataverse.type.selectTab.top']}"
                                                     itemValue="#{null}"
-                                                    aria-hidden="true"
                                                     noSelectionOption="true"
                                                     itemDisabled="true"/>
                                     <f:selectItem id="dvDepartment"

--- a/dataverse-webapp/src/main/webapp/dataverseuser.xhtml
+++ b/dataverse-webapp/src/main/webapp/dataverseuser.xhtml
@@ -698,7 +698,6 @@
                                                          styleClass="facet-category-default"
                                                          disabled="#{false}"
                                                          validator="#{DataverseUserPage.validatePreferredNotificationsLanguage}"
-                                                         hideNoSelectionOption="true"
                                                          rendered="#{DataverseUserPage.editMode eq 'CREATE'}"
                                                          value="#{DataverseUserPage.preferredNotificationsLanguage}"
                                                          required="#{true}"
@@ -707,9 +706,8 @@
                                             <f:selectItem
                                                     itemLabel="#{bundle['user.notificationsLanguage.selectItem']}"
                                                     noSelectionOption="true"
-                                                    itemValue=""
+                                                    itemValue="#{null}"
                                                     itemDisabled="true"
-                                                    aria-hidden="true"
                                             />
                                             <f:selectItems value="#{DataverseUserPage.getSupportedLanguages()}"
                                                            var="language"

--- a/dataverse-webapp/src/main/webapp/oauth2/firstLogin.xhtml
+++ b/dataverse-webapp/src/main/webapp/oauth2/firstLogin.xhtml
@@ -143,16 +143,14 @@
                                                      styleClass="facet-category-default"
                                                      disabled="#{false}"
                                                      validator="#{OAuth2FirstLoginPage.validatePreferredNotificationsLanguage}"
-                                                     hideNoSelectionOption="true"
                                                      value="#{OAuth2FirstLoginPage.preferredNotificationsLanguage}"
                                                      required="#{true}"
                                     >
                                         <f:selectItem
                                                 itemLabel="#{bundle['user.notificationsLanguage.selectItem']}"
                                                 noSelectionOption="true"
-                                                itemValue=""
+                                                itemValue="#{null}"
                                                 itemDisabled="true"
-                                                aria-hidden="true"
                                         />
                                         <f:selectItems value="#{OAuth2FirstLoginPage.getSupportedLanguages()}"
                                                        var="language"

--- a/dataverse-webapp/src/main/webapp/shib.xhtml
+++ b/dataverse-webapp/src/main/webapp/shib.xhtml
@@ -132,16 +132,14 @@
                                                  styleClass="facet-category-default"
                                                  disabled="#{false}"
                                                  validator="#{Shib.validatePreferredNotificationsLanguage}"
-                                                 hideNoSelectionOption="true"
                                                  value="#{Shib.preferredNotificationsLanguage}"
                                                  required="#{true}"
                                 >
                                     <f:selectItem
                                             itemLabel="#{bundle['user.notificationsLanguage.selectItem']}"
                                             noSelectionOption="true"
-                                            itemValue=""
+                                            itemValue="#{null}"
                                             itemDisabled="true"
-                                            aria-hidden="true"
                                     />
                                     <f:selectItems value="#{Shib.getSupportedLanguages()}"
                                                    var="language"


### PR DESCRIPTION
Not sure why. But primefaces really don't like combination of `itemDisabled="true"` and `itemValue=""` on noSelectionOption item.
After switching to `itemValue="#{null}"` everything seems to work.
Probably issue arouse from bumping up primefaces version to 7.0