### PR TITLE
Closes #2005: On mobile browsers, main content scrolls under carousel

### DIFF
--- a/dataverse-webapp/src/main/webapp/resources/vecler/theme-base.scss
+++ b/dataverse-webapp/src/main/webapp/resources/vecler/theme-base.scss
@@ -2749,15 +2749,17 @@ div[id$="facetCategoryList"] div li div.ui-widget {
 @media screen and (max-width: $screen-xs-max) {
 	.row.row-offcanvas.row-offcanvas-left {
 		#dv-sidebar {
-			visibility: hidden;
+			display: none;
 			opacity: 0;
+			height: 0;
 
 			transition: opacity 0.25s ease-in-out;
 		}
 
 		&.active #dv-sidebar {
-			visibility: visible;
+			display: block;
 			opacity: 1;
+			height: auto;
 
 			transition: opacity 0.25s ease-in-out;
 		}


### PR DESCRIPTION
This issue manifests itself  when the filters menu has a longer height than the search results (dataset/dataverse) list.

While this does not fix the issue fully, this inverts the problem to a more acceptable state: while previously the second scroll was there initially and went away when the filters menu was open, now the second scroll only appears after opening the filters menu. While still not ideal, I think it's a bit better, and a proper fix would require much more work.