### PR TITLE
Closes #1416: Do not update index timestamps in readonly mode

### DIFF
--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/SuperUserPage.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/SuperUserPage.java
@@ -60,8 +60,7 @@ public class SuperUserPage implements java.io.Serializable {
         if (user.isSuperuser()) {
             long numPartitions = 1;
             long partitionId = 0;
-            boolean previewOnly = false;
-            indexAllFuture = indexAllService.indexAllOrSubset(numPartitions, partitionId, false, previewOnly);
+            indexAllFuture = indexAllService.indexAllOrSubsetAsync(numPartitions, partitionId, false);
             indexAllStatus = "Index all started...";
         } else {
             indexAllStatus = "Only a superuser can run index all";

--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/api/Index.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/api/Index.java
@@ -173,7 +173,7 @@ public class Index extends AbstractApiBean {
              * @todo How can we expose the String returned from "index all" via
              * the API?
              */
-            Future<JsonObjectBuilder> indexAllFuture = indexAllService.indexAllOrSubset(numPartitions, partitionIdToProcess, skipIndexed, previewOnly);
+            Future<JsonObjectBuilder> indexAllFuture = indexAllService.indexAllOrSubsetAsync(numPartitions, partitionIdToProcess, skipIndexed);
             JsonObject workloadPreview = preview.build().getJsonObject("previewOfPartitionWorkload");
             int dataverseCount = workloadPreview.getInt("dataverseCount");
             int datasetCount = workloadPreview.getInt("datasetCount");

--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/search/index/IndexServiceBean.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/search/index/IndexServiceBean.java
@@ -243,7 +243,9 @@ public class IndexServiceBean {
             return new AsyncResult<>(status);
         }
 
-        dvObjectService.updateContentIndexTime(dataverse);
+        if (!systemConfig.isReadonlyMode()) {
+            dvObjectService.updateContentIndexTime(dataverse);
+        }
         IndexResponse indexResponse = solrIndexService.indexPermissionsForOneDvObject(dataverse);
         String msg = "indexed dataverse " + dataverse.getId() + ":" + dataverse.getAlias() + ". Response from permission indexing: " + indexResponse.getMessage();
         return new AsyncResult<>(msg);
@@ -1091,15 +1093,9 @@ public class IndexServiceBean {
         }
 
         Long dsId = dataset.getId();
-        /// Dataset updatedDataset =
-        /// (Dataset)dvObjectService.updateContentIndexTime(dataset);
-        /// updatedDataset = null;
-        // instead of making a call to dvObjectService, let's try and
-        // modify the index time stamp using the local EntityManager:
-        DvObject dvObjectToModify = em.find(DvObject.class, dsId);
-        dvObjectToModify.setIndexTime(new Timestamp(new Date().getTime()));
-        dvObjectToModify = em.merge(dvObjectToModify);
-        dvObjectToModify = null;
+        if (!systemConfig.isReadonlyMode()) {
+            dvObjectService.updateContentIndexTime(dataset);
+        }
 
         // return "indexed dataset " + dataset.getId() + " as " + solrDocId +
         // "\nindexFilesResults for " + solrDocId + ":" + fileInfo.toString();


### PR DESCRIPTION
I went for silently ignore updating timestamp instead of solution with extra query param in api endpoints. Reason behind this is too complicated code in indexing - it would require some refactor of indexing mechanism to do this by quey param in a reliable way