### PR TITLE
Closes #2023: Fix search widget styling; add label; allow for button text customization

### DIFF
--- a/dataverse-webapp/src/main/webapp/resources/js/widgets.js
+++ b/dataverse-webapp/src/main/webapp/resources/js/widgets.js
@@ -14,7 +14,8 @@ params.alias; // Dataverse Alias
 params.persistentId; // persistentId
 params.dvUrl; // Dataverse Installation URL
 params.heightPx; // iframe height in pixels
-params.text; // search input placeholder text
+params.text = params.text || 'Search my dataverse'; // search input label/placeholder text
+params.buttonText = params.buttonText || 'Find'; // search button text
 
 // Utility function to convert "a=b&c=d" into { a:'b', c:'d' }
 function parseQueryString(queryString) {
@@ -39,7 +40,7 @@ if(params.widget === 'search') {
     /*
     * Dataverse Search Box
     */
-   document.write('<input type="text" placeholder="' + params.text + '..." onkeydown="if (event.keyCode == 13) document.getElementById(\'btnDataverseSearch\').click()" style="background:#fff; border:1px solid #ccc; border-radius:3px; box-shadow:0 1px 1px rgba(0, 0, 0, 0.075) inset; padding:4px; min-width:180px;"/>&#160;<input id="btnDataverseSearch" value="Find" type="button" onclick="window.open(&#39;' + params.dvUrl + '/dataverse.xhtml?alias=' + params.alias + '&amp;q=&#39; + this.previousSibling.previousSibling.value + &#39;&#39;, &#39;_blank&#39;);" style="-moz-border-bottom-colors:none; -moz-border-left-colors:none; -moz-border-right-colors:none; -moz-border-top-colors:none; background-color:#f5f5f5; background-image:-moz-linear-gradient(center top , #ffffff, #e6e6e6); background-repeat:repeat-x; border:1px solid #ccc; border-color:#e6e6e6 #e6e6e6 #b3b3b3; border-image:none; border-radius:4px; box-shadow:0 1px 0 rgba(255, 255, 255, 0.2) inset, 0 1px 2px rgba(0, 0, 0, 0.05); color:#333; cursor:pointer; text-shadow:0 1px 1px rgba(255, 255, 255, 0.75); padding:0.3em 1em; line-height:1.4;" />');
+   document.write('<input type="text" aria-label="' + params.text + '" placeholder="' + params.text + '..." onkeydown="if (event.keyCode == 13) document.getElementById(\'btnDataverseSearch\').click()" style="min-width:180px;"/>&#160;<input id="btnDataverseSearch" value="' + params.buttonText + '" type="button" onclick="window.open(&#39;' + params.dvUrl + '/dataverse.xhtml?alias=' + params.alias + '&amp;q=&#39; + this.previousSibling.previousSibling.value + &#39;&#39;, &#39;_blank&#39;);" />');
 }
 
 if(params.widget === 'iframe' && params.alias) {

--- a/dataverse-webapp/src/main/webapp/themeAndWidgetsFragment.xhtml
+++ b/dataverse-webapp/src/main/webapp/themeAndWidgetsFragment.xhtml
@@ -235,7 +235,7 @@
                         <p class="help-block">#{bundle['dataverse.widgets.searchBox.tip']}</p>
                     </div>
                     <div>
-                        <textarea rows="3" cols="54" class="form-control" readonly="readonly">&lt;script src=&quot;#{systemConfig.dataverseSiteUrl}/resources/js/widgets.js?alias=#{themeWidgetFragment.editDv.alias}&amp;amp;dvUrl=#{systemConfig.dataverseSiteUrl}&amp;amp;widget=search&amp;amp;text=Search&#43;my&#43;dataverse&quot;&gt;&lt;/script&gt;</textarea>
+                        <textarea rows="3" cols="54" class="form-control" readonly="readonly">&lt;script src=&quot;#{systemConfig.dataverseSiteUrl}/resources/js/widgets.js?alias=#{themeWidgetFragment.editDv.alias}&amp;amp;dvUrl=#{systemConfig.dataverseSiteUrl}&amp;amp;widget=search&amp;amp;text=Search&#43;my&#43;dataverse&amp;amp;buttonText=Find&quot;&gt;&lt;/script&gt;</textarea>
                     </div>
                     <div>
                         <h5>


### PR DESCRIPTION
For testing purpouse we could save some page with the following text:
```
<div>
        <script src="http://localhost:8080/resources/js/widgets.js?alias=root&amp;dvUrl=http://localhost:8080&amp;widget=search&amp;text=Hello+world&amp;buttonText=Szukaj"></script>
</div>
```
and open it in browser

Default values was also added so pages that will not embeed with `buttonText` param will render the default instead of `undefined`
