### PR TITLE
Closes #1316: Fix moving dataverse to dataverse

### DIFF
--- a/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/dataset/Dataset.java
+++ b/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/dataset/Dataset.java
@@ -53,10 +53,6 @@ import java.util.stream.Stream;
                 query = "SELECT d FROM Dataset d WHERE d.identifier=:identifier"),
         @NamedQuery(name = "Dataset.findByIdentifierAuthorityProtocol",
                 query = "SELECT d FROM Dataset d WHERE d.identifier=:identifier AND d.protocol=:protocol AND d.authority=:authority"),
-        @NamedQuery(name = "Dataset.findIdByOwnerId",
-                query = "SELECT o.identifier FROM Dataset o WHERE o.owner.id=:ownerId"),
-        @NamedQuery(name = "Dataset.findByOwnerId",
-                query = "SELECT o FROM Dataset o WHERE o.owner.id=:ownerId"),
 })
 
 /*

--- a/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/dataset/DatasetRepository.java
+++ b/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/dataset/DatasetRepository.java
@@ -4,6 +4,8 @@ import edu.harvard.iq.dataverse.persistence.JpaRepository;
 
 import javax.ejb.Singleton;
 
+import java.util.List;
+
 @Singleton
 public class DatasetRepository extends JpaRepository<Long, Dataset> {
 
@@ -12,4 +14,19 @@ public class DatasetRepository extends JpaRepository<Long, Dataset> {
     public DatasetRepository() {
         super(Dataset.class);
     }
+
+    // -------------------- LOGIC --------------------
+
+    public List<Dataset> findByOwnerId(Long ownerId) {
+        return em.createQuery("SELECT o FROM Dataset o WHERE o.owner.id=:ownerId", Dataset.class)
+                .setParameter("ownerId", ownerId)
+                .getResultList();
+    }
+
+    public List<Long> findIdsByOwnerId(Long ownerId) {
+        return em.createQuery("SELECT o.id FROM Dataset o WHERE o.owner.id=:ownerId", Long.class)
+                .setParameter("ownerId", ownerId)
+                .getResultList();
+    }
+
 }

--- a/dataverse-persistence/src/main/resources/Bundle_pl.properties
+++ b/dataverse-persistence/src/main/resources/Bundle_pl.properties
@@ -2839,7 +2839,7 @@ dahsboard.datamove.dataverse.command.error.dataverse.template.not.in.target.data
 dahsboard.datamove.dataverse.command.error.dataverse.featured.in.current.dataverse=Kolekcja, kt\u00F3r\u0105 pr\u00F3bujesz przenie\u015B\u0107 jest wyr\u00F3\u017Cniona w swojej aktualnej kolekcji nadrz\u0119dnej.
 dahsboard.datamove.dataverse.command.error.dataverse.metadata.block.not.in.target.dataverse=Blok metadanych w kolekcji, kt\u00F3r\u0105 pr\u00F3bujesz przenie\u015B\u0107 nie jest obecny w nowej kolekcji nadrz\u0119dnej.
 dahsboard.datamove.dataverse.command.error.dataverse.linked.to.target.dataverse=Kolekcja, kt\u00F3r\u0105 pr\u00F3bujesz przenie\u015B\u0107 jest przypi\u0119ta do nowej kolekcji nadrz\u0119dnej lub kt\u00F3rej\u015B z jej kolekcji wy\u017Cszego rz\u0119du.
-dahsboard.datamove.dataverse.command.error.dataset.linked.to.target.dataverse=Zbi\u00F3r danych w kolekcji, kt\u00F3r\u0105 pr\u00F3bujesz przenie\u015B\u0107 jest przypi\u0119ty do nowej kolekcji narz\u0119dnej lub kt\u00F3rej\u015B z jej jej kolekcji wy\u017Cszego rz\u0119du.
+dahsboard.datamove.dataverse.command.error.dataset.linked.to.target.dataverse=Zbi\u00F3r danych w kolekcji, kt\u00F3r\u0105 pr\u00F3bujesz przenie\u015B\u0107 jest przypi\u0119ty do nowej kolekcji narz\u0119dnej lub kt\u00F3rej\u015B z jej kolekcji wy\u017Cszego rz\u0119du.
 dashboard.datamove.dataverse.command.suggestForce=Mo\u017Cesz wymusi\u0107 to polecenie zaznaczaj\u0105c opcj\u0119 "Wymu\u015B przeniesienie".
 dashboard.datamove.dataverse.message.success=Kolekcja "{0}" zosta\u0142a pomy\u015Blnie przeniesiona do kolekcji "{1}".
 dashboard.datamove.dataverse.message.failure.summary=Przeniesienie kolekcji nie powiod\u0142o si\u0119.

--- a/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/dataset/DatasetRepositoryIT.java
+++ b/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/dataset/DatasetRepositoryIT.java
@@ -1,0 +1,80 @@
+package edu.harvard.iq.dataverse.persistence.dataset;
+
+import edu.harvard.iq.dataverse.persistence.PersistenceArquillianDeployment;
+import org.junit.Test;
+
+import javax.inject.Inject;
+
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
+import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.hamcrest.Matchers.*;
+
+public class DatasetRepositoryIT extends PersistenceArquillianDeployment {
+
+    @Inject
+    private DatasetRepository datasetRepository;
+
+
+    //-------------------- TESTS --------------------
+
+    @Test
+    public void findByOwnerId() {
+        // when
+        List<Dataset> datasets = datasetRepository.findByOwnerId(19L);
+        // then
+        assertNotNull(datasets);
+        assertEquals(2, datasets.size());
+        assertThat(datasets.stream().map(Dataset::getId).collect(toList()), containsInAnyOrder(56L, 57L));
+    }
+
+    @Test
+    public void findByOwnerId_dataverse_without_datasets() {
+        // when
+        List<Dataset> datasets = datasetRepository.findByOwnerId(67L);
+        // then
+        assertNotNull(datasets);
+        assertEquals(0, datasets.size());
+    }
+
+    @Test
+    public void findByOwnerId_non_existing_dataverse() {
+        // when
+        List<Dataset> datasets = datasetRepository.findByOwnerId(9999L);
+        // then
+        assertNotNull(datasets);
+        assertEquals(0, datasets.size());
+    }
+
+
+    @Test
+    public void findIdsByOwnerId() {
+        // when
+        List<Long> datasetIds = datasetRepository.findIdsByOwnerId(19L);
+        // then
+        assertNotNull(datasetIds);
+        assertEquals(2, datasetIds.size());
+        assertThat(datasetIds, containsInAnyOrder(56L, 57L));
+    }
+
+    @Test
+    public void findIdsByOwnerId_dataverse_without_datasets() {
+        // when
+        List<Long> datasetIds = datasetRepository.findIdsByOwnerId(67L);
+        // then
+        assertNotNull(datasetIds);
+        assertEquals(0, datasetIds.size());
+    }
+
+    @Test
+    public void findIdsByOwnerId_non_existing_dataverse() {
+        // when
+        List<Long> datasetIds = datasetRepository.findIdsByOwnerId(9999L);
+        // then
+        assertNotNull(datasetIds);
+        assertEquals(0, datasetIds.size());
+    }
+}

--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/api/Access.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/api/Access.java
@@ -792,35 +792,6 @@ public class Access extends AbstractApiBean {
             }
         }
 
-        // If there's no uploaded logo for this dataverse, go through its 
-        // [released] datasets and see if any of them have card images:
-
-        // TODO: figure out if we want to be doing this! 
-        // (efficiency considerations...) -- L.A. 4.0 
-        // And we definitely don't want to be doing this for harvested 
-        // dataverses:
-        /*
-        StorageIO thumbnailDataAccess = null; 
-        
-        if (!dataverse.isHarvested()) {
-            for (Dataset dataset : datasetDao.findPublishedByOwnerId(dataverseId)) {
-                logger.info("dvCardImage: checking dataset "+dataset.getGlobalId());
-                if (dataset != null) {
-                    DatasetVersion releasedVersion = dataset.getReleasedVersion();
-                    logger.info("dvCardImage: obtained released version "+releasedVersion.getTitle());
-                    thumbnailDataAccess = getThumbnailForDatasetVersion(releasedVersion); 
-                    if (thumbnailDataAccess != null) {
-                        logger.info("dvCardImage: obtained thumbnail for the version.");
-                        break;
-                    }
-                }
-            }
-        }
-        
-        if (thumbnailDataAccess != null && thumbnailDataAccess.getInputStream() != null) {
-            return thumbnailDataAccess.getInputStream();
-        }
-        */
         return null;
     }
 

--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/api/Dataverses.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/api/Dataverses.java
@@ -76,6 +76,7 @@ import javax.validation.ConstraintViolation;
 import javax.validation.ConstraintViolationException;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
@@ -998,7 +999,9 @@ public class Dataverses extends AbstractApiBean {
 
     @POST
     @Path("{id}/move/{targetDataverseAlias}")
-    public Response moveDataverse(@PathParam("id") String id, @PathParam("targetDataverseAlias") String targetDataverseAlias, @QueryParam("forceMove") Boolean force) {
+    public Response moveDataverse(@PathParam("id") String id,
+                    @PathParam("targetDataverseAlias") String targetDataverseAlias, 
+                    @QueryParam("forceMove") @DefaultValue("false") boolean force) {
         try {
             User u = findUserOrDie();
             Dataverse dv = findDataverseOrDie(id);

--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/MoveDataverseCommand.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/MoveDataverseCommand.java
@@ -46,9 +46,9 @@ public class MoveDataverseCommand extends AbstractVoidCommand {
     private static final Logger logger = Logger.getLogger(MoveDataverseCommand.class.getName());
     final Dataverse moved;
     final Dataverse destination;
-    final Boolean force;
+    final boolean force;
 
-    public MoveDataverseCommand(DataverseRequest aRequest, Dataverse moved, Dataverse destination, Boolean force) {
+    public MoveDataverseCommand(DataverseRequest aRequest, Dataverse moved, Dataverse destination, boolean force) {
         super(aRequest, dv("moved", moved),
               dv("source", moved.getOwner()),
               dv("destination", destination));
@@ -116,7 +116,7 @@ public class MoveDataverseCommand extends AbstractVoidCommand {
             List<Guestbook> movedGbs = moved.getGuestbooks();
             destinationGbs = destination.getGuestbooks();
             boolean inheritGuestbooksValue = !destination.isGuestbookRoot();
-            if (inheritGuestbooksValue && destination.getOwner() != null) {
+            if (inheritGuestbooksValue && !destination.isRoot()) {
                 destinationGbs.addAll(destination.getParentGuestbooks());
             }
             // include guestbooks in moved dataverse since they will also be there
@@ -130,7 +130,7 @@ public class MoveDataverseCommand extends AbstractVoidCommand {
             logger.info("Checking featured dataverses...");
             for (DataverseFeaturedDataverse dfdv : ownerFeaturedDv) {
                 if (moved.equals(dfdv.getFeaturedDataverse())) {
-                    if (force == null || !force) {
+                    if (!force) {
                         removeFeatDv = true;
                         break;
                     }
@@ -162,7 +162,7 @@ public class MoveDataverseCommand extends AbstractVoidCommand {
             inheritMbValue = !destination.isMetadataBlockRoot();
         }
 
-        List<DataverseLinkingDataverse> linkingDataverses = new ArrayList();
+        List<DataverseLinkingDataverse> linkingDataverses = new ArrayList<>();
 
         logger.info("Checking templates and metadata blocks");
         for (Dataverse dv : dataverseChildren) {
@@ -171,7 +171,7 @@ public class MoveDataverseCommand extends AbstractVoidCommand {
             if (destinationTemplates != null) {
                 Template dvt = dv.getDefaultTemplate();
                 if (dvt != null && !destinationTemplates.contains(dvt)) {
-                    if (force == null || !force) {
+                    if (!force) {
                         removeTemplate = true;
                         break;
                     }
@@ -191,9 +191,9 @@ public class MoveDataverseCommand extends AbstractVoidCommand {
                     MetadataBlock mb = iter.next();
                     // if the owner is null, it means that the owner is the root dataverse
                     // because technically only custom metadata blocks have owners
-                    Dataverse mbOwner = (mb.getOwner() != null) ? mb.getOwner() : ctxt.dataverses().findByAlias(":root");
+                    Dataverse mbOwner = (mb.getOwner() != null) ? mb.getOwner() : ctxt.dataverses().findRootDataverse();
                     if (!mbParentsToCheck.contains(mbOwner)) {
-                        if (force == null || !force) {
+                        if (!force) {
                             removeMetadataBlock = true;
                             break;
                         }
@@ -203,7 +203,7 @@ public class MoveDataverseCommand extends AbstractVoidCommand {
                         metadataBlocksToKeep.add(mb);
                     }
                 }
-                if (force != null && force) {
+                if (force) {
                     dv.setMetadataBlocks(metadataBlocksToKeep);
                 }
             }
@@ -214,14 +214,14 @@ public class MoveDataverseCommand extends AbstractVoidCommand {
             }
         }
 
-        List<DatasetLinkingDataverse> linkingDatasets = new ArrayList();
+        List<DatasetLinkingDataverse> linkingDatasets = new ArrayList<>();
         logger.info("Checking guestbooks...");
         for (Dataset ds : datasetChildren) {
             // if all the dataverse's datasets GUESTBOOKS are not 
             //contained in the new dataverse, then remove them
             Guestbook dsgb = ds.getGuestbook();
             if (dsgb != null && (destinationGbs == null || !destinationGbs.contains(dsgb))) {
-                if (force == null || !force) {
+                if (!force) {
                     removeGuestbook = true;
                     break;
                 }
@@ -240,7 +240,7 @@ public class MoveDataverseCommand extends AbstractVoidCommand {
         for (DataverseLinkingDataverse dvld : linkingDataverses) {
             for (Dataverse owner : ownersToCheck) {
                 if ((dvld.getLinkingDataverse()).equals(owner)) {
-                    if (force == null || !force) {
+                    if (!force) {
                         removeLinkDv = true;
                         break;
                     }
@@ -257,7 +257,7 @@ public class MoveDataverseCommand extends AbstractVoidCommand {
         for (DatasetLinkingDataverse dsld : linkingDatasets) {
             for (Dataverse owner : ownersToCheck) {
                 if ((dsld.getLinkingDataverse()).equals(owner)) {
-                    if (force == null || !force) {
+                    if (!force) {
                         removeLinkDs = true;
                         break;
                     }

--- a/dataverse-webapp/src/test/java/edu/harvard/iq/dataverse/engine/command/impl/MoveDataverseCommandTest.java
+++ b/dataverse-webapp/src/test/java/edu/harvard/iq/dataverse/engine/command/impl/MoveDataverseCommandTest.java
@@ -305,14 +305,14 @@ public class MoveDataverseCommandTest {
         DataverseRequest aRequest = new DataverseRequest(auth, httpRequest);
 
         testEngine.submit(
-                new MoveDataverseCommand(aRequest, childB, childA, null));
+                new MoveDataverseCommand(aRequest, childB, childA, false));
 
         assertEquals(childA, childB.getOwner());
         assertEquals(Arrays.asList(root, childA), childB.getOwners());
 
         // move back
         testEngine.submit(
-                new MoveDataverseCommand(aRequest, childB, root, null));
+                new MoveDataverseCommand(aRequest, childB, root, false));
 
         assertEquals(root, childB.getOwner());
         assertEquals(Arrays.asList(root), childB.getOwners());
@@ -326,7 +326,7 @@ public class MoveDataverseCommandTest {
         System.out.println("testInvalidMove");
         DataverseRequest aRequest = new DataverseRequest(auth, httpRequest);
         testEngine.submit(
-                new MoveDataverseCommand(aRequest, childA, grandchildAA, null));
+                new MoveDataverseCommand(aRequest, childA, grandchildAA, false));
         fail();
     }
 
@@ -338,7 +338,7 @@ public class MoveDataverseCommandTest {
         System.out.println("testNotSuperUser");
         DataverseRequest aRequest = new DataverseRequest(nobody, httpRequest);
         testEngine.submit(
-                new MoveDataverseCommand(aRequest, childB, childA, null));
+                new MoveDataverseCommand(aRequest, childB, childA, false));
         fail();
     }
 
@@ -347,7 +347,7 @@ public class MoveDataverseCommandTest {
         System.out.println("testMoveIntoSelf");
         DataverseRequest aRequest = new DataverseRequest(auth, httpRequest);
         testEngine.submit(
-                new MoveDataverseCommand(aRequest, childB, childB, null));
+                new MoveDataverseCommand(aRequest, childB, childB, false));
         fail();
     }
 
@@ -356,7 +356,7 @@ public class MoveDataverseCommandTest {
         System.out.println("testMoveIntoParent");
         DataverseRequest aRequest = new DataverseRequest(auth, httpRequest);
         testEngine.submit(
-                new MoveDataverseCommand(aRequest, grandchildAA, childA, null));
+                new MoveDataverseCommand(aRequest, grandchildAA, childA, false));
         fail();
     }
 
@@ -365,12 +365,12 @@ public class MoveDataverseCommandTest {
         System.out.println("testKeepGuestbook");
         DataverseRequest aRequest = new DataverseRequest(auth, httpRequest);
         testEngine.submit(
-                new MoveDataverseCommand(aRequest, childC, childB, null));
+                new MoveDataverseCommand(aRequest, childC, childB, false));
         assertNotNull(datasetC.getGuestbook());
 
         // move back
         testEngine.submit(
-                new MoveDataverseCommand(aRequest, childC, root, null));
+                new MoveDataverseCommand(aRequest, childC, root, false));
         assertEquals(root, childC.getOwner());
     }
 
@@ -379,7 +379,7 @@ public class MoveDataverseCommandTest {
         System.out.println("testRemoveGuestbookWithoutForce");
         DataverseRequest aRequest = new DataverseRequest(auth, httpRequest);
         testEngine.submit(
-                new MoveDataverseCommand(aRequest, grandchildCC, root, null));
+                new MoveDataverseCommand(aRequest, grandchildCC, root, false));
         fail();
     }
 
@@ -402,12 +402,12 @@ public class MoveDataverseCommandTest {
         System.out.println("testKeepTemplate");
         DataverseRequest aRequest = new DataverseRequest(auth, httpRequest);
         testEngine.submit(
-                new MoveDataverseCommand(aRequest, childD, childB, null));
+                new MoveDataverseCommand(aRequest, childD, childB, false));
         assertNotNull(grandchildDD.getDefaultTemplate());
 
         // move back
         testEngine.submit(
-                new MoveDataverseCommand(aRequest, childD, root, null));
+                new MoveDataverseCommand(aRequest, childD, root, false));
         assertEquals(root, childD.getOwner());
 
     }
@@ -417,7 +417,7 @@ public class MoveDataverseCommandTest {
         System.out.println("testRemoveTemplateWithoutForce");
         DataverseRequest aRequest = new DataverseRequest(auth, httpRequest);
         testEngine.submit(
-                new MoveDataverseCommand(aRequest, grandchildDD, root, null));
+                new MoveDataverseCommand(aRequest, grandchildDD, root, false));
         fail();
     }
 
@@ -440,12 +440,12 @@ public class MoveDataverseCommandTest {
         System.out.println("testKeepMetadataBlock");
         DataverseRequest aRequest = new DataverseRequest(auth, httpRequest);
         testEngine.submit(
-                new MoveDataverseCommand(aRequest, childE, childB, null));
+                new MoveDataverseCommand(aRequest, childE, childB, false));
         assertEquals(Arrays.asList(mbB), childE.getRootMetadataBlocks());
 
         // move back
         testEngine.submit(
-                new MoveDataverseCommand(aRequest, childE, root, null));
+                new MoveDataverseCommand(aRequest, childE, root, false));
         assertEquals(root, childE.getOwner());
     }
 
@@ -454,7 +454,7 @@ public class MoveDataverseCommandTest {
         System.out.println("testRemoveMetadataBlockWithoutForce");
         DataverseRequest aRequest = new DataverseRequest(auth, httpRequest);
         testEngine.submit(
-                new MoveDataverseCommand(aRequest, grandchildEE, root, null));
+                new MoveDataverseCommand(aRequest, grandchildEE, root, false));
         fail();
     }
 


### PR DESCRIPTION
The main culprit was in method:
`DatasetDao.findIdsByOwnerId(Long ownerId, boolean onlyPublished)` it was executing query:
`createNamedQuery("Dataset.findIdByOwnerId")` - `"SELECT o.identifier FROM Dataset o WHERE o.owner.id=:ownerId"`
But `o.identifier` <> `o.id` in result we were getting exception on cast from string to long