### PR TITLE
Closes #1335: A superuser should be able to curate a dataset version having a replaced or deleted/added file

### DIFF
--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/CuratePublishedDatasetVersionCommand.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/CuratePublishedDatasetVersionCommand.java
@@ -125,8 +125,6 @@ public class CuratePublishedDatasetVersionCommand extends AbstractDatasetCommand
                     metadataUpdated = true;
                 }
 
-            } else {
-                throw new IllegalCommandException("Cannot change files in the dataset", this);
             }
             if (metadataUpdated) {
                 dataFile.setModificationTime(getTimestamp());


### PR DESCRIPTION
I'm not sure why exception at this point is thrown.