### PR TITLE
Closes #1226: Date fields are not marked as invalid

### DIFF
--- a/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/dataset/DatasetFieldValidator.java
+++ b/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/dataset/DatasetFieldValidator.java
@@ -1,23 +1,25 @@
 package edu.harvard.iq.dataverse.persistence.dataset;
 
-import com.google.common.collect.Lists;
-import edu.harvard.iq.dataverse.common.BundleUtil;
-import edu.harvard.iq.dataverse.persistence.config.EMailValidator;
-import edu.harvard.iq.dataverse.persistence.dataverse.Dataverse;
-import org.apache.commons.lang3.StringUtils;
-
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Calendar;
-import java.util.Date;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.GregorianCalendar;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.google.common.collect.Lists;
+
+import edu.harvard.iq.dataverse.common.BundleUtil;
+import edu.harvard.iq.dataverse.persistence.config.EMailValidator;
+import edu.harvard.iq.dataverse.persistence.dataverse.Dataverse;
 
 
 /**
@@ -166,22 +168,19 @@ public class DatasetFieldValidator implements ConstraintValidator<ValidateDatase
 
     private boolean isValidDate(String dateString, String pattern) {
         boolean valid = true;
-        Date date;
-        SimpleDateFormat sdf = new SimpleDateFormat(pattern);
-        sdf.setLenient(false);
+        
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(pattern);
         try {
             dateString = dateString.trim();
-            date = sdf.parse(dateString);
-            Calendar calendar = Calendar.getInstance();
-            calendar.setTime(date);
-            int year = calendar.get(Calendar.YEAR);
-            int era = calendar.get(Calendar.ERA);
+            LocalDate localDate = LocalDate.parse(dateString, formatter);
+            int year = localDate.getYear();
+            int era = localDate.getEra().getValue();
             if (era == GregorianCalendar.AD) {
                 if (year > 9999) {
                     valid = false;
                 }
             }
-        } catch (ParseException e) {
+        } catch (DateTimeParseException e) {
             valid = false;
         }
         if (dateString.length() > pattern.length()) {

--- a/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/dataset/DatasetFieldValidator.java
+++ b/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/dataset/DatasetFieldValidator.java
@@ -184,7 +184,7 @@ public class DatasetFieldValidator implements ConstraintValidator<ValidateDatase
         } catch (ParseException e) {
             valid = false;
         }
-        if (dateString.length() > pattern.length()) {
+        if (dateString.length() != pattern.length()) {
             valid = false;
         }
         return valid;

--- a/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/dataset/DatasetFieldValidatorTest.java
+++ b/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/dataset/DatasetFieldValidatorTest.java
@@ -146,11 +146,14 @@ public class DatasetFieldValidatorTest {
                 
                 //more date cases
                 
-                Arguments.of("966", Option.of(FieldType.DATE), Option.none(), true),
-                Arguments.of("1999-1", Option.of(FieldType.DATE), Option.none(), true),
-                Arguments.of("1999-1-1", Option.of(FieldType.DATE), Option.none(), true),
-                Arguments.of("1999-01-1", Option.of(FieldType.DATE), Option.none(), true),
+                Arguments.of("966", Option.of(FieldType.DATE), Option.none(), false),
+                Arguments.of("0966", Option.of(FieldType.DATE), Option.none(), true),
+                Arguments.of("1999-1", Option.of(FieldType.DATE), Option.none(), false),
+                Arguments.of("1999-1-1", Option.of(FieldType.DATE), Option.none(), false),
+                Arguments.of("1999-01-1", Option.of(FieldType.DATE), Option.none(), false),
                 Arguments.of("-1999", Option.of(FieldType.DATE), Option.none(), true),
+                Arguments.of("-999", Option.of(FieldType.DATE), Option.none(), false),
+                Arguments.of("-0999", Option.of(FieldType.DATE), Option.none(), true),
                 Arguments.of("-1991-01", Option.of(FieldType.DATE), Option.none(), true),
                 Arguments.of("10000", Option.of(FieldType.DATE), Option.none(), false),
                 Arguments.of("1999-13", Option.of(FieldType.DATE), Option.none(), false),


### PR DESCRIPTION
When SimpleDateFormat is lenient=false it still interprets "2020-7-7" as valid date with format "yyyy-MM-dd"