### PR TITLE
Closes #1431: Fix duplicated oairecords

### DIFF
--- a/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/dataset/DatasetRepository.java
+++ b/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/dataset/DatasetRepository.java
@@ -29,4 +29,8 @@ public class DatasetRepository extends JpaRepository<Long, Dataset> {
                 .getResultList();
     }
 
+    public List<Long> findIdsByNullHarvestedFrom() {
+        return em.createQuery("SELECT o.id FROM Dataset o WHERE o.harvestedFrom IS null ORDER BY o.id", Long.class)
+                .getResultList();
+    }
 }

--- a/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/harvest/OAIRecord.java
+++ b/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/harvest/OAIRecord.java
@@ -39,19 +39,23 @@ import java.util.Date;
 public class OAIRecord implements Serializable, JpaEntity<Long> {
 
     private static final long serialVersionUID = 1L;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    public Long getId() {
-        return id;
-    }
+    private String setName;
 
-    public void setId(Long id) {
-        this.id = id;
-    }
+    private String globalId;
 
-    public OAIRecord() {
+    @Temporal(value = TemporalType.TIMESTAMP)
+    private Date lastUpdateTime;
+
+    private boolean removed;
+
+    // -------------------- CONSTRUCTORS --------------------
+
+    protected OAIRecord() {
     }
 
     public OAIRecord(String setName, String globalId, Date lastUpdateTime) {
@@ -60,45 +64,47 @@ public class OAIRecord implements Serializable, JpaEntity<Long> {
         this.lastUpdateTime = lastUpdateTime;
     }
 
-    private String globalId;
-    private String setName;
-    @Temporal(value = TemporalType.TIMESTAMP)
-    private Date lastUpdateTime;
-    private boolean removed;
+    // -------------------- GETTERS --------------------
 
-
-    public String getGlobalId() {
-        return globalId;
-    }
-
-    public void setGlobalId(String globalId) {
-        this.globalId = globalId;
+    public Long getId() {
+        return id;
     }
 
     public String getSetName() {
         return setName;
     }
 
-    public void setSetName(String setName) {
-        this.setName = setName;
+    public String getGlobalId() {
+        return globalId;
     }
 
     public Date getLastUpdateTime() {
         return lastUpdateTime;
     }
 
-    public void setLastUpdateTime(Date lastUpdateTime) {
-        this.lastUpdateTime = lastUpdateTime;
-    }
-
     public boolean isRemoved() {
         return removed;
+    }
+
+    // -------------------- SETTERS --------------------
+
+    public void setSetName(String setName) {
+        this.setName = setName;
+    }
+
+    public void setGlobalId(String globalId) {
+        this.globalId = globalId;
+    }
+
+    public void setLastUpdateTime(Date lastUpdateTime) {
+        this.lastUpdateTime = lastUpdateTime;
     }
 
     public void setRemoved(boolean removed) {
         this.removed = removed;
     }
 
+    // -------------------- hashCode & equals --------------------
 
     @Override
     public int hashCode() {
@@ -116,6 +122,8 @@ public class OAIRecord implements Serializable, JpaEntity<Long> {
         OAIRecord other = (OAIRecord) object;
         return (this.id != null || other.id == null) && (this.id == null || this.id.equals(other.id));
     }
+
+    // -------------------- toString --------------------
 
     @Override
     public String toString() {

--- a/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/harvest/OAIRecordRepository.java
+++ b/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/harvest/OAIRecordRepository.java
@@ -9,14 +9,23 @@ import java.util.List;
 @Stateless
 public class OAIRecordRepository extends JpaRepository<Long, OAIRecord> {
 
+    // -------------------- CONSTRUCTORS --------------------
+
     public OAIRecordRepository() {
         super(OAIRecord.class);
     }
 
+    // -------------------- LOGIC --------------------
 
     public List<OAIRecord> findBySetName(String setName) {
         return em.createQuery("SELECT r from OAIRecord r where r.setName = :setName", OAIRecord.class)
             .setParameter("setName", setName)
             .getResultList();
+    }
+    
+    public void deleteBySetName(String setName) {
+        em.createQuery("delete from OAIRecord hs where hs.setName = :setName", OAIRecord.class)
+            .setParameter("setName", setName)
+            .executeUpdate();
     }
 }

--- a/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/harvest/OAISet.java
+++ b/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/harvest/OAISet.java
@@ -19,6 +19,8 @@
  */
 package edu.harvard.iq.dataverse.persistence.harvest;
 
+import edu.harvard.iq.dataverse.persistence.JpaEntity;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -35,27 +37,22 @@ import java.io.Serializable;
  * @author Ellen Kraffmiller
  */
 @Entity
-public class OAISet implements Serializable {
+public class OAISet implements Serializable, JpaEntity<Long> {
 
     private static final long serialVersionUID = 1L;
 
-    public OAISet() {
-    }
+    public static final String DEFAULT_SET_SPEC_NAME = "";
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
+    @Version
+    private Long version;
 
     @Column(columnDefinition = "TEXT")
     private String name;
+
     @Column(columnDefinition = "TEXT", nullable = false, unique = true)
     @Size(max = 30, message = "{setspec.maxLength}")
     @Pattern.List({@Pattern(regexp = "[a-zA-Z0-9\\_\\-]*", message = "{dataverse.nameIllegalCharacters}")})
@@ -68,72 +65,91 @@ public class OAISet implements Serializable {
     @Column(columnDefinition = "TEXT", nullable = false)
     private String description;
 
-    @Version
-    private Long version;
 
     private boolean updateInProgress;
 
     private boolean deleted;
 
-    public boolean isUpdateInProgress() {
-        return this.updateInProgress;
+    // -------------------- CONSTRUCTORS --------------------
+
+    public OAISet() {
     }
 
-    public void setUpdateInProgress(boolean updateInProgress) {
-        this.updateInProgress = updateInProgress;
-    }
+    // -------------------- GETTERS --------------------
 
-    public boolean isDeleteInProgress() {
-        return this.deleted;
-    }
-
-    public void setDeleteInProgress(boolean deleteInProgress) {
-        this.deleted = deleteInProgress;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public String getSpec() {
-        return spec;
-    }
-
-    public void setSpec(String spec) {
-        this.spec = spec;
-    }
-
-    public String getDefinition() {
-        return definition;
-    }
-
-    public void setDefinition(String definition) {
-        this.definition = definition;
-    }
-
-    public String getDescription() {
-        return description;
-    }
-
-    public void setDescription(String description) {
-        this.description = description;
+    public Long getId() {
+        return id;
     }
 
     public Long getVersion() {
         return version;
     }
 
+    public String getName() {
+        return name;
+    }
+
+    public String getSpec() {
+        return spec;
+    }
+
+    public String getDefinition() {
+        return definition;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public boolean isUpdateInProgress() {
+        return this.updateInProgress;
+    }
+
+    public boolean isDeleteInProgress() {
+        return this.deleted;
+    }
+
+    // -------------------- LOGIC --------------------
+
+    public boolean isDefaultSet() {
+        return DEFAULT_SET_SPEC_NAME.equals(this.spec);
+    }
+
+    // -------------------- PRIVATE --------------------
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
     public void setVersion(Long version) {
         this.version = version;
     }
 
-    public boolean isDefaultSet() {
-        return "".equals(this.spec);
+    public void setName(String name) {
+        this.name = name;
     }
+
+    public void setSpec(String spec) {
+        this.spec = spec;
+    }
+
+    public void setDefinition(String definition) {
+        this.definition = definition;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public void setUpdateInProgress(boolean updateInProgress) {
+        this.updateInProgress = updateInProgress;
+    }
+
+    public void setDeleteInProgress(boolean deleteInProgress) {
+        this.deleted = deleteInProgress;
+    }
+
+    // -------------------- hashCode & equals --------------------
 
     @Override
     public int hashCode() {
@@ -151,6 +167,8 @@ public class OAISet implements Serializable {
         OAISet other = (OAISet) object;
         return (this.id != null || other.id == null) && (this.id == null || this.id.equals(other.id));
     }
+
+    // -------------------- toString --------------------
 
     @Override
     public String toString() {

--- a/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/harvest/OAISetRepository.java
+++ b/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/harvest/OAISetRepository.java
@@ -1,0 +1,32 @@
+package edu.harvard.iq.dataverse.persistence.harvest;
+
+import edu.harvard.iq.dataverse.persistence.JpaRepository;
+
+import javax.ejb.Stateless;
+
+import java.util.List;
+import java.util.Optional;
+
+@Stateless
+public class OAISetRepository extends JpaRepository<Long, OAISet> {
+
+    // -------------------- CONSTRUCTORS --------------------
+
+    public OAISetRepository() {
+        super(OAISet.class);
+    }
+
+    // -------------------- LOGIC --------------------
+
+    public Optional<OAISet> findBySpecName(String specName) {
+        return JpaRepository.getSingleResult(
+                em.createQuery("SELECT o FROM OAISet o WHERE o.spec = :specName", OAISet.class)
+                    .setParameter("specName", specName));
+    }
+
+    public List<OAISet> findAllBySpecNameNot(String specName) {
+        return em.createQuery("SELECT o FROM OAISet o WHERE o.spec != :specName ORDER BY o.spec", OAISet.class)
+                    .setParameter("specName", specName)
+                    .getResultList();
+    }
+}

--- a/dataverse-persistence/src/main/resources/db/migration/V38__removeDuplicateOaiRecordsAndAddConstraints.sql
+++ b/dataverse-persistence/src/main/resources/db/migration/V38__removeDuplicateOaiRecordsAndAddConstraints.sql
@@ -1,0 +1,15 @@
+
+ALTER TABLE oaiset ALTER COLUMN spec SET NOT NULL;
+ALTER TABLE oaiset ALTER COLUMN deleted SET NOT NULL;
+ALTER TABLE oaiset ALTER COLUMN updateinprogress SET NOT NULL;
+
+ALTER TABLE oairecord ALTER COLUMN lastupdatetime SET NOT NULL;
+ALTER TABLE oairecord ALTER COLUMN globalid SET NOT NULL;
+ALTER TABLE oairecord ALTER COLUMN setname SET NOT NULL;
+ALTER TABLE oairecord ALTER COLUMN removed SET NOT NULL;
+
+DELETE FROM oairecord r1 USING oairecord r2
+WHERE  r1.lastupdatetime < r2.lastupdatetime
+  AND  r1.globalid = r2.globalid AND  r1.setname = r2.setname;
+
+ALTER TABLE oairecord ADD CONSTRAINT oairecord_globalid_setname_unique_idx UNIQUE (globalid, setname);

--- a/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/harvest/OAIRecordRepositoryIt.java
+++ b/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/harvest/OAIRecordRepositoryIt.java
@@ -1,0 +1,57 @@
+package edu.harvard.iq.dataverse.persistence.harvest;
+
+import edu.harvard.iq.dataverse.persistence.PersistenceArquillianDeployment;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.inject.Inject;
+
+import java.util.Date;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+public class OAIRecordRepositoryIt extends PersistenceArquillianDeployment {
+
+    @Inject
+    private OAIRecordRepository repository;
+
+
+    @Before
+    public void setUp() {
+        repository.save(new OAIRecord("set_name_1", "global_id_1", new Date()));
+        repository.save(new OAIRecord("set_name_1", "global_id_2", new Date()));
+        repository.save(new OAIRecord("set_name_1", "global_id_3", new Date()));
+        repository.save(new OAIRecord("set_name_2", "global_id_1", new Date()));
+        repository.save(new OAIRecord("set_name_2", "global_id_4", new Date()));
+    }
+    
+    // -------------------- TESTS --------------------
+
+    @Test
+    public void findBySetName() {
+        // when
+        List<OAIRecord> oaiRecords = repository.findBySetName("set_name_1");
+        // then
+        assertThat(oaiRecords)
+            .extracting(OAIRecord::getGlobalId, OAIRecord::getSetName)
+            .containsExactlyInAnyOrder(
+                tuple("global_id_1", "set_name_1"),
+                tuple("global_id_2", "set_name_1"),
+                tuple("global_id_3", "set_name_1")
+            );
+    }
+
+    @Test
+    public void deleteBySetName() {
+        // when
+        repository.deleteBySetName("oai_set_2");
+        // then
+        assertThat(repository.findAll())
+            .extracting(OAIRecord::getSetName)
+            .noneMatch(setName -> StringUtils.equals(setName, "oai_set_2"));
+    }
+
+}

--- a/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/harvest/OAISetRepositoryIT.java
+++ b/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/harvest/OAISetRepositoryIT.java
@@ -1,0 +1,62 @@
+package edu.harvard.iq.dataverse.persistence.harvest;
+
+import edu.harvard.iq.dataverse.persistence.PersistenceArquillianDeployment;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.inject.Inject;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+public class OAISetRepositoryIT extends PersistenceArquillianDeployment {
+
+    @Inject
+    private OAISetRepository repository;
+
+
+    @Before
+    public void setUp() {
+        repository.save(buildOaiSet("Oai Set 1", "oai_set_1"));
+        repository.save(buildOaiSet("Oai Set 2", "oai_set_2"));
+        repository.save(buildOaiSet("Oai Set 3", "oai_set_3"));
+    }
+    
+    // -------------------- TESTS --------------------
+
+    @Test
+    public void findBySpecName() {
+        // when
+        Optional<OAISet> oaiSet = repository.findBySpecName("oai_set_2");
+        // then
+        assertThat(oaiSet).isPresent();
+        assertThat(oaiSet.get())
+            .extracting(OAISet::getName, OAISet::getSpec)
+            .containsExactly("Oai Set 2", "oai_set_2");
+    }
+    
+    @Test
+    public void findAllBySpecNameNot() {
+        // when
+        List<OAISet> oaiSets = repository.findAllBySpecNameNot("oai_set_2");
+        // then
+        assertThat(oaiSets)
+            .extracting(OAISet::getName, OAISet::getSpec)
+            .containsExactlyInAnyOrder(
+                    tuple("Oai Set 1", "oai_set_1"),
+                    tuple("Oai Set 3", "oai_set_3")
+            );
+    }
+    
+    // -------------------- PRIVATE --------------------
+    
+    private OAISet buildOaiSet(String name, String specName) {
+        OAISet oaiSet = new OAISet();
+        oaiSet.setName(name);
+        oaiSet.setSpec(specName);
+        return oaiSet;
+    }
+}

--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/DatasetDao.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/DatasetDao.java
@@ -2,7 +2,6 @@ package edu.harvard.iq.dataverse;
 
 import edu.harvard.iq.dataverse.authorization.AuthenticationServiceBean;
 import edu.harvard.iq.dataverse.common.DatasetFieldConstant;
-import edu.harvard.iq.dataverse.dataaccess.DataAccess;
 import edu.harvard.iq.dataverse.dataset.DatasetThumbnailService;
 import edu.harvard.iq.dataverse.engine.command.CommandContext;
 import edu.harvard.iq.dataverse.engine.command.DataverseRequest;
@@ -29,7 +28,6 @@ import javax.ejb.Stateless;
 import javax.ejb.TransactionAttribute;
 import javax.ejb.TransactionAttributeType;
 import javax.inject.Inject;
-import javax.inject.Named;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.persistence.Query;
@@ -52,7 +50,6 @@ import java.util.logging.Logger;
 
 
 @Stateless
-@Named
 public class DatasetDao implements java.io.Serializable {
 
     private static final Logger logger = Logger.getLogger(DatasetDao.class.getCanonicalName());

--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/api/datadeposit/ContainerManagerImpl.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/api/datadeposit/ContainerManagerImpl.java
@@ -57,8 +57,6 @@ public class ContainerManagerImpl implements ContainerManager {
     DatasetDao datasetDao;
     @EJB
     IndexServiceBean indexService;
-    @PersistenceContext(unitName = "VDCNet-ejbPU")
-    EntityManager em;
     @EJB
     ImportGenericServiceBean importGenericService;
     @EJB

--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/SetDatasetCitationDateCommand.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/SetDatasetCitationDateCommand.java
@@ -4,7 +4,6 @@ import edu.harvard.iq.dataverse.engine.command.AbstractCommand;
 import edu.harvard.iq.dataverse.engine.command.CommandContext;
 import edu.harvard.iq.dataverse.engine.command.DataverseRequest;
 import edu.harvard.iq.dataverse.engine.command.RequiredPermissions;
-import edu.harvard.iq.dataverse.engine.command.exception.CommandException;
 import edu.harvard.iq.dataverse.engine.command.exception.IllegalCommandException;
 import edu.harvard.iq.dataverse.persistence.dataset.Dataset;
 import edu.harvard.iq.dataverse.persistence.dataset.DatasetFieldType;

--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/harvest/client/HarvesterServiceBean.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/harvest/client/HarvesterServiceBean.java
@@ -26,12 +26,10 @@ import org.apache.commons.lang.mutable.MutableBoolean;
 import org.apache.commons.lang.mutable.MutableLong;
 import org.xml.sax.SAXException;
 
-import javax.annotation.Resource;
 import javax.ejb.Asynchronous;
 import javax.ejb.EJB;
 import javax.ejb.EJBException;
 import javax.ejb.Stateless;
-import javax.ejb.Timer;
 import javax.ejb.TransactionAttribute;
 import javax.ejb.TransactionAttributeType;
 import javax.faces.bean.ManagedBean;
@@ -66,8 +64,6 @@ public class HarvesterServiceBean {
 
     @EJB
     DatasetDao datasetDao;
-    @Resource
-    javax.ejb.TimerService timerService;
     @EJB
     DataverseTimerServiceBean dataverseTimerService;
     @EJB
@@ -116,19 +112,6 @@ public class HarvesterServiceBean {
                 dataverseTimerService.createHarvestTimer(harvestingConfig);
             }
         }
-    }
-
-    public List<HarvestTimerInfo> getHarvestTimers() {
-        ArrayList<HarvestTimerInfo> timers = new ArrayList<>();
-
-        for (Iterator it = timerService.getTimers().iterator(); it.hasNext(); ) {
-            Timer timer = (Timer) it.next();
-            if (timer.getInfo() instanceof HarvestTimerInfo) {
-                HarvestTimerInfo info = (HarvestTimerInfo) timer.getInfo();
-                timers.add(info);
-            }
-        }
-        return timers;
     }
 
     /**

--- a/dataverse-webapp/src/test/java/edu/harvard/iq/dataverse/harvest/server/OAIRecordServiceBeanTest.java
+++ b/dataverse-webapp/src/test/java/edu/harvard/iq/dataverse/harvest/server/OAIRecordServiceBeanTest.java
@@ -36,7 +36,7 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class OAIRecordServiceBeanTest {
-
+    
     private Logger logger = Logger.getLogger(OAIRecordServiceBeanTest.class.getCanonicalName());
     
     @InjectMocks
@@ -54,6 +54,7 @@ class OAIRecordServiceBeanTest {
     @Captor
     private ArgumentCaptor<OAIRecord> oaiRecordCaptor;
 
+    private static final String SET_NAME = "setName";
     private static final long OAI_RECORD_UPDATE_TIME = 123456;
     private static final long DATASET_METADATA_CHANGE_TIME = 1234567;
     private static final long UTC_CLOCK_TIME = 12345678;
@@ -77,10 +78,10 @@ class OAIRecordServiceBeanTest {
         when(datasetRepository.findById(dataset.getId())).thenReturn(Optional.of(dataset));
 
         OAIRecord oaiRecord = setupOaiRecord();
-        when(oaiRecordRepository.findBySetName("setName")).thenReturn(Lists.newArrayList(oaiRecord));
+        when(oaiRecordRepository.findBySetName(SET_NAME)).thenReturn(Lists.newArrayList(oaiRecord));
 
         //when
-        oaiRecordServiceBean.updateOaiRecords("setName", Lists.newArrayList(dataset.getId()), logger);
+        oaiRecordServiceBean.updateOaiRecords(SET_NAME, Lists.newArrayList(dataset.getId()), logger);
 
         //then
         Assert.assertEquals(utcClock.instant(), oaiRecord.getLastUpdateTime().toInstant());
@@ -98,10 +99,10 @@ class OAIRecordServiceBeanTest {
         when(datasetRepository.findById(dataset.getId())).thenReturn(Optional.of(dataset));
 
         OAIRecord oaiRecord = setupOaiRecord();
-        when(oaiRecordRepository.findBySetName("setName")).thenReturn(Lists.newArrayList(oaiRecord));
+        when(oaiRecordRepository.findBySetName(SET_NAME)).thenReturn(Lists.newArrayList(oaiRecord));
 
         //when
-        oaiRecordServiceBean.updateOaiRecords("setName", Lists.newArrayList(dataset.getId()), logger);
+        oaiRecordServiceBean.updateOaiRecords(SET_NAME, Lists.newArrayList(dataset.getId()), logger);
 
         //then
         Assert.assertEquals(utcClock.instant(), oaiRecord.getLastUpdateTime().toInstant());
@@ -120,10 +121,10 @@ class OAIRecordServiceBeanTest {
 
         OAIRecord oaiRecord = setupOaiRecord();
         oaiRecord.setRemoved(false);
-        when(oaiRecordRepository.findBySetName("setName")).thenReturn(Lists.newArrayList(oaiRecord));
+        when(oaiRecordRepository.findBySetName(SET_NAME)).thenReturn(Lists.newArrayList(oaiRecord));
 
         //when
-        oaiRecordServiceBean.updateOaiRecords("setName", Lists.newArrayList(dataset.getId()), logger);
+        oaiRecordServiceBean.updateOaiRecords(SET_NAME, Lists.newArrayList(dataset.getId()), logger);
 
         //then
         Assert.assertEquals(Instant.ofEpochMilli(OAI_RECORD_UPDATE_TIME), oaiRecord.getLastUpdateTime().toInstant());
@@ -144,10 +145,10 @@ class OAIRecordServiceBeanTest {
         OAIRecord oaiRecord = setupOaiRecord();
         oaiRecord.setLastUpdateTime(Date.from(presentTime.instant().minus(1, ChronoUnit.DAYS)));
         oaiRecord.setRemoved(false);
-        when(oaiRecordRepository.findBySetName("setName")).thenReturn(Lists.newArrayList(oaiRecord));
+        when(oaiRecordRepository.findBySetName(SET_NAME)).thenReturn(Lists.newArrayList(oaiRecord));
 
         //when
-        oaiRecordServiceBean.updateOaiRecords("setName", Lists.newArrayList(dataset.getId()), logger);
+        oaiRecordServiceBean.updateOaiRecords(SET_NAME, Lists.newArrayList(dataset.getId()), logger);
 
         //then
         Assert.assertEquals(presentTime.instant(), oaiRecord.getLastUpdateTime().toInstant());
@@ -162,10 +163,10 @@ class OAIRecordServiceBeanTest {
         when(datasetRepository.findById(dataset.getId())).thenReturn(Optional.of(dataset));
 
         OAIRecord oaiRecord = setupOaiRecord();
-        when(oaiRecordRepository.findBySetName("setName")).thenReturn(Lists.newArrayList(oaiRecord));
+        when(oaiRecordRepository.findBySetName(SET_NAME)).thenReturn(Lists.newArrayList(oaiRecord));
 
         //when
-        oaiRecordServiceBean.updateOaiRecords("setName", Lists.newArrayList(dataset.getId()), logger);
+        oaiRecordServiceBean.updateOaiRecords(SET_NAME, Lists.newArrayList(dataset.getId()), logger);
 
         //then
         Assert.assertEquals(utcClock.instant(), oaiRecord.getLastUpdateTime().toInstant());
@@ -179,17 +180,15 @@ class OAIRecordServiceBeanTest {
         Dataset dataset = setupDatasetData();
         when(datasetRepository.findById(dataset.getId())).thenReturn(Optional.of(dataset));
 
-        String setName = "setName";
-
         //when
-        oaiRecordServiceBean.updateOaiRecords(setName, Lists.newArrayList(dataset.getId()), logger);
+        oaiRecordServiceBean.updateOaiRecords(SET_NAME, Lists.newArrayList(dataset.getId()), logger);
 
         //then
         verify(oaiRecordRepository).save(oaiRecordCaptor.capture());
         
         OAIRecord persistedRecord = oaiRecordCaptor.getValue();
         Assert.assertEquals(utcClock.instant(), persistedRecord.getLastUpdateTime().toInstant());
-        Assert.assertEquals(setName, persistedRecord.getSetName());
+        Assert.assertEquals(SET_NAME, persistedRecord.getSetName());
         Assert.assertEquals("doi:nice/ID1", persistedRecord.getGlobalId());
 
     }
@@ -201,10 +200,8 @@ class OAIRecordServiceBeanTest {
         dataset.getLatestVersion().setVersionState(VersionState.DEACCESSIONED);
         when(datasetRepository.findById(dataset.getId())).thenReturn(Optional.of(dataset));
 
-        String setName = "setName";
-
         //when
-        oaiRecordServiceBean.updateOaiRecords(setName, Lists.newArrayList(dataset.getId()), logger);
+        oaiRecordServiceBean.updateOaiRecords(SET_NAME, Lists.newArrayList(dataset.getId()), logger);
 
         //then
         verify(oaiRecordRepository, times(0)).save(any());
@@ -219,12 +216,10 @@ class OAIRecordServiceBeanTest {
         
         OAIRecord oaiRecord = setupOaiRecord();
         oaiRecord.setRemoved(false);
-        when(oaiRecordRepository.findBySetName("setName")).thenReturn(Lists.newArrayList(oaiRecord));
-
-        String setName = "setName";
+        when(oaiRecordRepository.findBySetName(SET_NAME)).thenReturn(Lists.newArrayList(oaiRecord));
 
         //when
-        oaiRecordServiceBean.updateOaiRecords(setName, Lists.newArrayList(dataset.getId()), logger);
+        oaiRecordServiceBean.updateOaiRecords(SET_NAME, Lists.newArrayList(dataset.getId()), logger);
 
         //then
         Assert.assertEquals(utcClock.instant(), oaiRecord.getLastUpdateTime().toInstant());
@@ -234,10 +229,9 @@ class OAIRecordServiceBeanTest {
     // -------------------- PRIVATE --------------------
 
     private OAIRecord setupOaiRecord() {
-        OAIRecord oaiRecord = new OAIRecord();
-        oaiRecord.setGlobalId("doi:nice/ID1");
+        OAIRecord oaiRecord = new OAIRecord(SET_NAME, "doi:nice/ID1",
+                                            Date.from(Instant.ofEpochMilli(OAI_RECORD_UPDATE_TIME)));
         oaiRecord.setRemoved(true);
-        oaiRecord.setLastUpdateTime(Date.from(Instant.ofEpochMilli(OAI_RECORD_UPDATE_TIME)));
         return oaiRecord;
     }
 

--- a/dataverse-webapp/src/test/java/edu/harvard/iq/dataverse/harvest/server/OAISetServiceBeanTest.java
+++ b/dataverse-webapp/src/test/java/edu/harvard/iq/dataverse/harvest/server/OAISetServiceBeanTest.java
@@ -1,0 +1,184 @@
+package edu.harvard.iq.dataverse.harvest.server;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import edu.harvard.iq.dataverse.persistence.harvest.OAIRecordRepository;
+import edu.harvard.iq.dataverse.persistence.harvest.OAISet;
+import edu.harvard.iq.dataverse.persistence.harvest.OAISetRepository;
+import edu.harvard.iq.dataverse.search.query.SolrQuerySanitizer;
+import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.common.SolrDocument;
+import org.apache.solr.common.SolrDocumentList;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class OAISetServiceBeanTest {
+
+    private static final String SPEC_NAME = "spec";
+
+    @InjectMocks
+    private OAISetServiceBean oaiSetService;
+
+    @Mock
+    private OAISetRepository oaiSetRepository;
+
+    @Mock
+    private OAIRecordRepository oaiRecordRepository;
+
+    @Mock
+    private SolrClient solrServer;
+
+    @Mock
+    private SolrQuerySanitizer querySanitizer;
+
+    @Captor
+    private ArgumentCaptor<SolrQuery> solrQueryCaptor;
+    
+    private OAISet oaiSet = new OAISet();
+    private OAISet oaiSet2 = new OAISet();
+
+
+    @BeforeEach
+    void beforeEach() {
+        oaiSet.setId(3L);
+        oaiSet.setSpec(SPEC_NAME);
+
+        oaiSet2.setId(4L);
+    }
+
+    @Test
+    void specExists_true() {
+        // given
+        when(oaiSetRepository.findBySpecName(SPEC_NAME)).thenReturn(Optional.of(oaiSet));
+        // when & then
+        assertThat(oaiSetService.specExists(SPEC_NAME)).isTrue();
+    }
+
+    @Test
+    void specExists_false() {
+        // given
+        when(oaiSetRepository.findBySpecName(SPEC_NAME)).thenReturn(Optional.empty());
+        // when & then
+        assertThat(oaiSetService.specExists(SPEC_NAME)).isFalse();
+    }
+
+    @Test
+    void findBySpec() {
+        // given
+        when(oaiSetRepository.findBySpecName(SPEC_NAME)).thenReturn(Optional.of(oaiSet));
+        // when & then
+        assertThat(oaiSetService.findBySpec(SPEC_NAME)).isEqualTo(oaiSet);
+    }
+
+    @Test
+    void findDefaultSet() {
+        // given
+        when(oaiSetRepository.findBySpecName("")).thenReturn(Optional.of(oaiSet));
+        // when & then
+        assertThat(oaiSetService.findDefaultSet()).isEqualTo(oaiSet);
+    }
+
+    @Test
+    void findAll() {
+        // given
+        when(oaiSetRepository.findAll()).thenReturn(Lists.newArrayList(oaiSet, oaiSet2));
+        // when & then
+        assertThat(oaiSetService.findAll()).containsExactlyInAnyOrder(oaiSet, oaiSet2);
+    }
+
+    @Test
+    void findAllNamedSets() {
+        // given
+        when(oaiSetRepository.findAllBySpecNameNot("")).thenReturn(Lists.newArrayList(oaiSet, oaiSet2));
+        // when & then
+        assertThat(oaiSetService.findAllNamedSets()).containsExactlyInAnyOrder(oaiSet, oaiSet2);
+    }
+
+    @Test
+    void remove() {
+        // given
+        when(oaiSetRepository.findById(oaiSet.getId())).thenReturn(Optional.of(oaiSet));
+        // when
+        oaiSetService.remove(oaiSet.getId());
+        // then
+        verify(oaiRecordRepository).deleteBySetName(SPEC_NAME);
+        verify(oaiSetRepository).delete(oaiSet);
+    }
+
+    @Test
+    void expandSetQuery() throws OaiSetException, SolrServerException, IOException {
+        // given
+        QueryResponse queryResponse = mock(QueryResponse.class);
+        SolrDocumentList solrDocuments = new SolrDocumentList();
+        solrDocuments.add(new SolrDocument(ImmutableMap.of("entityId", 100L)));
+        solrDocuments.add(new SolrDocument(ImmutableMap.of("entityId", 101L)));
+        when(queryResponse.getResults()).thenReturn(solrDocuments);
+        
+        when(querySanitizer.sanitizeQuery("field:someQuery")).thenReturn("field:sanitizedQuery");
+        when(solrServer.query(any())).thenReturn(queryResponse);
+        
+        // when
+        List<Long> datasetIds = oaiSetService.expandSetQuery("field:someQuery");
+        
+        // then
+        assertThat(datasetIds).containsExactly(100L, 101L);
+        verify(solrServer).query(solrQueryCaptor.capture());
+        
+        SolrQuery querySentToSolr = solrQueryCaptor.getValue();
+        assertThat(querySentToSolr.getQuery()).isEqualTo("field:sanitizedQuery");
+        assertThat(querySentToSolr.getFilterQueries()).containsExactlyInAnyOrder(
+                "dvObjectType:datasets",
+                "isHarvested:false",
+                "publicationStatus:Published");
+    }
+
+    @Test
+    void setUpdateInProgress() {
+        // given
+        when(oaiSetRepository.findById(oaiSet.getId())).thenReturn(Optional.of(oaiSet));
+        // when
+        oaiSetService.setUpdateInProgress(oaiSet.getId());
+        // then
+        assertThat(oaiSet.isUpdateInProgress()).isTrue();
+        verify(oaiSetRepository).save(oaiSet);
+    }
+
+    @Test
+    void setDeleteInProgress() {
+        // given
+        when(oaiSetRepository.findById(oaiSet.getId())).thenReturn(Optional.of(oaiSet));
+        // when
+        oaiSetService.setDeleteInProgress(oaiSet.getId());
+        // then
+        assertThat(oaiSet.isDeleteInProgress()).isTrue();
+        verify(oaiSetRepository).save(oaiSet);
+    }
+
+    @Test
+    void save() {
+        // when
+        oaiSetService.save(oaiSet);
+        // then
+        verify(oaiSetRepository).save(oaiSet);
+    }
+}


### PR DESCRIPTION
Main issue was with solr query that obtains datasets to expose via oai.
Returned dataset ids was filtered by adding
```
        query = query.concat(" AND " + SearchFields.TYPE + ":" + SearchObjectType.DATASETS.getSolrValue()
                + " AND " + SearchFields.IS_HARVESTED + ":" + false 
                + " AND " + SearchFields.PUBLICATION_STATUS + ":" + SearchPublicationStatus.PUBLISHED.getSolrValue());
```
To the query defined by user. In some cases it was possible to bypass above restrictions (query was fragile to something similar to concept of sql injection in databases). 
For example when we would defined oai set query: `nowe:` - the final query sent to solr would return all the records in solr.
Internal restrictions was moved to filterQueries.

Additionally I added constraint to oairecord table - so it would not be possible to store duplicated records.
Sql migration also will remove duplicated records (leaving only oairecord with highest lastupdatetime).
