### PR TITLE
Closes #1190: Unable to scroll tables when their are inside tab component

### DIFF
--- a/dataverse-webapp/src/main/webapp/dataverse.xhtml
+++ b/dataverse-webapp/src/main/webapp/dataverse.xhtml
@@ -280,12 +280,10 @@
                             rendered="#{SearchIncludeFragment.filterQueries.size() == 0 and empty SearchIncludeFragment.query}">
                         <ui:fragment
                                 rendered="#{!empty DataversePage.dataverse.description and !widgetWrapper.widgetView}">
-                            <div id="dataverseDesc" style="margin-bottom:1em;">
-                                <p class="text-block">
+                            <div id="dataverseDesc">
                                     <h:outputText
                                             value="#{MarkupChecker:sanitizeBasicHTML(DataversePage.dataverse.description)}"
                                             escape="false"/>
-                                </p>
                             </div>
                             <div class="clearfix"/>
                         </ui:fragment>

--- a/dataverse-webapp/src/main/webapp/resources/js/dv_rebind_bootstrap_ui.js
+++ b/dataverse-webapp/src/main/webapp/resources/js/dv_rebind_bootstrap_ui.js
@@ -579,7 +579,15 @@ function reinitializePrimefacesComponentsJS() {
             });
         }
     }
-}
+
+    /* disable swipe events for tabView and paginator, to allow scrolling contents without unexpected behavior */
+    if (PrimeFaces.widget.Paginator) {
+        PrimeFaces.widget.Paginator.prototype.bindSwipeEvents = function() {} 
+    }
+    if (PrimeFaces.widget.TabView) {
+        PrimeFaces.widget.TabView.prototype.bindSwipeEvents = function() {
+    }
+}}
 reinitializePrimefacesComponentsJS();
 
 /*

--- a/dataverse-webapp/src/main/webapp/resources/vecler/theme-base.scss
+++ b/dataverse-webapp/src/main/webapp/resources/vecler/theme-base.scss
@@ -2252,6 +2252,7 @@ html, body {
 
 #dataverseDesc {
 	margin-left: 15px;
+	margin-bottom:1em;
 	width: 100%;
 	padding-top: 15px;
 }
@@ -2884,6 +2885,7 @@ div.filesTable .ui-paginator {
 #title-block {
 	margin-top: 20px;
 	margin-bottom: 32px;
+	max-width: calc(100vw - 50px);
 
 	.title-preview-icon-block {
 		.icon-dataset {
@@ -3340,13 +3342,13 @@ p.text-block {
 }
 
 body.eighty-limit-toggle {
-	p.text-block, p.help-block, span.ui-chkbox-label, #terms-agreement-block {
+	p.text-block, p.help-block, span.ui-chkbox-label, #terms-agreement-block, #dataverseDesc {
 		max-width: 36.4em;
 	}
 }
 
 body.eighty-limit-toggle.wcag-text-toggle {
-	p.text-block, p.help-block, span.ui-chkbox-label, #terms-agreement-block {
+	p.text-block, p.help-block, span.ui-chkbox-label, #terms-agreement-block, #dataverseDesc {
 		max-width: 48em;
 	}
 }
@@ -3357,7 +3359,7 @@ body.eighty-limit-toggle.wcag-text-toggle {
  */
 
 body.wcag-text-toggle {
-	p.text-block, p.help-block, span.ui-chkbox-label, #terms-agreement-block {
+	p.text-block, p.help-block, span.ui-chkbox-label, #terms-agreement-block, #dataverseDesc {
 		word-spacing: 0.16em;
 		letter-spacing: 0.12em;
 		line-height: 1.5em;


### PR DESCRIPTION
Closes #1190

This bug only affected mobile devices. When viewing e.g. a dataset on a smartphone, trying to scroll the file list table would change the tabs instead, or change the page (if there's more than one page of files), or both. This bug was not reproducible via responsive view in desktop browser developer tools. Changing tabs/pages via swiping is now disabled for all pages.

NOTE: there is no easy way to refresh the cache on mobile devices (like Ctrl+F5 on desktop), I suggest doing test in private mode to ensure the cache will get refreshed.