### PR TITLE
Closes #786: Footer on small pages are not sticked to bottom of the page

### DIFF
--- a/dataverse-webapp/src/main/webapp/resources/vecler/theme.scss
+++ b/dataverse-webapp/src/main/webapp/resources/vecler/theme.scss
@@ -1488,10 +1488,24 @@ $navbar-height: 6.8em;
 		}
 	}
 }
+.widget-view {
+	&#footer {
+		position: static;
+	}
+	#footer-logos {
+		display: none;
+	}
+}
 
 @media screen and (max-width: $screen-xs-max) {
-	#footer div[class^="col-"] {
-		text-align: center;
+	#footer {
+		&.widget-view .poweredbylogo {
+			text-align: inherit;
+		}
+		
+		div[class^="col-"] {
+			text-align: center;
+		}
 	}
 }
 

--- a/dataverse-webapp/src/main/webapp/resources/vecler/theme.scss
+++ b/dataverse-webapp/src/main/webapp/resources/vecler/theme.scss
@@ -1495,6 +1495,26 @@ $navbar-height: 6.8em;
 	}
 }
 
+/* Sticky footer fix */
+html, body {
+	height: 100%;
+
+	&, #body-wrapper {
+		min-height: 100%;
+	}
+}
+#body-wrapper {
+	display: flex;
+	flex-direction: column;
+}
+#content {
+	flex: 1 0 auto;
+	max-width: 100%;
+}
+#navbarFixed, #footer {
+	flex-shrink: 0;
+}
+
 
 /* Main page */
 


### PR DESCRIPTION
Closes #786 

Footer is now sticky to the bottom of the page even if there's not enough content on the screen. Easiest to check on the Login page.

Please also double check if the responsive (mobile) view didn't break, I had a huge headache getting this to work.