### PR TITLE
Closes #1405: Remove unused methods in PermissionServiceBean and small refactor

### DIFF
--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
@@ -275,7 +275,7 @@ public class DatasetPage implements java.io.Serializable {
     }
 
     public boolean canViewUnpublishedDataset() {
-        return permissionsWrapper.canViewUnpublishedDataset(dvRequestService.getDataverseRequest(), dataset);
+        return permissionsWrapper.canViewUnpublishedDataset(dataset);
     }
 
     /*
@@ -1214,7 +1214,7 @@ public class DatasetPage implements java.io.Serializable {
     }
 
     public boolean isUserUnderEmbargo() {
-        return dataset.hasActiveEmbargo() && !permissionsWrapper.canViewUnpublishedDataset(dvRequestService.getDataverseRequest(), dataset);
+        return dataset.hasActiveEmbargo() && !permissionsWrapper.canViewUnpublishedDataset(dataset);
     }
 
     public boolean isUserAbleToSetOrUpdateEmbargo() {

--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/DataverseSession.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/DataverseSession.java
@@ -1,9 +1,7 @@
 package edu.harvard.iq.dataverse;
 
-import edu.harvard.iq.dataverse.PermissionServiceBean.StaticPermissionQuery;
 import edu.harvard.iq.dataverse.actionlogging.ActionLogServiceBean;
 import edu.harvard.iq.dataverse.persistence.ActionLogRecord;
-import edu.harvard.iq.dataverse.persistence.dataverse.Dataverse;
 import edu.harvard.iq.dataverse.persistence.user.GuestUser;
 import edu.harvard.iq.dataverse.persistence.user.User;
 import edu.harvard.iq.dataverse.util.SystemConfig;
@@ -28,9 +26,6 @@ import java.util.logging.Logger;
 @Named
 @SessionScoped
 public class DataverseSession implements Serializable {
-
-    @EJB
-    PermissionServiceBean permissionsService;
 
     @EJB
     ActionLogServiceBean logSvc;
@@ -109,10 +104,6 @@ public class DataverseSession implements Serializable {
                 && !localeCode.equals(FacesContext.getCurrentInstance().getViewRoot().getLocale().getLanguage())) {
             FacesContext.getCurrentInstance().getViewRoot().setLocale(new Locale(localeCode));
         }
-    }
-
-    public StaticPermissionQuery on(Dataverse d) {
-        return permissionsService.userOn(user, d);
     }
 
     // -------------------- PRIVATE --------------------

--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/EditDatasetMetadataPage.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/EditDatasetMetadataPage.java
@@ -130,10 +130,10 @@ public class EditDatasetMetadataPage implements Serializable {
 
 
         // Check permisisons
-        if (!permissionsWrapper.canUpdateDataset(dvRequestService.getDataverseRequest(), dataset)) {
+        if (!permissionsWrapper.canCurrentUserUpdateDataset(dataset)) {
             return permissionsWrapper.notAuthorized();
         }
-        if (datasetDao.isInReview(dataset) && !permissionsWrapper.canUpdateAndPublishDataset(dvRequestService.getDataverseRequest(), dataset)) {
+        if (datasetDao.isInReview(dataset) && !permissionsWrapper.canUpdateAndPublishDataset(dataset)) {
             return permissionsWrapper.notAuthorized();
         }
 

--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/PermissionsWrapper.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/PermissionsWrapper.java
@@ -11,10 +11,10 @@ import edu.harvard.iq.dataverse.engine.command.impl.PublishDataverseCommand;
 import edu.harvard.iq.dataverse.engine.command.impl.UpdateDatasetVersionCommand;
 import edu.harvard.iq.dataverse.engine.command.impl.UpdateDataverseCommand;
 import edu.harvard.iq.dataverse.persistence.DvObject;
+import edu.harvard.iq.dataverse.persistence.datafile.DataFile;
 import edu.harvard.iq.dataverse.persistence.dataset.Dataset;
 import edu.harvard.iq.dataverse.persistence.dataverse.Dataverse;
 import edu.harvard.iq.dataverse.persistence.user.Permission;
-import edu.harvard.iq.dataverse.persistence.user.User;
 import javax.faces.view.ViewScoped;
 
 import javax.ejb.EJB;
@@ -35,16 +35,13 @@ public class PermissionsWrapper implements java.io.Serializable {
     PermissionServiceBean permissionService;
 
     @Inject
-    DataverseSession session;
-
-    @Inject
     DataverseRequestServiceBean dvRequestService;
 
     private final Map<Long, Map<Class<? extends Command<?>>, Boolean>> commandMap = new HashMap<>();
 
     // Maps for caching permissions lookup results:
     private final Map<Long, Boolean> fileDownloadPermissionMap = new HashMap<>(); // { DvObject.id : Boolean }
-    private final Map<String, Boolean> datasetPermissionMap = new HashMap<>(); // { Permission human_name : Boolean }
+    private final Map<Permission, Boolean> datasetPermissionMap = new HashMap<>();
 
     /**
      * Check if the current Dataset can Issue Commands
@@ -109,7 +106,7 @@ public class PermissionsWrapper implements java.io.Serializable {
     }
 
     public boolean canEditDataverseTextMessagesAndBanners(Long dataverseId) {
-        return permissionService.isUserCanEditDataverseTextMessagesAndBanners(dataverseId);
+        return permissionService.isUserCanEditDataverseTextMessagesAndBanners(dvRequestService.getDataverseRequest().getUser(), dataverseId);
     }
 
     public boolean canManagePermissions(DvObject dvo) {
@@ -117,47 +114,37 @@ public class PermissionsWrapper implements java.io.Serializable {
             return false;
         }
 
-        User u = session.getUser();
         return dvo instanceof Dataverse
-                ? canManageDataversePermissions(u, (Dataverse) dvo)
-                : canManageDatasetOrMinorDatasetPermissions(u, (Dataset) dvo);
+                ? canManageDataversePermissions((Dataverse) dvo)
+                : canManageDatasetOrMinorDatasetPermissions((Dataset) dvo);
     }
 
-    public boolean canManageDataversePermissions(User u, Dataverse dv) {
+    public boolean canManageDataversePermissions(Dataverse dv) {
         if (dv == null || (dv.getId() == null)) {
-            return false;
-        }
-        if (u == null) {
             return false;
         }
         return permissionService.requestOn(dvRequestService.getDataverseRequest(), dv).has(Permission.ManageDataversePermissions);
     }
 
-    public boolean canManageDatasetOrMinorDatasetPermissions(User u, Dataset ds) {
+    public boolean canManageDatasetOrMinorDatasetPermissions(Dataset ds) {
         if (ds == null || (ds.getId() == null)) {
-            return false;
-        }
-        if (u == null) {
             return false;
         }
         return permissionService.requestOn(dvRequestService.getDataverseRequest(), ds).has(Permission.ManageDatasetPermissions) ||
                 permissionService.requestOn(dvRequestService.getDataverseRequest(), ds).has(Permission.ManageMinorDatasetPermissions);
     }
 
-    public boolean canViewUnpublishedDataset(DataverseRequest dr, Dataset dataset) {
-        return doesSessionUserHaveDataSetPermission(dr, dataset, Permission.ViewUnpublishedDataset);
+    public boolean canViewUnpublishedDataset(Dataset dataset) {
+        return doesSessionUserHaveDataSetPermission(dvRequestService.getDataverseRequest(), dataset, Permission.ViewUnpublishedDataset);
     }
 
-    public boolean canUpdateDataset(DataverseRequest dr, Dataset dataset) {
-        return doesSessionUserHaveDataSetPermission(dr, dataset, Permission.EditDataset);
-    }
     public boolean canCurrentUserUpdateDataset(Dataset dataset) {
         DataverseRequest dataverseRequest = dvRequestService.getDataverseRequest();
         return doesSessionUserHaveDataSetPermission(dataverseRequest, dataset, Permission.EditDataset);
     }
 
-    public boolean canUpdateAndPublishDataset(DataverseRequest dr, Dataset dataset) {
-        return canUpdateDataset(dr, dataset) && canIssuePublishDatasetCommand(dataset);
+    public boolean canUpdateAndPublishDataset(Dataset dataset) {
+        return canCurrentUserUpdateDataset(dataset) && canIssuePublishDatasetCommand(dataset);
     }
 
     /**
@@ -171,25 +158,23 @@ public class PermissionsWrapper implements java.io.Serializable {
      * @param permissionToCheck
      * @return
      */
-    public boolean doesSessionUserHaveDataSetPermission(DataverseRequest req, Dataset dataset, Permission permissionToCheck) {
+    private boolean doesSessionUserHaveDataSetPermission(DataverseRequest req, Dataset dataset, Permission permissionToCheck) {
         if (permissionToCheck == null) {
             return false;
         }
 
-        String permName = permissionToCheck.getHumanName();
-
         // Has this check already been done? 
         // 
-        if (this.datasetPermissionMap.containsKey(permName)) {
+        if (this.datasetPermissionMap.containsKey(permissionToCheck)) {
             // Yes, return previous answer
-            return this.datasetPermissionMap.get(permName);
+            return this.datasetPermissionMap.get(permissionToCheck);
         }
 
         // Check the permission
         boolean hasPermission = this.permissionService.requestOn(req, dataset).has(permissionToCheck);
 
         // Save the permission
-        this.datasetPermissionMap.put(permName, hasPermission);
+        this.datasetPermissionMap.put(permissionToCheck, hasPermission);
 
         // return true/false
         return hasPermission;
@@ -198,34 +183,34 @@ public class PermissionsWrapper implements java.io.Serializable {
     /**
      * Does this dvoObject have "Permission.DownloadFile"?
      *
-     * @param dvo
+     * @param datafile
      * @return
      */
-    public boolean hasDownloadFilePermission(DvObject dvo) {
+    public boolean hasDownloadFilePermission(DataFile datafile) {
 
-        if ((dvo == null) || (dvo.getId() == null)) {
+        if ((datafile == null) || (datafile.getId() == null)) {
             return false;
         }
 
         // Has this check already been done? Check the hash
         //
-        if (this.fileDownloadPermissionMap.containsKey(dvo.getId())) {
+        if (this.fileDownloadPermissionMap.containsKey(datafile.getId())) {
             // Yes, return previous answer
-            return this.fileDownloadPermissionMap.get(dvo.getId());
+            return this.fileDownloadPermissionMap.get(datafile.getId());
         }
 
         // Check permissions
         //
-        if (permissionService.on(dvo).has(Permission.DownloadFile)) {
+        if (permissionService.requestOn(dvRequestService.getDataverseRequest(), datafile).has(Permission.DownloadFile)) {
 
             // Yes, has permission, store result
-            fileDownloadPermissionMap.put(dvo.getId(), true);
+            fileDownloadPermissionMap.put(datafile.getId(), true);
             return true;
 
         } else {
 
             // No permission, store result
-            fileDownloadPermissionMap.put(dvo.getId(), false);
+            fileDownloadPermissionMap.put(datafile.getId(), false);
             return false;
         }
     }

--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/PermissionsWrapper.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/PermissionsWrapper.java
@@ -59,7 +59,7 @@ public class PermissionsWrapper implements java.io.Serializable {
         }
 
         if (commandMap.containsKey(dvo.getId())) {
-            Map<Class<? extends Command<?>>, Boolean> dvoCommandMap = this.commandMap.get(dvo.getId());
+            Map<Class<? extends Command<?>>, Boolean> dvoCommandMap = commandMap.get(dvo.getId());
             if (dvoCommandMap.containsKey(command)) {
                 return dvoCommandMap.get(command);
             } else {
@@ -165,16 +165,16 @@ public class PermissionsWrapper implements java.io.Serializable {
 
         // Has this check already been done? 
         // 
-        if (this.datasetPermissionMap.containsKey(permissionToCheck)) {
+        if (datasetPermissionMap.containsKey(permissionToCheck)) {
             // Yes, return previous answer
-            return this.datasetPermissionMap.get(permissionToCheck);
+            return datasetPermissionMap.get(permissionToCheck);
         }
 
         // Check the permission
-        boolean hasPermission = this.permissionService.requestOn(req, dataset).has(permissionToCheck);
+        boolean hasPermission = permissionService.requestOn(req, dataset).has(permissionToCheck);
 
         // Save the permission
-        this.datasetPermissionMap.put(permissionToCheck, hasPermission);
+        datasetPermissionMap.put(permissionToCheck, hasPermission);
 
         // return true/false
         return hasPermission;
@@ -194,9 +194,9 @@ public class PermissionsWrapper implements java.io.Serializable {
 
         // Has this check already been done? Check the hash
         //
-        if (this.fileDownloadPermissionMap.containsKey(datafile.getId())) {
+        if (fileDownloadPermissionMap.containsKey(datafile.getId())) {
             // Yes, return previous answer
-            return this.fileDownloadPermissionMap.get(datafile.getId());
+            return fileDownloadPermissionMap.get(datafile.getId());
         }
 
         // Check permissions

--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/api/Access.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/api/Access.java
@@ -1290,21 +1290,17 @@ public class Access extends AbstractApiBean {
          */
 
         if (session != null) {
-            if (session.getUser() != null) {
-                if (session.getUser().isAuthenticated()) {
-                    user = session.getUser();
-                } else {
-                    logger.fine("User associated with the session is not an authenticated user.");
-                    if (session.getUser() instanceof PrivateUrlUser) {
-                        logger.fine("User associated with the session is a PrivateUrlUser user.");
-                        user = session.getUser();
-                    }
-                    if (session.getUser() instanceof GuestUser) {
-                        logger.fine("User associated with the session is indeed a guest user.");
-                    }
-                }
+            if (session.getUser().isAuthenticated()) {
+                user = session.getUser();
             } else {
-                logger.fine("No user associated with the session.");
+                logger.fine("User associated with the session is not an authenticated user.");
+                if (session.getUser() instanceof PrivateUrlUser) {
+                    logger.fine("User associated with the session is a PrivateUrlUser user.");
+                    user = session.getUser();
+                }
+                if (session.getUser() instanceof GuestUser) {
+                    logger.fine("User associated with the session is indeed a guest user.");
+                }
             }
         } else {
             logger.fine("Session is null.");
@@ -1354,10 +1350,7 @@ public class Access extends AbstractApiBean {
             boolean hasAccessToRestrictedBySession = false;
             boolean hasAccessToRestrictedByToken = false;
 
-            if (permissionService.on(df).has(Permission.DownloadFile)) {
-                // Note: PermissionServiceBean.on(Datafile df) will obtain the
-                // User from the Session object, just like in the code fragment
-                // above. That's why it's not passed along as an argument.
+            if (session != null && permissionService.requestOn(createDataverseRequest(session.getUser()), df).has(Permission.DownloadFile)) {
                 hasAccessToRestrictedBySession = true;
             } else if (apiTokenUser.isPresent() && permissionService.requestOn(createDataverseRequest(apiTokenUser.get()), df).has(Permission.DownloadFile)) {
                 hasAccessToRestrictedByToken = true;
@@ -1383,7 +1376,7 @@ public class Access extends AbstractApiBean {
                     // session user that has the permission on the file, and the API token 
                     // user with the ViewUnpublished permission, or vice versa!
                     if (hasAccessToRestrictedBySession) {
-                        if (permissionService.on(df.getOwner()).has(Permission.ViewUnpublishedDataset)) {
+                        if (permissionService.requestOn(createDataverseRequest(session.getUser()), df.getOwner()).has(Permission.ViewUnpublishedDataset)) {
                             if (user != null) {
                                 logger.log(Level.FINE, "Session-based auth: user {0} is granted access to the restricted, unpublished datafile.", user.getIdentifier());
                             } else {

--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/api/Dataverses.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/api/Dataverses.java
@@ -490,8 +490,8 @@ public class Dataverses extends AbstractApiBean {
     public Response getMetadataRoot(@PathParam("identifier") String dvIdtf) {
         return response(req -> {
             final Dataverse dataverse = findDataverseOrDie(dvIdtf);
-            if (permissionSvc.request(req)
-                    .on(dataverse)
+            if (permissionSvc
+                    .requestOn(req, dataverse)
                     .has(Permission.EditDataverse)) {
                 return ok(dataverse.isMetadataBlockRoot());
             } else {

--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/api/WorldMapRelatedData.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/api/WorldMapRelatedData.java
@@ -219,7 +219,7 @@ public class WorldMapRelatedData extends AbstractApiBean {
         }
 
         // Does this user have permission to edit metadata for this file?    
-        if (!permissionService.request(createDataverseRequest(dvUser)).on(dfile.getOwner()).has(Permission.EditDataset)) {
+        if (!permissionService.requestOn(createDataverseRequest(dvUser), dfile.getOwner()).has(Permission.EditDataset)) {
             String errMsg = "The user does not have permission to edit metadata for this file.";
             return error(Response.Status.FORBIDDEN, errMsg);
         }
@@ -573,7 +573,7 @@ public class WorldMapRelatedData extends AbstractApiBean {
         }
 
         // check permissions!
-        if (!permissionService.request(createDataverseRequest(dvUser)).on(dfile.getOwner()).has(Permission.EditDataset)) {
+        if (!permissionService.requestOn(createDataverseRequest(dvUser), dfile.getOwner()).has(Permission.EditDataset)) {
             String errMsg = "The user does not have permission to edit metadata for this file. (MapLayerMetadata)";
             return error(Response.Status.FORBIDDEN, errMsg);
         }

--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/datafile/file/EditSingleFilePage.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/datafile/file/EditSingleFilePage.java
@@ -3,8 +3,6 @@ package edu.harvard.iq.dataverse.datafile.file;
 import com.google.common.collect.Lists;
 import edu.harvard.iq.dataverse.DataFileServiceBean;
 import edu.harvard.iq.dataverse.DatasetDao;
-import edu.harvard.iq.dataverse.DataverseRequestServiceBean;
-import edu.harvard.iq.dataverse.PermissionServiceBean;
 import edu.harvard.iq.dataverse.PermissionsWrapper;
 import edu.harvard.iq.dataverse.common.BundleUtil;
 import edu.harvard.iq.dataverse.datafile.page.FileDownloadHelper;
@@ -16,7 +14,6 @@ import edu.harvard.iq.dataverse.persistence.datafile.DataFileTag;
 import edu.harvard.iq.dataverse.persistence.datafile.FileMetadata;
 import edu.harvard.iq.dataverse.persistence.dataset.Dataset;
 import edu.harvard.iq.dataverse.persistence.dataset.DatasetVersion;
-import edu.harvard.iq.dataverse.persistence.user.Permission;
 import edu.harvard.iq.dataverse.provenance.ProvPopupFragmentBean;
 import edu.harvard.iq.dataverse.settings.SettingsServiceBean;
 import edu.harvard.iq.dataverse.util.JsfHelper;
@@ -24,7 +21,6 @@ import io.vavr.control.Try;
 import org.apache.commons.lang3.math.NumberUtils;
 
 import javax.faces.view.ViewScoped;
-
 import javax.inject.Inject;
 import javax.inject.Named;
 
@@ -43,9 +39,7 @@ public class EditSingleFilePage implements java.io.Serializable {
     private DatasetDao datasetDao;
     private DatasetService datasetService;
     private DataFileServiceBean datafileService;
-    private PermissionServiceBean permissionService;
     private SettingsServiceBean settingsService;
-    private DataverseRequestServiceBean dvRequestService;
     private PermissionsWrapper permissionsWrapper;
     private FileDownloadHelper fileDownloadHelper;
     private ProvPopupFragmentBean provPopupFragmentBean;
@@ -70,17 +64,15 @@ public class EditSingleFilePage implements java.io.Serializable {
 
     @Inject
     public EditSingleFilePage(DatasetDao datasetDao, DatasetService datasetService,
-                              DataFileServiceBean datafileService, PermissionServiceBean permissionService,
+                              DataFileServiceBean datafileService,
                               SettingsServiceBean settingsService,
-                              DataverseRequestServiceBean dvRequestService, PermissionsWrapper permissionsWrapper,
+                              PermissionsWrapper permissionsWrapper,
                               FileDownloadHelper fileDownloadHelper, ProvPopupFragmentBean provPopupFragmentBean,
                               SingleFileFacade singleFileFacade, DatasetThumbnailService datasetThumbnailService) {
         this.datasetService = datasetService;
         this.datasetDao = datasetDao;
         this.datafileService = datafileService;
-        this.permissionService = permissionService;
         this.settingsService = settingsService;
-        this.dvRequestService = dvRequestService;
         this.permissionsWrapper = permissionsWrapper;
         this.fileDownloadHelper = fileDownloadHelper;
         this.provPopupFragmentBean = provPopupFragmentBean;
@@ -173,10 +165,10 @@ public class EditSingleFilePage implements java.io.Serializable {
 
         // Check if they have permission to modify this dataset:
 
-        if (!permissionService.on(dataset).has(Permission.EditDataset)) {
+        if (!permissionsWrapper.canCurrentUserUpdateDataset(dataset)) {
             return permissionsWrapper.notAuthorized();
         }
-        if (datasetDao.isInReview(dataset) && !permissionsWrapper.canUpdateAndPublishDataset(dvRequestService.getDataverseRequest(), dataset)) {
+        if (datasetDao.isInReview(dataset) && !permissionsWrapper.canUpdateAndPublishDataset(dataset)) {
             return permissionsWrapper.notAuthorized();
         }
 

--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/datafile/file/ReplaceDatafilesPage.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/datafile/file/ReplaceDatafilesPage.java
@@ -390,7 +390,7 @@ public class ReplaceDatafilesPage implements Serializable {
             return permissionsWrapper.notFound();
         }
 
-        if (!permissionService.on(dataset).has(Permission.EditDataset)) {
+        if (!permissionsWrapper.canCurrentUserUpdateDataset(dataset)) {
             return permissionsWrapper.notAuthorized();
         }
 

--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/datafile/page/EditDatafilesPage.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/datafile/page/EditDatafilesPage.java
@@ -32,7 +32,6 @@ import edu.harvard.iq.dataverse.persistence.dataset.Dataset;
 import edu.harvard.iq.dataverse.persistence.dataset.DatasetLock;
 import edu.harvard.iq.dataverse.persistence.dataset.DatasetVersion;
 import edu.harvard.iq.dataverse.persistence.user.AuthenticatedUser;
-import edu.harvard.iq.dataverse.persistence.user.Permission;
 import edu.harvard.iq.dataverse.provenance.ProvPopupFragmentBean;
 import edu.harvard.iq.dataverse.search.index.IndexServiceBean;
 import edu.harvard.iq.dataverse.settings.SettingsServiceBean;
@@ -396,10 +395,10 @@ public class EditDatafilesPage implements java.io.Serializable {
 
         // Check if they have permission to modify this dataset: 
 
-        if (!permissionService.on(dataset).has(Permission.EditDataset)) {
+        if (!permissionsWrapper.canCurrentUserUpdateDataset(dataset)) {
             return permissionsWrapper.notAuthorized();
         }
-        if (datasetDao.isInReview(dataset) && !permissionsWrapper.canUpdateAndPublishDataset(dvRequestService.getDataverseRequest(), dataset)) {
+        if (datasetDao.isInReview(dataset) && !permissionsWrapper.canUpdateAndPublishDataset(dataset)) {
             return permissionsWrapper.notAuthorized();
         }
 

--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/datafile/page/FilePage.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/datafile/page/FilePage.java
@@ -150,7 +150,7 @@ public class FilePage implements java.io.Serializable {
                 return permissionsWrapper.notFound();
             }
 
-            if (!permissionsWrapper.canViewUnpublishedDataset(dvRequestService.getDataverseRequest(), file.getOwner()) &&
+            if (!permissionsWrapper.canViewUnpublishedDataset(file.getOwner()) &&
                     file.getOwner().hasActiveEmbargo()) {
                 return permissionsWrapper.notAuthorized();
             }
@@ -207,7 +207,7 @@ public class FilePage implements java.io.Serializable {
     }
 
     private boolean canViewUnpublishedDataset() {
-        return permissionsWrapper.canViewUnpublishedDataset(dvRequestService.getDataverseRequest(), fileMetadata.getDatasetVersion().getDataset());
+        return permissionsWrapper.canViewUnpublishedDataset(fileMetadata.getDatasetVersion().getDataset());
     }
 
 
@@ -359,7 +359,7 @@ public class FilePage implements java.io.Serializable {
         for (DatasetVersion versionLoop : fileMetadata.getDatasetVersion().getDataset().getVersions()) {
             boolean foundFmd = false;
 
-            if (versionLoop.isReleased() || versionLoop.isDeaccessioned() || permissionService.on(fileMetadata.getDatasetVersion().getDataset()).has(Permission.ViewUnpublishedDataset)) {
+            if (versionLoop.isReleased() || versionLoop.isDeaccessioned() || permissionsWrapper.canViewUnpublishedDataset(fileMetadata.getDatasetVersion().getDataset())) {
                 for (DataFile df : allfiles) {
                     FileMetadata fmd = datafileService.findFileMetadataByDatasetVersionIdAndDataFileId(versionLoop.getId(), df.getId());
                     if (fmd != null) {
@@ -522,7 +522,7 @@ public class FilePage implements java.io.Serializable {
 
 
     public boolean canUpdateDataset() {
-        return permissionsWrapper.canUpdateDataset(dvRequestService.getDataverseRequest(), this.file.getOwner());
+        return permissionsWrapper.canCurrentUserUpdateDataset(file.getOwner());
     }
 
     public int getSelectedTabIndex() {

--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/datafile/page/ReorderDataFilesPage.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/datafile/page/ReorderDataFilesPage.java
@@ -1,12 +1,10 @@
 package edu.harvard.iq.dataverse.datafile.page;
 
 import edu.harvard.iq.dataverse.DatasetDao;
-import edu.harvard.iq.dataverse.PermissionServiceBean;
 import edu.harvard.iq.dataverse.PermissionsWrapper;
 import edu.harvard.iq.dataverse.dataset.datasetversion.DatasetVersionServiceBean;
 import edu.harvard.iq.dataverse.persistence.datafile.FileMetadata;
 import edu.harvard.iq.dataverse.persistence.dataset.DatasetVersion;
-import edu.harvard.iq.dataverse.persistence.user.Permission;
 import io.vavr.Tuple;
 import io.vavr.Tuple2;
 import org.primefaces.event.ReorderEvent;
@@ -27,8 +25,6 @@ public class ReorderDataFilesPage implements java.io.Serializable {
     private DatasetDao datasetDao;
     @EJB
     private DatasetVersionServiceBean datasetVersionService;
-    @EJB
-    private PermissionServiceBean permissionService;
     @Inject
     private PermissionsWrapper permissionsWrapper;
 
@@ -53,7 +49,7 @@ public class ReorderDataFilesPage implements java.io.Serializable {
 
         fileMetadatas = fetchedDatasetVersion.get().getAllFilesMetadataSorted();
 
-        if (!permissionService.on(datasetVersion.getDataset()).has(Permission.EditDataset)) {
+        if (!permissionsWrapper.canCurrentUserUpdateDataset(datasetVersion.getDataset())) {
             return permissionsWrapper.notAuthorized();
         }
 

--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/dataset/DatasetWidgetsPage.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/dataset/DatasetWidgetsPage.java
@@ -1,12 +1,9 @@
 package edu.harvard.iq.dataverse.dataset;
 
 import edu.harvard.iq.dataverse.DatasetDao;
-import edu.harvard.iq.dataverse.DataverseRequestServiceBean;
 import edu.harvard.iq.dataverse.PermissionsWrapper;
 import edu.harvard.iq.dataverse.common.BundleUtil;
-import edu.harvard.iq.dataverse.dataaccess.DataAccess;
 import edu.harvard.iq.dataverse.dataaccess.ImageThumbConverter;
-import edu.harvard.iq.dataverse.engine.command.impl.UpdateDatasetVersionCommand;
 import edu.harvard.iq.dataverse.persistence.datafile.DataFile;
 import edu.harvard.iq.dataverse.persistence.dataset.Dataset;
 import edu.harvard.iq.dataverse.util.FileUtil;
@@ -36,9 +33,6 @@ public class DatasetWidgetsPage implements java.io.Serializable {
 
     @EJB
     DatasetDao datasetDao;
-
-    @Inject
-    DataverseRequestServiceBean dvRequestService;
 
     @Inject
     private PermissionsWrapper permissionsWrapper;
@@ -75,10 +69,10 @@ public class DatasetWidgetsPage implements java.io.Serializable {
          * UpdateDatasetThumbnailCommand since it's really the only update you
          * can do from this page.
          */
-        if (!permissionsWrapper.canIssueCommand(dataset, UpdateDatasetVersionCommand.class)) {
+        if (!permissionsWrapper.canCurrentUserUpdateDataset(dataset)) {
             return permissionsWrapper.notAuthorized();
         }
-        if (datasetDao.isInReview(dataset) && !permissionsWrapper.canUpdateAndPublishDataset(dvRequestService.getDataverseRequest(), dataset)) {
+        if (datasetDao.isInReview(dataset) && !permissionsWrapper.canUpdateAndPublishDataset(dataset)) {
             return permissionsWrapper.notAuthorized();
         }
 

--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/dataset/EmbargoAccessService.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/dataset/EmbargoAccessService.java
@@ -1,5 +1,6 @@
 package edu.harvard.iq.dataverse.dataset;
 
+import edu.harvard.iq.dataverse.DataverseRequestServiceBean;
 import edu.harvard.iq.dataverse.PermissionServiceBean;
 import edu.harvard.iq.dataverse.persistence.dataset.Dataset;
 import edu.harvard.iq.dataverse.persistence.user.Permission;
@@ -10,6 +11,8 @@ import javax.inject.Inject;
 @Stateless
 public class EmbargoAccessService {
     private PermissionServiceBean permissionService;
+    private DataverseRequestServiceBean dvRequestService;
+    
 
     // -------------------- CONSTRUCTORS --------------------
     @Deprecated
@@ -17,13 +20,14 @@ public class EmbargoAccessService {
     }
 
     @Inject
-    public EmbargoAccessService(PermissionServiceBean permissionService) {
+    public EmbargoAccessService(PermissionServiceBean permissionService, DataverseRequestServiceBean dvRequestService) {
         this.permissionService = permissionService;
+        this.dvRequestService = dvRequestService;
     }
 
     // -------------------- LOGIC --------------------
     public boolean isRestrictedByEmbargo(Dataset dataset) {
-        return dataset.hasActiveEmbargo() && !permissionService.on(dataset).has(Permission.ViewUnpublishedDataset);
+        return dataset.hasActiveEmbargo() && !permissionService.requestOn(dvRequestService.getDataverseRequest(), dataset).has(Permission.ViewUnpublishedDataset);
     }
 
 }

--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/dataset/tab/DatasetFilesTab.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/dataset/tab/DatasetFilesTab.java
@@ -240,7 +240,7 @@ public class DatasetFilesTab implements Serializable {
     }
 
     private List<FileMetadata> getAccessibleFilesMetadata() {
-        if (permissionsWrapper.canViewUnpublishedDataset(dvRequestService.getDataverseRequest(), dataset)) {
+        if (permissionsWrapper.canViewUnpublishedDataset(dataset)) {
             return workingVersion.getAllFilesMetadataSorted();
         } else {
             return workingVersion.getOnlyFilesMetadataNotUnderEmbargoSorted();
@@ -444,7 +444,7 @@ public class DatasetFilesTab implements Serializable {
 
     // Another convenience method - to cache Update Permission on the dataset: 
     public boolean canUpdateDataset() {
-        return permissionsWrapper.canUpdateDataset(dvRequestService.getDataverseRequest(), this.dataset);
+        return permissionsWrapper.canCurrentUserUpdateDataset(dataset);
     }
 
     public void updateMultipleFileOptionFlags () {

--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/dataset/tab/DatasetVersionsTab.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/dataset/tab/DatasetVersionsTab.java
@@ -1,17 +1,18 @@
 package edu.harvard.iq.dataverse.dataset.tab;
 
-import edu.harvard.iq.dataverse.PermissionServiceBean;
+import edu.harvard.iq.dataverse.PermissionsWrapper;
 import edu.harvard.iq.dataverse.VersionSummaryDTO;
 import edu.harvard.iq.dataverse.dataset.datasetversion.DatasetVersionServiceBean;
 import edu.harvard.iq.dataverse.dataset.difference.DatasetVersionDifference;
 import edu.harvard.iq.dataverse.persistence.dataset.Dataset;
 import edu.harvard.iq.dataverse.persistence.dataset.DatasetVersion;
-import edu.harvard.iq.dataverse.persistence.user.Permission;
 import org.primefaces.PrimeFaces;
 
 import javax.ejb.EJB;
 import javax.faces.view.ViewScoped;
+import javax.inject.Inject;
 import javax.inject.Named;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -23,8 +24,8 @@ public class DatasetVersionsTab implements Serializable {
     @EJB
     private DatasetVersionServiceBean datasetVersionService;
     
-    @EJB
-    private PermissionServiceBean permissionService;
+    @Inject
+    private PermissionsWrapper permissionsWrapper;
 
     private Dataset dataset;
     private List<DatasetVersion> datasetVersions = new ArrayList<>();
@@ -130,7 +131,7 @@ public class DatasetVersionsTab implements Serializable {
     }
 
     private boolean canShowVersion(DatasetVersion datasetVersion) {
-        if (datasetVersion.isDraft() && !permissionService.on(dataset).has(Permission.ViewUnpublishedDataset)) {
+        if (datasetVersion.isDraft() && !permissionsWrapper.canViewUnpublishedDataset(dataset)) {
             return false;
         }
         return true;
@@ -138,7 +139,7 @@ public class DatasetVersionsTab implements Serializable {
 
     private boolean canShowLinkToDatasetVersion(DatasetVersion datasetVersion) {
         if (datasetVersion.isDeaccessioned() || datasetVersion.isDraft()) {
-            return permissionService.on(dataset).has(Permission.ViewUnpublishedDataset);
+            return permissionsWrapper.canViewUnpublishedDataset(dataset);
         }
         return true;
     }

--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/datasetutility/WorldMapPermissionHelper.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/datasetutility/WorldMapPermissionHelper.java
@@ -62,7 +62,7 @@ public class WorldMapPermissionHelper implements java.io.Serializable {
 
     private final Map<Long, Boolean> fileMetadataWorldMapExplore = new HashMap<>(); // { FileMetadata.id : Boolean } 
     private Map<Long, MapLayerMetadata> mapLayerMetadataLookup = null;
-    private final Map<String, Boolean> datasetPermissionMap = new HashMap<>(); // { Permission human_name : Boolean }
+    private final Map<Permission, Boolean> datasetPermissionMap = new HashMap<>();
 
 
     public WorldMapPermissionHelper() {
@@ -565,13 +565,11 @@ public class WorldMapPermissionHelper implements java.io.Serializable {
             return false;
         }
 
-        String permName = permissionToCheck.getHumanName();
-
         // Has this check already been done? 
         // 
-        if (this.datasetPermissionMap.containsKey(permName)) {
+        if (this.datasetPermissionMap.containsKey(permissionToCheck)) {
             // Yes, return previous answer
-            return this.datasetPermissionMap.get(permName);
+            return this.datasetPermissionMap.get(permissionToCheck);
         }
 
         // Check the permission
@@ -580,7 +578,7 @@ public class WorldMapPermissionHelper implements java.io.Serializable {
         boolean hasPermission = this.permissionService.userOn(this.session.getUser(), objectToCheck).has(permissionToCheck);
 
         // Save the permission
-        this.datasetPermissionMap.put(permName, hasPermission);
+        this.datasetPermissionMap.put(permissionToCheck, hasPermission);
 
         // return true/false
         return hasPermission;

--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/dataverse/CreateEditDataversePage.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/dataverse/CreateEditDataversePage.java
@@ -331,7 +331,7 @@ public class CreateEditDataversePage implements Serializable {
 
     private String setupViewForDataverseEdit() {
         dataverse = dataverseDao.find(dataverseId);
-        if (!permissionService.on(dataverse).has(Permission.EditDataverse)) {
+        if (!permissionsWrapper.canIssueUpdateDataverseCommand(dataverse)) {
             return permissionsWrapper.notAuthorized();
         }
 
@@ -347,7 +347,7 @@ public class CreateEditDataversePage implements Serializable {
 
         if (dataverse.getOwner() == null) {
             return permissionsWrapper.notFound();
-        } else if (!permissionService.on(dataverse.getOwner()).has(Permission.AddDataverse)) {
+        } else if (!permissionsWrapper.canIssueCreateDataverseCommand(dataverse.getOwner())) {
             return permissionsWrapper.notAuthorized();
         }
 

--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/dataverse/DataversePage.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/dataverse/DataversePage.java
@@ -3,6 +3,7 @@ package edu.harvard.iq.dataverse.dataverse;
 import com.google.common.collect.Lists;
 import edu.harvard.iq.dataverse.DataverseDao;
 import edu.harvard.iq.dataverse.DataverseLinkingDao;
+import edu.harvard.iq.dataverse.DataverseRequestServiceBean;
 import edu.harvard.iq.dataverse.DataverseSession;
 import edu.harvard.iq.dataverse.FeaturedDataverseServiceBean;
 import edu.harvard.iq.dataverse.PermissionServiceBean;
@@ -67,6 +68,8 @@ public class DataversePage implements java.io.Serializable {
     private DataverseService dataverseService;
     @Inject
     private SavedSearchService savedSearchService;
+    @Inject
+    private DataverseRequestServiceBean dataverseRequestService;
 
     private Dataverse dataverse;
     private String dataverseAlias;
@@ -137,7 +140,8 @@ public class DataversePage implements java.io.Serializable {
         if (dataverse == null) {
             return permissionsWrapper.notFound();
         }
-        if (!dataverse.isReleased() && !permissionService.on(dataverse).has(Permission.ViewUnpublishedDataverse)) {
+        if (!dataverse.isReleased() && !permissionService.requestOn(dataverseRequestService.getDataverseRequest(), dataverse)
+                                                         .has(Permission.ViewUnpublishedDataverse)) {
             return permissionsWrapper.notAuthorized();
         }
 

--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/engine/command/CommandHelper.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/engine/command/CommandHelper.java
@@ -65,19 +65,6 @@ public class CommandHelper {
         return requiredPerms == null || requiredPerms.isAllPermissionsRequired();
     }
 
-    /**
-     * Given a command, returns the set of permissions needed to be able to
-     * execute it. Needed permissions are specified by annotating the command's
-     * class with the {@link RequiredPermissions} annotation.
-     *
-     * @param c The command
-     * @return Set of permissions, or {@code null} if the command's class was
-     * not annotated.
-     */
-    public Map<String, Set<Permission>> permissionsRequired(Command c) {
-        return permissionsRequired(c.getClass());
-    }
-
     private Set<Permission> asPermissionSet(Permission[] permissionArray) {
         return (permissionArray.length == 0) ? EnumSet.noneOf(Permission.class)
                 : (permissionArray.length == 1) ? EnumSet.of(permissionArray[0])

--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/ListVersionsCommand.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/ListVersionsCommand.java
@@ -10,7 +10,6 @@ import edu.harvard.iq.dataverse.engine.command.AbstractCommand;
 import edu.harvard.iq.dataverse.engine.command.CommandContext;
 import edu.harvard.iq.dataverse.engine.command.DataverseRequest;
 import edu.harvard.iq.dataverse.engine.command.RequiredPermissions;
-import edu.harvard.iq.dataverse.engine.command.exception.CommandException;
 import edu.harvard.iq.dataverse.persistence.dataset.Dataset;
 import edu.harvard.iq.dataverse.persistence.dataset.DatasetVersion;
 import edu.harvard.iq.dataverse.persistence.user.Permission;
@@ -36,7 +35,7 @@ public class ListVersionsCommand extends AbstractCommand<List<DatasetVersion>> {
     public List<DatasetVersion> execute(CommandContext ctxt)  {
         List<DatasetVersion> outputList = new LinkedList<>();
         for (DatasetVersion dsv : ds.getVersions()) {
-            if (dsv.isReleased() || ctxt.permissions().request(getRequest()).on(ds).has(Permission.EditDataset)) {
+            if (dsv.isReleased() || ctxt.permissions().requestOn(getRequest(), ds).has(Permission.EditDataset)) {
                 outputList.add(dsv);
             }
         }

--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/guestbook/SelectGuestbookPage.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/guestbook/SelectGuestbookPage.java
@@ -1,7 +1,6 @@
 package edu.harvard.iq.dataverse.guestbook;
 
 import edu.harvard.iq.dataverse.DatasetDao;
-import edu.harvard.iq.dataverse.DataverseRequestServiceBean;
 import edu.harvard.iq.dataverse.PermissionsWrapper;
 import edu.harvard.iq.dataverse.common.BundleUtil;
 import edu.harvard.iq.dataverse.persistence.dataset.Dataset;
@@ -27,7 +26,6 @@ public class SelectGuestbookPage implements java.io.Serializable {
 
     private DatasetDao datasetDao;
     private PermissionsWrapper permissionsWrapper;
-    private DataverseRequestServiceBean dvRequestService;
     private SelectGuestBookService selectGuestBookService;
 
     private String persistentId;
@@ -35,7 +33,6 @@ public class SelectGuestbookPage implements java.io.Serializable {
 
     private Dataset dataset;
     private Guestbook selectedGuestbook;
-    private Guestbook guestbookBeforeChanges;
     private List<Guestbook> availableGuestbooks;
 
     // -------------------- CONSTRUCTORS --------------------
@@ -45,11 +42,9 @@ public class SelectGuestbookPage implements java.io.Serializable {
 
     @Inject
     public SelectGuestbookPage(DatasetDao datasetDao, PermissionsWrapper permissionsWrapper,
-                               DataverseRequestServiceBean dvRequestService,
                                SelectGuestBookService selectGuestBookService) {
         this.datasetDao = datasetDao;
         this.permissionsWrapper = permissionsWrapper;
-        this.dvRequestService = dvRequestService;
         this.selectGuestBookService = selectGuestBookService;
     }
 
@@ -87,11 +82,10 @@ public class SelectGuestbookPage implements java.io.Serializable {
         }
 
         // Check permisisons
-        if (!permissionsWrapper.canUpdateDataset(dvRequestService.getDataverseRequest(), dataset)) {
+        if (!permissionsWrapper.canCurrentUserUpdateDataset(dataset)) {
             return permissionsWrapper.notAuthorized();
         }
-        if (datasetDao.isInReview(dataset) && !permissionsWrapper.canUpdateAndPublishDataset(dvRequestService.getDataverseRequest(),
-                                                                                             dataset)) {
+        if (datasetDao.isInReview(dataset) && !permissionsWrapper.canUpdateAndPublishDataset(dataset)) {
             return permissionsWrapper.notAuthorized();
         }
 

--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/permission/ManagePermissionsPage.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/permission/ManagePermissionsPage.java
@@ -118,7 +118,7 @@ public class ManagePermissionsPage implements java.io.Serializable {
         // for dataFiles, check the perms on its owning dataset
         DvObject checkPermissionsdvObject = dvObject instanceof DataFile ? dvObject.getOwner() : dvObject;
 
-        if (!isAllowedToManageDataverseOrDataset(checkPermissionsdvObject)) {
+        if (!permissionsWrapper.canManagePermissions(checkPermissionsdvObject)) {
             return permissionsWrapper.notAuthorized();
         }
 
@@ -126,7 +126,7 @@ public class ManagePermissionsPage implements java.io.Serializable {
             Dataset dataset = dvObject instanceof Dataset ? (Dataset) dvObject : ((DataFile) dvObject).getOwner();
             if (datasetDao.isInReview(dataset)
                     && !(permissionsWrapper.canIssuePublishDatasetCommand(dataset)
-                    && permissionsWrapper.canManageDatasetOrMinorDatasetPermissions(dvRequestService.getDataverseRequest().getUser(), dataset))) {
+                    && permissionsWrapper.canManageDatasetOrMinorDatasetPermissions(dataset))) {
                 return permissionsWrapper.notAuthorized();
             }
         }
@@ -137,13 +137,6 @@ public class ManagePermissionsPage implements java.io.Serializable {
         }
         roleAssignments = initRoleAssignments();
         return "";
-    }
-
-    private boolean isAllowedToManageDataverseOrDataset(DvObject checkPermissionsdvObject) {
-        return (checkPermissionsdvObject instanceof Dataverse &&
-                permissionService.on(checkPermissionsdvObject).has(Permission.ManageDataversePermissions)) ||
-                permissionService.on(checkPermissionsdvObject).has(Permission.ManageDatasetPermissions) ||
-                permissionService.on(checkPermissionsdvObject).has(Permission.ManageMinorDatasetPermissions);
     }
 
     /*

--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/search/SearchIncludeFragment.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/search/SearchIncludeFragment.java
@@ -7,12 +7,16 @@ import edu.harvard.iq.dataverse.DataverseDao;
 import edu.harvard.iq.dataverse.DataverseRequestServiceBean;
 import edu.harvard.iq.dataverse.DataverseSession;
 import edu.harvard.iq.dataverse.DvObjectServiceBean;
+import edu.harvard.iq.dataverse.PermissionServiceBean;
 import edu.harvard.iq.dataverse.ThumbnailServiceWrapper;
 import edu.harvard.iq.dataverse.WidgetWrapper;
 import edu.harvard.iq.dataverse.dataset.datasetversion.DatasetVersionServiceBean;
 import edu.harvard.iq.dataverse.persistence.datafile.DataFile;
 import edu.harvard.iq.dataverse.persistence.datafile.DataTable;
 import edu.harvard.iq.dataverse.persistence.dataverse.Dataverse;
+import edu.harvard.iq.dataverse.persistence.group.AuthenticatedUsers;
+import edu.harvard.iq.dataverse.persistence.user.AuthenticatedUser;
+import edu.harvard.iq.dataverse.persistence.user.Permission;
 import edu.harvard.iq.dataverse.search.SearchServiceBean.SortOrder;
 import edu.harvard.iq.dataverse.search.query.SearchForTypes;
 import edu.harvard.iq.dataverse.search.query.SearchObjectType;
@@ -65,6 +69,8 @@ public class SearchIncludeFragment implements java.io.Serializable {
     private DatasetFieldServiceBean datasetFieldService;
     @Inject
     private DataverseRequestServiceBean dataverseRequestService;
+    @Inject
+    private PermissionServiceBean permissionService;
 
     private String query;
     private List<String> filterQueries = new ArrayList<>();
@@ -965,4 +971,8 @@ public class SearchIncludeFragment implements java.io.Serializable {
 
     }
 
+    public boolean couldCreateDatasetOrDataverseIfWasAuthenticated() throws ClassNotFoundException {
+        return permissionService.userOn(AuthenticatedUsers.get(), dataverse).has(Permission.AddDataverse)
+                || permissionService.userOn(AuthenticatedUsers.get(), dataverse).has(Permission.AddDataset);
+    }
 }

--- a/dataverse-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/dataverse-webapp/src/main/webapp/WEB-INF/web.xml
@@ -97,11 +97,6 @@
         <servlet-class>javax.faces.webapp.FacesServlet</servlet-class>
         <load-on-startup>1</load-on-startup>
     </servlet>
-    <servlet>
-        <servlet-name>Push Servlet</servlet-name>
-        <servlet-class>org.primefaces.push.PushServlet</servlet-class>
-        <async-supported>true</async-supported>
-    </servlet>
     <!-- Map these files with JSF -->
     <servlet>
         <servlet-name>OAIServlet</servlet-name>
@@ -127,23 +122,10 @@
     <servlet-mapping>
         <servlet-name>Faces Servlet</servlet-name>
         <url-pattern>/faces/*</url-pattern>
-    </servlet-mapping>
-    <servlet-mapping>
-        <servlet-name>Faces Servlet</servlet-name>
         <url-pattern>*.jsf</url-pattern>
-    </servlet-mapping>
-    <servlet-mapping>
-        <servlet-name>Faces Servlet</servlet-name>
         <url-pattern>*.faces</url-pattern>
-    </servlet-mapping>
-    <servlet-mapping>
-        <servlet-name>Faces Servlet</servlet-name>
         <url-pattern>*.xhtml</url-pattern>
         <url-pattern>/javax.faces.resource/*</url-pattern>
-    </servlet-mapping>
-    <servlet-mapping>
-        <servlet-name>Push Servlet</servlet-name>
-        <url-pattern>/primepush/*</url-pattern>
     </servlet-mapping>
     <servlet-mapping>
         <servlet-name>OAIServlet</servlet-name>
@@ -203,9 +185,6 @@
     <servlet-mapping>
         <servlet-name>edu.harvard.iq.dataverse.api.datadeposit.SWORDv2ServiceDocumentServlet</servlet-name>
         <url-pattern>/dvn/api/data-deposit/v1/swordv2/service-document/*</url-pattern>
-    </servlet-mapping>
-    <servlet-mapping>
-        <servlet-name>edu.harvard.iq.dataverse.api.datadeposit.SWORDv2ServiceDocumentServlet</servlet-name>
         <url-pattern>/dvn/api/data-deposit/v1.1/swordv2/service-document/*</url-pattern>
     </servlet-mapping>
     <context-param>
@@ -223,9 +202,6 @@
     <servlet-mapping>
         <servlet-name>edu.harvard.iq.dataverse.api.datadeposit.SWORDv2CollectionServlet</servlet-name>
         <url-pattern>/dvn/api/data-deposit/v1/swordv2/collection/*</url-pattern>
-    </servlet-mapping>
-    <servlet-mapping>
-        <servlet-name>edu.harvard.iq.dataverse.api.datadeposit.SWORDv2CollectionServlet</servlet-name>
         <url-pattern>/dvn/api/data-deposit/v1.1/swordv2/collection/*</url-pattern>
     </servlet-mapping>
     <context-param>
@@ -239,9 +215,6 @@
     <servlet-mapping>
         <servlet-name>edu.harvard.iq.dataverse.api.datadeposit.SWORDv2MediaResourceServlet</servlet-name>
         <url-pattern>/dvn/api/data-deposit/v1/swordv2/edit-media/*</url-pattern>
-    </servlet-mapping>
-    <servlet-mapping>
-        <servlet-name>edu.harvard.iq.dataverse.api.datadeposit.SWORDv2MediaResourceServlet</servlet-name>
         <url-pattern>/dvn/api/data-deposit/v1.1/swordv2/edit-media/*</url-pattern>
     </servlet-mapping>
     <context-param>
@@ -255,9 +228,6 @@
     <servlet-mapping>
         <servlet-name>edu.harvard.iq.dataverse.api.datadeposit.SWORDv2StatementServlet</servlet-name>
         <url-pattern>/dvn/api/data-deposit/v1/swordv2/statement/*</url-pattern>
-    </servlet-mapping>
-    <servlet-mapping>
-        <servlet-name>edu.harvard.iq.dataverse.api.datadeposit.SWORDv2StatementServlet</servlet-name>
         <url-pattern>/dvn/api/data-deposit/v1.1/swordv2/statement/*</url-pattern>
     </servlet-mapping>
     <context-param>
@@ -271,9 +241,6 @@
     <servlet-mapping>
         <servlet-name>edu.harvard.iq.dataverse.api.datadeposit.SWORDv2ContainerServlet</servlet-name>
         <url-pattern>/dvn/api/data-deposit/v1/swordv2/edit/*</url-pattern>
-    </servlet-mapping>
-    <servlet-mapping>
-        <servlet-name>edu.harvard.iq.dataverse.api.datadeposit.SWORDv2ContainerServlet</servlet-name>
         <url-pattern>/dvn/api/data-deposit/v1.1/swordv2/edit/*</url-pattern>
     </servlet-mapping>
     <!-- END Data Deposit API (SWORD v2) -->

--- a/dataverse-webapp/src/main/webapp/file-versions.xhtml
+++ b/dataverse-webapp/src/main/webapp/file-versions.xhtml
@@ -32,7 +32,7 @@
         <p:column headerText="#{bundle['file.dataFilesTab.versions.headers.dataset']}" class="col-sm-1 text-center">
             <ui:fragment rendered="#{versionTab.datasetVersion != FilePage.fileMetadata.datasetVersion }">
                 <ui:fragment rendered="#{versionTab.datasetVersion.released or ((versionTab.datasetVersion.deaccessioned or versionTab.datasetVersion.draft)
-                                     and permissionServiceBean.on(versionTab.datasetVersion.dataset).has('ViewUnpublishedDataset'))}">
+                                     and FilePage.canViewUnpublishedDataset())}">
                     <h:outputLink rendered="#{!(versionTab.datasetVersion.released or versionTab.datasetVersion.deaccessioned) and versionTab.dataFile != null }"
                                   value="/file.xhtml?fileId=#{versionTab.dataFile.id}&#38;version=#{versionTab.datasetVersion.versionState}" styleClass="ui-commandlink ui-widget">
                         <h:outputText value="#{versionTab.datasetVersion.versionState}" />
@@ -47,7 +47,7 @@
                                   value="#{versionTab.datasetVersion.versionNumber}.#{versionTab.datasetVersion.minorVersionNumber}" />
                 </ui:fragment>
                 <h:outputText rendered="#{versionTab.datasetVersion.deaccessioned
-                                     and !permissionServiceBean.on(versionTab.datasetVersion.dataset).has('ViewUnpublishedDataset')}"
+                                     and !FilePage.canViewUnpublishedDataset()}"
                               value="#{versionTab.datasetVersion.versionNumber}.#{versionTab.datasetVersion.minorVersionNumber}" />
             </ui:fragment>
             <ui:fragment rendered="#{versionTab.datasetVersion == FilePage.fileMetadata.datasetVersion }">

--- a/dataverse-webapp/src/main/webapp/search-include-fragment.xhtml
+++ b/dataverse-webapp/src/main/webapp/search-include-fragment.xhtml
@@ -35,9 +35,7 @@
         <div class="col-sm-4 text-right col-manage-action" jsf:rendered="#{!widgetWrapper.widgetView}">
             <div class="button-block pull-right">
                 <!-- ADD DATA -->
-                <o:importFunctions type="edu.harvard.iq.dataverse.persistence.group.AuthenticatedUsers" />
-                <ui:fragment rendered="#{!dataverseSession.user.authenticated and (permissionServiceBean.userOn(AuthenticatedUsers:get(),SearchIncludeFragment.dataverse).canIssueCommand('CreateDataverseCommand')
-                                         or permissionServiceBean.userOn(AuthenticatedUsers:get(),SearchIncludeFragment.dataverse).canIssueCommand('CreateNewDatasetCommand'))}">
+                <ui:fragment rendered="#{!dataverseSession.user.authenticated and SearchIncludeFragment.couldCreateDatasetOrDataverseIfWasAuthenticated()}">
                     <button type="button" class="btn btn-default btn-access" onclick="PF('addData_popup').show()">
                         <span class="glyphicon glyphicon-plus" aria-hidden="true"/> #{bundle['dataverse.results.btn.addData']}
                     </button>


### PR DESCRIPTION
Changes I've made:
 - I removed unused methods.
 - Removed usage of permissionServiceBean on xhtml's
 - I've modified permissionServiceBean so It's unaware of currently logged user
 - and modified permissionServiceWrapper so it's methods don't have DataverseRequest in signatures (permissionServiceWrapper is aware of currently logged user)
