### PR TITLE
Closes #1728: Fixed piwik attached events being cleared.

### DIFF
--- a/dataverse-webapp/src/main/webapp/dataset.xhtml
+++ b/dataverse-webapp/src/main/webapp/dataset.xhtml
@@ -79,6 +79,9 @@
                 <f:viewAction action="#{datasetDeaccessionDialog.init(DatasetPage.dataset)}"/>
                 <f:viewAction action="#{dataverseHeaderFragment.initBreadcrumbs(DatasetPage.dataset)}"/>
             </f:metadata>
+            <a id="currentDownloadRequestLink" href="#" target="_blank" rel="noopener noreferrer" download="" style="display: none;">
+                download requested files
+            </a>
             <h:form id="datasetForm">
                 <!-- Header / Button Panel -->
                 <!-- View editMode -->

--- a/dataverse-webapp/src/main/webapp/file.xhtml
+++ b/dataverse-webapp/src/main/webapp/file.xhtml
@@ -29,6 +29,11 @@
                     <f:viewAction action="#{FilePage.init}" />
                     <f:viewAction action="#{dataverseHeaderFragment.initBreadcrumbsForFileMetadata(FilePage.fileMetadata)}"/>
                 </f:metadata>
+
+                <a id="currentDownloadRequestLink" href="#" target="_blank" rel="noopener noreferrer" download="" style="display: none;">
+                    download requested files
+                </a>
+
                 <h:form id="fileForm">
                     <div id="topDatasetBlock" class="row">
                         <div id="actionButtonBlock" class="col-xs-12">
@@ -194,9 +199,6 @@
                             </div>
                         </div>
                     </div>
-                    <a id="currentDownloadRequestLink" href="#" target="_blank" rel="noopener noreferrer" download="" style="display: none;">
-                        download requested files
-                    </a>
                     
                     <!-- END topDatasetBlock -->
                     <div id="fileImageTitle" class="row">

--- a/dataverse-webapp/src/main/webapp/filesFragment.xhtml
+++ b/dataverse-webapp/src/main/webapp/filesFragment.xhtml
@@ -438,10 +438,6 @@
             </p:column>
         </p:dataTable>
 
-        <a id="currentDownloadRequestLink" href="#" target="_blank" rel="noopener noreferrer" download="" style="display: none;">
-          download requested files
-        </a>
-
         <p:remoteCommand name="refreshTagsCommand"
                          onstart="#{FileTagModal.initForMultipleFiles(datasetFilesTab.retrieveSelectedFiles(), datasetFilesTab.dataset)}"
                          update="@form"


### PR DESCRIPTION
I have tested basic operations, but it seems like update='@form' doesn't clear the event on <a> (as it should be). So all the operations should have proper tracking now.