### PR TITLE
Closes #2009: On wide, horizontally oriented mobile screens, top menu can sprawl into two lines, leaving very narrow space to view main content

### DIFF
--- a/dataverse-webapp/src/main/webapp/resources/js/dv_accessibility.js
+++ b/dataverse-webapp/src/main/webapp/resources/js/dv_accessibility.js
@@ -3,6 +3,14 @@
  */
 
 /**
+ * The screen width value where the top navbar changes into the mobile state (hamburger menu),
+ * Default value: 768
+ * @type integer screen width in px
+ */
+
+var accessibilityTopNavbarMobileBreakpoint = 992;
+
+/**
  * Denotes whether to print debug info to console.
  * @type boolean true = enabled, false = disabled
  */
@@ -212,7 +220,7 @@ function accessibilityApplySetting(setting, value) {
 function accessibilityToggleNavbar(visible) {
     var navbar = document.getElementById("topNavBar");
 
-    if (window.innerWidth > 768) {
+    if (window.innerWidth > accessibilityTopNavbarMobileBreakpoint) {
         if (visible) {
             navbar.classList.add("in");
             navbar.setAttribute("aria-expanded", "true");

--- a/dataverse-webapp/src/main/webapp/resources/vecler/theme-base.scss
+++ b/dataverse-webapp/src/main/webapp/resources/vecler/theme-base.scss
@@ -2081,6 +2081,23 @@ $navbar-height: 102px;
 	margin: 8px;
 }
 
+@media screen and (min-width: $screen-md-min) {
+	#userDisplayInfoTitle {
+		max-width: 100px;
+		display: inline-block;
+		overflow: hidden;
+		white-space: nowrap;
+		text-overflow: ellipsis;
+		vertical-align: bottom;
+	}
+}
+
+@media screen and (min-width: $screen-lg-min) {
+	#userDisplayInfoTitle {
+		max-width: 200px;
+	}
+}
+
 @media screen and (max-width: $screen-xs-max) {
 	$navbar-height-mobile: 70px;
 
@@ -2141,6 +2158,8 @@ $navbar-height: 102px;
 			height: $navbar-height;
 	}
 }
+
+/* Accessibility controls */
 
 #accessibility-controls {
 	position: absolute;
@@ -2313,6 +2332,116 @@ $navbar-height: 102px;
 
 #accessibility-controls button[aria-pressed="true"]:not(.toggle) {
 	cursor: default;
+}
+
+/* Force navbar mobile mode on sm-md screen width */
+
+@mixin force-navbar-mobile {
+	.navbar-toggle {
+		display: block;
+	}
+
+	.navbar-header {
+		float: none;
+	}
+
+	.navbar-default #topNavBar {
+		border-top: 1px solid $gray-border-color;
+
+		&.navbar-collapse.collapse {
+			display: none !important;
+
+			&.in {
+				display: block !important;
+			}
+		}
+
+		.pull-right {
+			width: 100%;
+			float: none !important;
+		}
+
+		.navbar-nav {
+			height: auto;
+			margin: 7.5px -15px;
+			display: block;
+
+			> li, .navbar-left {
+				float: none !important;
+			}
+
+			.open .dropdown-menu {
+				position: static;
+				float: none;
+				width: auto;
+				margin-top: 0;
+				background-color: transparent;
+				border: 0;
+				-webkit-box-shadow: none;
+				box-shadow: none;
+
+				> li > a {
+					line-height: 20px;
+
+					&:focus, &:hover {
+						background-image: none;
+					}
+				}
+
+				.dropdown-header, > li > a, > li > form > a {
+					padding: 0.667em 1em !important;
+				}
+			}
+		}
+	}
+
+	@include accessibility-controls-mobile;
+
+	.navbar-default #topNavBar .navbar-nav .open .dropdown-menu {
+		.dropdown-header, > li > a, > li > form > a {
+			padding: 0.667em 1em !important;
+		}
+	}
+
+	.navbar-nav .open .dropdown-menu {
+		position: static;
+		float: none;
+		width: 100%;
+		margin-top: 0;
+		background-color: transparent;
+		box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
+	}
+
+	.navbar-default #topNavBar .navbar-nav .open .dropdown-menu {
+		.dropdown-header, > li > a, > li > form > a {
+			padding: 0.667em 1em !important;
+		}
+	}
+
+	.navbar-nav .open .dropdown-menu {
+		position: static;
+		float: none;
+		width: 100%;
+		margin-top: 0;
+		background-color: transparent;
+		box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
+	}
+}
+
+@media screen and (min-width: $screen-sm-min) and (max-width: $screen-sm-max) {
+	@include force-navbar-mobile;
+
+	body.navbar-expanded {
+		overflow: hidden;
+	}
+}
+
+@media only screen and (hover: none) and (pointer: coarse) {
+	@include force-navbar-mobile;
+
+	body.navbar-expanded {
+		overflow: hidden;
+	}
 }
 
 /* Footer */
@@ -3600,80 +3729,7 @@ body.wcag-text-toggle {
 body.font-size-percent-150,
 body.font-size-percent-200 {
 	@media (min-width: $screen-sm-min) {
-		.navbar-toggle {
-			display: block;
-		}
-
-		.navbar-header {
-			float: none;
-		}
-
-		.navbar-default #topNavBar {
-			border-top: 1px solid $gray-border-color;
-
-			&.navbar-collapse.collapse {
-				display: none !important;
-
-				&.in {
-					display: block !important;
-				}
-			}
-
-			.pull-right {
-				width: 100%;
-				float: none !important;
-			}
-
-			.navbar-nav {
-				height: auto;
-				margin: 7.5px -15px;
-				display: block;
-
-				> li, .navbar-left {
-					float: none !important;
-				}
-
-				.open .dropdown-menu {
-					position: static;
-					float: none;
-					width: auto;
-					margin-top: 0;
-					background-color: transparent;
-					border: 0;
-					-webkit-box-shadow: none;
-					box-shadow: none;
-
-					> li > a {
-						line-height: 20px;
-
-						&:focus, &:hover {
-							background-image: none;
-						}
-					}
-
-					.dropdown-header, > li > a, > li > form > a {
-						padding: 0.667em 1em !important;
-					}
-				}
-			}
-		}
-
-		@include accessibility-controls-mobile;
-	}
-
-	.navbar-default #topNavBar .navbar-nav .open .dropdown-menu {
-		.dropdown-header, > li > a, > li > form > a {
-			padding: 0.667em 1em !important;
-		}
-	}
-
-	.navbar-nav .open .dropdown-menu {
-		position: static;
-		float: none;
-		width: 100%;
-		margin-top: 0;
-		background-color: transparent;
-		box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
+		@include force-navbar-mobile;
 	}
 }
 


### PR DESCRIPTION
The hamburger menu now appears when the screen width falls below 992px (previously it was 768px - not enough space to display all items). On mobile devices, it should always be displayed as a hamburger menu.

Also fixed: the username in the top navbar has now a max length defined, to avoid ruining the layout when it gets too long.

