### PR TITLE
Closes #1986: On phone browsers, elements in the carousel may overlap if there is an oblong horizontal logo

### DIFF
--- a/dataverse-webapp/src/main/webapp/dataverse.xhtml
+++ b/dataverse-webapp/src/main/webapp/dataverse.xhtml
@@ -285,12 +285,12 @@
                                             <c:set var="dvFeatUrl" value="/dataverse/#{dv.alias}"/>
                                             <a href="#{widgetWrapper.wrapURL(dvFeatUrl)}" class="item" aria-label="#{bundle.dataverse} #{dv.name}">
                                                 <ui:fragment rendered="#{empty dv.dataverseTheme.logo}">
-                                                    <div>
+                                                    <div class="owl-carousel-logo">
                                                         <i class="icon-dataverse" role="img" aria-label="#{bundle.dataverse}"></i>
                                                     </div>
                                                 </ui:fragment>
                                                 <ui:fragment rendered="#{!empty dv.dataverseTheme.logo}">
-                                                    <div>
+                                                    <div class="owl-carousel-logo">
                                                         <img src="/logos/#{dv.logoOwnerId}/#{dv.dataverseTheme.logo}"
                                                             alt="#{bundle['dataverse.results.cards.dataverse.logoPrefix']} #{dv.name}"/>
                                                     </div>

--- a/dataverse-webapp/src/main/webapp/resources/vecler/theme-base.scss
+++ b/dataverse-webapp/src/main/webapp/resources/vecler/theme-base.scss
@@ -2576,6 +2576,21 @@ div.panelSearchForm input.search-input {
 			width: 100%;
 			padding-left: 17px;
 		}
+
+		@media screen and (max-width: $screen-xs-max) {
+			div {
+				display: block;
+			}
+
+			.owl-carousel-logo {
+				text-align: center;
+			}
+
+			.owl-carousel-description {
+				margin-top: 0.5em;
+				padding-left: 0;
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
On mobile devices, the dataverse title is now displayed under the logo.