### PR TITLE
Closes #2008: "Assign role" modal window is too wide and causes the page underneath to sprawl horizontally (mobile browser, Chrome 89, Android)

### DIFF
--- a/dataverse-webapp/src/main/webapp/resources/vecler/theme-base.scss
+++ b/dataverse-webapp/src/main/webapp/resources/vecler/theme-base.scss
@@ -1680,6 +1680,13 @@ div.filesTable {
 	}
 }
 
+/* Fix erroneous horizontal scrollbar in mobile Chrome */
+.ui-datatable-tablewrapper {
+	.ui-helper-hidden-accessible, .sr-only {
+		position: fixed;
+	}
+}
+
 /* Fix submenus in scrollable tables not overflowing outside */
 .ui-tabs {
 	position: static;
@@ -3141,6 +3148,10 @@ div.filesTable .ui-paginator {
 
 .dataverseHeaderCell span[style="color:#888888;"] {
 	color: $gray-text-color !important;
+}
+
+#dataverseHeader .dataverseHeaderLogo img {
+	max-width: Min(940px, calc(100vw - 30px));
 }
 
 @media screen and (max-width: $screen-xs-max) {


### PR DESCRIPTION
This issue only manifested itself in Chrome. It wasn't limited to mobile devices, it could be reproduced on narrow browser windows on desktop.

The modal window wasn't related to this issue at all; the problem lied with the user/group table that is displayed in the users/groups field. More specifically, the hidden element(s) for the screen reader (`.sr`) were still rendered by Chrome as if they were on screen, hence the horizontal scrollbar. Changing their `position` CSS attribute from `absolute` to `fixed` has done away with this bug. No idea what's that all about, but at least it works now. Doesn't seem like this change broke anything either.

A very similar issue was present on the "Manage users" page, this time the checkbox present in one of the cells was the culprit. Fixed.

Also fixed: dataverse logo had its max allowed width set to `940px`, thus allowing it to exceed the browser width. This was changed to also take the screen width into consideration.