### PR TITLE
Closes #1341: Fix request access button showing up on tags edit

### DIFF
--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
@@ -694,62 +694,6 @@ public class DatasetPage implements java.io.Serializable {
         return returnToDatasetOnly();
     }
 
-
-    public void refresh(ActionEvent e) {
-        refresh();
-    }
-
-    public void refresh() {
-        logger.fine("refreshing");
-
-        //dataset = datasetDao.find(dataset.getId());
-        dataset = null;
-
-        logger.fine("refreshing working version");
-
-        DatasetVersionServiceBean.RetrieveDatasetVersionResponse retrieveDatasetVersionResponse = null;
-
-        if (persistentId != null) {
-            //retrieveDatasetVersionResponse = datasetVersionService.retrieveDatasetVersionByPersistentId(persistentId, version);
-            dataset = datasetDao.findByGlobalId(persistentId);
-            retrieveDatasetVersionResponse = datasetVersionService.selectRequestedVersion(dataset.getVersions(), version);
-        } else if (versionId != null) {
-            retrieveDatasetVersionResponse = datasetVersionService.retrieveDatasetVersionByVersionId(versionId);
-        } else if (dataset.getId() != null) {
-            //retrieveDatasetVersionResponse = datasetVersionService.retrieveDatasetVersionById(dataset.getId(), version);
-            dataset = datasetDao.find(dataset.getId());
-            retrieveDatasetVersionResponse = datasetVersionService.selectRequestedVersion(dataset.getVersions(), version);
-        }
-
-        if (retrieveDatasetVersionResponse == null) {
-            // TODO:
-            // should probably redirect to the 404 page, if we can't find
-            // this version anymore.
-            // -- L.A. 4.2.3
-            return;
-        }
-        this.workingVersion = retrieveDatasetVersionResponse.getDatasetVersion();
-
-        if (this.workingVersion == null) {
-            // TODO:
-            // same as the above
-
-            return;
-        }
-
-
-        if (dataset == null) {
-            // this would be the case if we were retrieving the version by
-            // the versionId, above.
-            this.dataset = this.workingVersion.getDataset();
-        }
-
-        displayCitation = dataset.getCitation(true, workingVersion);
-        stateChanged = false;
-        metadataTab.updateDatasetLockState(isLocked());
-        datasetFilesTab.refresh();
-    }
-
     public String deleteDataset() {
 
         DestroyDatasetCommand cmd;

--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/dataset/tab/DatasetMetadataTab.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/dataset/tab/DatasetMetadataTab.java
@@ -90,14 +90,6 @@ public class DatasetMetadataTab implements Serializable {
     }
 
     /**
-     * Updates the dataset lock state.
-     */
-    public boolean updateDatasetLockState(boolean isDatasetLocked) {
-        this.isDatasetLocked = isDatasetLocked;
-        return isDatasetLocked;
-    }
-
-    /**
      * Extracts exporters display name and redirect url.
      */
     public List<Tuple2<String, String>> getExportersDisplayNameAndURL() {

--- a/dataverse-webapp/src/main/webapp/dataset.xhtml
+++ b/dataverse-webapp/src/main/webapp/dataset.xhtml
@@ -657,9 +657,6 @@
                         <p:remoteCommand name="refreshAllLocksCommand" process="@this"
                                          update=":#{p:resolveClientId('datasetForm:pageRefreshFragment', view)}"
                                          actionListener="#{DatasetPage.refreshAllLocks()}"/>
-                        <p:remoteCommand name="refreshAllCommand" process="@this"
-                                         update=":datasetForm:topDatasetBlockFragment,:datasetForm:tabView:filesTable,:messagePanel"
-                                         actionListener="#{DatasetPage.refresh}"/>
 
                         <p:remoteCommand name="showDatasetUnlockedInfo"
                                          actionListener="#{DatasetPage.showDatasetUnlockedInfo()}"/>


### PR DESCRIPTION
When edit tags modal is showing up - then method `DatasetFilesTab.refreshTagsPopUp` is executed. This in result can change `DatasetFilesTab.workingVersion` to version that is not present in db.

When checking if we should show request access button we execute `fileDownloadHelper.canUserDownloadFile(fm)` when file metadata had empty id then it returns false - that is the reason of button showing up.

I changed methods deciding if we should show file request buttons to simple getters and initiate them in `init()` method - so they will not change as we manipulate with `workingVersion` assignment.

But to be honest I'm not sure if modifying `workingVersion` as we stay on the same page is good idea and if it not causes any more problems.

I'm also removed some leftover functions regarding full page refresh after lock removal functionality.
