### PR TITLE
Closes #1987: On phone browsers, when I drop down the top menu and scroll over it, the page underneath it scrolls

### DIFF
--- a/dataverse-webapp/src/main/webapp/resources/js/dv_accessibility.js
+++ b/dataverse-webapp/src/main/webapp/resources/js/dv_accessibility.js
@@ -157,6 +157,26 @@ function accessibilityApplySetting(setting, value) {
 }
 
 /**
+ * Toggle the navbar-expanded class on body tag.
+ *  @param state true - add class, false - remove class, undefined - toggle class
+ */
+ function accessibilityToggleNavbarBodyCass(state) {
+
+    if (state === undefined) {
+        accessibilityDebugLog("Toggling navbar-expanded class");
+        document.body.classList.toggle("navbar-expanded");
+    }
+    else if (state) {
+        accessibilityDebugLog("Adding navbar-expanded class");
+        document.body.classList.add("navbar-expanded");
+    }
+    else {
+        accessibilityDebugLog("Removing navbar-expanded class");
+        document.body.classList.remove("navbar-expanded");
+    }
+}
+
+/**
  * Toggle the visibility of the mobile navbar.
  * @param boolean true -> visible, false -> hidden
  */
@@ -168,12 +188,14 @@ function accessibilityToggleNavbar(visible) {
             navbar.classList.add("in");
             navbar.setAttribute("aria-expanded", "true");
             navbar.style = "";
+            accessibilityToggleNavbarBodyCass(true);
             accessibilityDebugLog("Toggled navbar to its visible state");
         }
         else {
             navbar.classList.remove("in");
             navbar.setAttribute("aria-expanded", "false");
             navbar.style = "height: 1px";
+            accessibilityToggleNavbarBodyCass(false);
             accessibilityDebugLog("Toggled navbar to its hidden state");
         }
     }
@@ -204,6 +226,10 @@ function accessibilityBindButtonEvents() {
             accessibilityDebugLog("Bound button event to \"" + key + "\"");
         }
     }
+
+    document.querySelector(".navbar-toggle").addEventListener("click", function() {
+        accessibilityToggleNavbarBodyCass();
+    }, false);
 }
 
 

--- a/dataverse-webapp/src/main/webapp/resources/vecler/theme-base.scss
+++ b/dataverse-webapp/src/main/webapp/resources/vecler/theme-base.scss
@@ -2037,6 +2037,10 @@ $navbar-height: 102px;
 @media screen and (max-width: $screen-xs-max) {
 	$navbar-height-mobile: 70px;
 
+	body.navbar-expanded {
+		overflow: hidden;
+	}
+
 	#navbarFixed .navbar-brand {
 		height: $navbar-height-mobile;
 		margin-left: 0.666em;
@@ -3538,6 +3542,13 @@ body.font-size-percent-200 {
 		margin-top: 0;
 		background-color: transparent;
 		box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
+	}
+}
+
+body.font-size-percent-150,
+body.font-size-percent-200 {
+	&.navbar-expanded {
+		overflow: hidden;
 	}
 }
 


### PR DESCRIPTION
A `navbar-expanded` class is added to `body` when the top menu is expanded, and the body scrolling is then blocked. This also works on non-mobile screens when the font size is increased.