### PR TITLE
Closes #2004: On phone browsers, fix paging components on "Manage users" page

### DIFF
--- a/dataverse-webapp/src/main/webapp/resources/js/dv_rebind_bootstrap_ui.js
+++ b/dataverse-webapp/src/main/webapp/resources/js/dv_rebind_bootstrap_ui.js
@@ -745,14 +745,26 @@ function reinitializePrimefacesComponentsJS() {
             originalPaginatorInit.apply(this, [cfg]);
 
             var currentPage = this.pagesContainer.find('.ui-paginator-page.ui-state-active');
-            currentPage.attr('aria-label', currentPage.attr('aria-label') + ' ' + PrimeFaces.getLocaleSettings().ariaCurrentPagePaginator)
+            currentPage.attr('aria-label', currentPage.attr('aria-label') + ' ' + PrimeFaces.getLocaleSettings().ariaCurrentPagePaginator);
+
+            /* Move pagination controls inside a container */
+            var paginatorMainContainer = document.getElementById(this.pagesContainer.prevObject.attr("id"));
+            var buttonContainer = document.createElement("div");
+            buttonContainer.classList.add("ui-paginator-container");
+            paginatorMainContainer.insertBefore(buttonContainer, paginatorMainContainer.firstChild);
+
+            var paginationElements = paginatorMainContainer.querySelectorAll("a[class*=ui-paginator]:not(a.ui-paginator-page), span.ui-paginator-pages");
+            
+            for (var i=0; i<paginationElements.length; i++) {
+                buttonContainer.appendChild(paginationElements[i]);
+            }
         }
 
         PrimeFaces.widget.Paginator.prototype.updatePageLinks = function() {
             originalPaginatorUpdatePageLinks.apply(this);
 
             var currentPage = this.pagesContainer.find('.ui-paginator-page.ui-state-active');
-            currentPage.attr('aria-label', currentPage.attr('aria-label') + ' ' + PrimeFaces.getLocaleSettings().ariaCurrentPagePaginator)
+            currentPage.attr('aria-label', currentPage.attr('aria-label') + ' ' + PrimeFaces.getLocaleSettings().ariaCurrentPagePaginator);
         }
     }
 

--- a/dataverse-webapp/src/main/webapp/resources/vecler/theme-base.scss
+++ b/dataverse-webapp/src/main/webapp/resources/vecler/theme-base.scss
@@ -568,7 +568,8 @@ textarea,
 .ui-tabs-header,
 .ui-sortable-column,
 .select-scroll-block,
-ul.pagination a {
+ul.pagination a,
+.ui-paginator a[class*=ui-paginator] {
 	&:focus {
 		outline-offset: -2px;
 	}
@@ -3057,6 +3058,23 @@ div.filesTable .ui-paginator {
 
 	.ui-paginator-page {
 		@include link-color;
+	}
+}
+
+@media screen and (min-width: $screen-sm-min) {
+	.ui-paginator-container {
+		display: inline;
+		margin-right: 1em;
+	}
+}
+
+@media screen and (max-width: $screen-xs-max) {
+	.ui-paginator .ui-paginator-current, .ui-paginator .ui-paginator-rpp-options {
+		margin-right: 0;
+	}
+
+	.ui-paginator-container {
+		margin-bottom: 0.5em;
 	}
 }
 


### PR DESCRIPTION
While there's a `paginatorTemplate` option in the `dataTable` attributes, it does not work correctly for this purpose - that is, I can make something like this:

```paginatorTemplate="&lt;div&gt; {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} &lt;/div&gt; #{bundle['file.dynamicCounter.filesPerPage']} {RowsPerPageDropdown}"```

This does the job as far as the layout is concerned (everything displays as intended), but the buttons that I've placed inside the `<div>` element don't work - they don't have any events bound to them. That's why I've tried another approeach relocating the buttons using JavaScript, as you can see in this PR - as far as I can tell, everything works correctly.