### PR TITLE
Closes #1990: On phone screen, edit datavrese dropdown opens partially outside of the screen and is impossible to use

### DIFF
--- a/dataverse-webapp/src/main/webapp/resources/vecler/theme-base.scss
+++ b/dataverse-webapp/src/main/webapp/resources/vecler/theme-base.scss
@@ -3067,8 +3067,12 @@ div.filesTable {
 	}
 }
 
-/* Fix offscreen submenu on mobile */
+/* Fix offscreen menu/submenu on mobile */
 @media screen and (max-width: $screen-xs-max) {
+	#actionButtonBlock {
+		text-align: right;
+	}
+
 	.dropdown-submenu.pull-left > .dropdown-menu {
 		left: 0;
 	}


### PR DESCRIPTION
It might be difficult to properly fix the reported issue - this is just a workaround, but it does make these menus usable.