### PR TITLE
Closes #1988 #2003: Improved picklist behavior on touch devices

### DIFF
--- a/dataverse-webapp/src/main/webapp/dataverse.xhtml
+++ b/dataverse-webapp/src/main/webapp/dataverse.xhtml
@@ -324,6 +324,7 @@
                                         var="featureddataverse"
                                         itemLabel="#{featureddataverse.name}"
                                         itemValue="#{featureddataverse}" converter="dataverseConverter"
+                                        responsive="true"
                                         showSourceFilter="true" showTargetFilter="true"
                                         widgetVar="featuredDataversePicklist"
                                         addLabel="#{bundle['dataverse.featuredDataverse.edit.add']}"

--- a/dataverse-webapp/src/main/webapp/resources/js/dv_rebind_bootstrap_ui.js
+++ b/dataverse-webapp/src/main/webapp/resources/js/dv_rebind_bootstrap_ui.js
@@ -656,6 +656,10 @@ function reinitializePrimefacesComponentsJS() {
                 }
             }
 
+            /* Disable drag & drop for touchscreens */
+            if(window.matchMedia('(pointer: coarse)').matches) {
+                $(this.jqId + ' ul').sortable('disable');
+            }
         };
 
         PrimeFaces.widget.PickList.prototype.disableButton = function(button) {

--- a/dataverse-webapp/src/main/webapp/resources/vecler/theme-base.scss
+++ b/dataverse-webapp/src/main/webapp/resources/vecler/theme-base.scss
@@ -1266,6 +1266,22 @@ input.fancy-checkbox[type=checkbox] {
     }
 }
 
+@media screen and (max-width: $screen-xs-max) {
+	.ui-picklist .ui-picklist-buttons .ui-picklist-buttons-cell {
+		margin: 0;
+		padding: 0;
+	}
+}
+
+/* Fix scroll block on touch devices */
+.ui-picklist .ui-sortable-handle {
+	touch-action: auto;
+}
+
+/* Fix erroneous horizontal scrollbar in Chrome */
+.ui-picklist.ui-picklist-responsive > div.ui-helper-hidden-accessible {
+	width: 1px !important;
+}
 
 /* Float elements parent size fix */
 .col-md-6.form-group.form-col-container {


### PR DESCRIPTION
Closes #1988 
Closes #2003 

Drag & drop was disabled on touch devices for the picklist component. While this is far from an ideal soultion, at least the user can scroll through the list now.

Other changes:
- the picklist in the "Featured Dataverses" modal window uses a responsive layout now - should be more usable on mobile devices.
- a bit similarly to the #2008 issue, there was an erroneous horizontal scrollbar on the "Add Dataverse" page, only on Chrome on narrow screen width - fixed. Some of the styles were clashing and overwrote the element width.

Note: Firefox devtools don't emulate touch input properly. Use Chrome if you wish to test it on desktop.