### PR TITLE
Closes #1984: Color should not be the only way of informing about WCAG switches activity

### DIFF
--- a/dataverse-webapp/src/main/webapp/dataverse_header.xhtml
+++ b/dataverse-webapp/src/main/webapp/dataverse_header.xhtml
@@ -259,13 +259,17 @@
                             <ul id="eighty-limit-mode-selector">
                                 <li>
                                     <button class="toggle" title="#{bundle['header.accessibility.eightyLimit.toggle']}"
-                                        aria-label="#{bundle['header.accessibility.eightyLimit.toggle']}" />
+                                        aria-label="#{bundle['header.accessibility.eightyLimit.toggle']}">
+                                        <span class="selected-option-check" role="presentation"></span>
+                                    </button>
                                 </li>
                             </ul>
                             <ul id="wcag-text-mode-selector">
                                 <li>
                                     <button class="toggle" title="#{bundle['header.accessibility.wcagText.toggle']}"
-                                        aria-label="#{bundle['header.accessibility.wcagText.toggle']}" />
+                                        aria-label="#{bundle['header.accessibility.wcagText.toggle']}">
+                                        <span class="selected-option-check" role="presentation"></span>
+                                    </button>
                                 </li>
                             </ul>
                         </div>
@@ -275,15 +279,21 @@
                             <ul id="font-size-mode-selector">
                                 <li>
                                     <button class="default" title="100%"
-                                        aria-label="#{bundle['header.accessibility.font.change']}: 100%" />
+                                        aria-label="#{bundle['header.accessibility.font.change']}: 100%">
+                                        <span class="selected-option-check" role="presentation"></span>
+                                    </button>
                                 </li>
                                 <li>
                                     <button class="percent-150" title="150%"
-                                        aria-label="#{bundle['header.accessibility.font.change']}: 150%" />
+                                        aria-label="#{bundle['header.accessibility.font.change']}: 150%">
+                                        <span class="selected-option-check" role="presentation"></span>
+                                    </button>
                                 </li>
                                 <li>
                                     <button class="percent-200" title="200%"
-                                        aria-label="#{bundle['header.accessibility.font.change']}: 200%" />
+                                        aria-label="#{bundle['header.accessibility.font.change']}: 200%">
+                                        <span class="selected-option-check" role="presentation"></span>
+                                    </button>
                                 </li>
                             </ul>
                         </div>
@@ -293,11 +303,15 @@
                             <ul id="high-contrast-mode-selector">
                                 <li>
                                     <button class="default" title="#{bundle['header.accessibility.contrast.default']}"
-                                        aria-label="#{bundle['header.accessibility.contrast.change']}: #{bundle['header.accessibility.contrast.default']}" />
+                                        aria-label="#{bundle['header.accessibility.contrast.change']}: #{bundle['header.accessibility.contrast.default']}">
+                                        <span class="selected-option-check" role="presentation"></span>
+                                    </button>
                                 </li>
                                 <li>
                                     <button class="yellow-on-black" title="#{bundle['header.accessibility.contrast.yellowOnBlack']}"
-                                        aria-label="#{bundle['header.accessibility.contrast.change']}: #{bundle['header.accessibility.contrast.yellowOnBlack']}" />
+                                        aria-label="#{bundle['header.accessibility.contrast.change']}: #{bundle['header.accessibility.contrast.yellowOnBlack']}">
+                                        <span class="selected-option-check" role="presentation"></span>
+                                    </button>
                                 </li>
                             </ul>
                         </div>

--- a/dataverse-webapp/src/main/webapp/resources/js/dv_accessibility.js
+++ b/dataverse-webapp/src/main/webapp/resources/js/dv_accessibility.js
@@ -112,6 +112,31 @@ function accessibilityRemoveSettingClass(setting) {
 }
 
 /**
+ * Set the aria-pressed attribute for WCAG buttons.
+ * @param string Setting name.
+ */
+ function accessibilitySetAriaPressed(setting) {
+    if (!(setting in accessibilityUserPreferencesData)) {
+        accessibilityDebugErr("This setting is not defined in accessibilityUserPreferencesData");
+        return;
+    }
+
+    var value = accessibilityGetSetting(setting);
+    var buttons = document.querySelectorAll("#" + accessibilityUserPreferencesData[setting] + "-mode-selector button");
+
+    for (var i=0; i<buttons.length; i++) {
+        if (value && value === buttons[i].className || !value && buttons[i].className === "default") {
+            accessibilityDebugLog("Set aria-pressed button state for \"" + setting + "\":\"" + buttons[i].className + "\" to \"true\"");
+            buttons[i].setAttribute("aria-pressed", "true");
+        }
+        else {
+            accessibilityDebugLog("Set aria-pressed button state for \"" + setting + "\":\"" + buttons[i].className + "\" to \"false\"");
+            buttons[i].setAttribute("aria-pressed", "false");
+        }
+    }
+}
+
+/**
  * Apply setting changes to storage and body tag.
  * @param string Setting name.
  * @param string Setting value.
@@ -127,12 +152,14 @@ function accessibilityApplySetting(setting, value) {
             accessibilityDebugLog("Toggling setting \"" + setting + "\" off");
             accessibilityRemoveSetting(setting);
             accessibilityRemoveSettingClass(setting);
+            accessibilitySetAriaPressed(setting);
         }
         else {
             accessibilityDebugLog("Toggling setting \"" + setting + "\" on");
             accessibilitySetSetting(setting, value);
             accessibilityRemoveSettingClass(setting);
             accessibilityAddSettingClass(setting);
+            accessibilitySetAriaPressed(setting);
         }
     }
     else if (value && value !== "default") {
@@ -140,6 +167,7 @@ function accessibilityApplySetting(setting, value) {
         accessibilitySetSetting(setting, value);
         accessibilityRemoveSettingClass(setting);
         accessibilityAddSettingClass(setting);
+        accessibilitySetAriaPressed(setting);
 
         if (setting === "fontSize") {
             accessibilityToggleNavbar(true);
@@ -149,6 +177,7 @@ function accessibilityApplySetting(setting, value) {
         accessibilityDebugLog("Changing setting \"" + setting + "\"to default");
         accessibilityRemoveSetting(setting);
         accessibilityRemoveSettingClass(setting);
+        accessibilitySetAriaPressed(setting);
 
         if (setting === "fontSize") {
             accessibilityToggleNavbar(false);
@@ -203,6 +232,8 @@ function accessibilityBindButtonEvents() {
             }, false);
             accessibilityDebugLog("Bound button event to \"" + key + "\"");
         }
+
+        accessibilitySetAriaPressed(key);
     }
 }
 

--- a/dataverse-webapp/src/main/webapp/resources/vecler/theme-base.scss
+++ b/dataverse-webapp/src/main/webapp/resources/vecler/theme-base.scss
@@ -2119,6 +2119,10 @@ $navbar-height: 102px;
 				cursor: pointer;
 			}
 		}
+
+		+ ul[id$="-mode-selector"] {
+			margin-left: -0.25em;
+		}
 	}
 
     div {
@@ -2148,6 +2152,31 @@ $navbar-height: 102px;
 	@include accessibility-controls-mobile;
 }
 
+.selected-option-check {
+	display: none;
+}
+
+@mixin mode-selector-checkmark-colors($text: $main-color, $background: #fff) {
+	.selected-option-check:before {
+		color: $text;
+		text-shadow: 1px 1px $background, -1px 1px $background, 1px -1px $background, -1px -1px $background;
+	}
+}
+@mixin mode-selector-checkmark {
+	.selected-option-check {
+		display: inline;
+
+		&:before {
+			content: "✔";
+			position: absolute;
+			top: 0.875em;
+			left: 0.875em;
+		}
+	}
+
+	@include mode-selector-checkmark-colors;
+}
+
 #eighty-limit-mode-selector button,
 #wcag-text-mode-selector button {
 	position: relative;
@@ -2163,9 +2192,11 @@ $navbar-height: 102px;
 		content: "Aa";
 	}
 }
-body.eighty-limit-toggle #eighty-limit-mode-selector button,
-body.wcag-text-toggle #wcag-text-mode-selector button {
+#eighty-limit-mode-selector button[aria-pressed="true"],
+#wcag-text-mode-selector button[aria-pressed="true"] {
 	color: $focus-color;
+
+	@include mode-selector-checkmark;
 }
 
 #eighty-limit-mode-selector button::before {
@@ -2218,10 +2249,19 @@ body.wcag-text-toggle #wcag-text-mode-selector button {
 	color: $main-color !important;
 	font-weight: bold;
 	text-decoration: none !important;
+	overflow: hidden;
 
 	&::before {
 		content: "Aa";
 	}
+}
+
+#high-contrast-mode-selector button[aria-pressed="true"] {
+	@include mode-selector-checkmark;
+}
+
+#accessibility-controls button[aria-pressed="true"]:not(.toggle) {
+	cursor: default;
 }
 
 /* Footer */
@@ -3639,11 +3679,11 @@ body.font-size-percent-200 {
 
 /* Misc fixes */
 
-body:not([class*="font-size-percent"]) {
-	#font-size-mode-selector button.default {
-		color: $focus-color;
-		cursor: default;
-	}
+#font-size-mode-selector button[aria-pressed="true"] {
+	color: $focus-color;
+	cursor: default;
+
+	@include mode-selector-checkmark;
 }
 
 body.font-size-percent-150 {
@@ -3668,11 +3708,6 @@ body.font-size-percent-150 {
 
 	.ui-picklist-filter-container .ui-icon-search {
 		margin: 5px 5px 0 0;
-	}
-
-	#font-size-mode-selector button.percent-150 {
-		color: $focus-color;
-		cursor: default;
 	}
 
 	.ql-formats button {
@@ -3706,11 +3741,6 @@ body.font-size-percent-200 {
 
 	.ui-picklist-filter-container .ui-icon-search {
 		margin: 10px 10px 0 0;
-	}
-
-	#font-size-mode-selector button.percent-200 {
-		color: $focus-color;
-		cursor: default;
 	}
 
 	.ql-formats button {
@@ -4847,9 +4877,12 @@ body.font-size-percent-200 {
 		}
 	}
 
-	&.eighty-limit-toggle #eighty-limit-mode-selector button,
-	&.wcag-text-toggle #wcag-text-mode-selector button {
+	#eighty-limit-mode-selector button[aria-pressed="true"],
+	#wcag-text-mode-selector button[aria-pressed="true"],
+	#font-size-mode-selector button[aria-pressed="true"] {
 		color: $contrast-alt-focus-color;
+
+		@include mode-selector-checkmark-colors($contrast-foreground-color, $contrast-background-color);
 	}
 
 	#font-size-mode-selector button {
@@ -4860,13 +4893,6 @@ body.font-size-percent-200 {
 		&::before {
 			text-decoration: underline;
 		}
-	}
-
-	&:not([class*=font-size-percent]) #font-size-mode-selector button.default,
-	&.font-size-percent-150 #font-size-mode-selector button.percent-150,
-	&.font-size-percent-200 #font-size-mode-selector button.percent-200 {
-		color: $contrast-alt-focus-color;
-		cursor: default;
 	}
 
 	#footer .footer-links .row {
@@ -4978,6 +5004,11 @@ body.font-size-percent-200 {
 
 body.high-contrast-yellow-on-black {
 	@include high-contrast-template();
+
+	#high-contrast-mode-selector button.yellow-on-black {
+		@include mode-selector-checkmark;
+		@include mode-selector-checkmark-colors(#ff0, #000);
+	}
 }
 #high-contrast-mode-selector button.yellow-on-black {
 	border-color: #ff0;


### PR DESCRIPTION
Added a checkmark that shows the currectly activated options. A `aria-pressed` is now also set on all accessibility buttons. This also allowed for some simplification in the stylesheet.

Also fixed a small issue when having multiple toggle buttons side-by-side (80 characters limit and "WCAG text mode) - there is an erroneous whitespace added between element; a negative margin was added to account for that and keep the spacing consistent,