### PR TITLE
Closes #2044: On Embargo modal, date picking component does not like not like "low" screens with scarce vertical space

### DIFF
--- a/dataverse-webapp/src/main/webapp/dataset.xhtml
+++ b/dataverse-webapp/src/main/webapp/dataset.xhtml
@@ -806,6 +806,8 @@
                                     validator="#{DatasetPage.validateEmbargoDate}"
                                     locale="#{dataverseSession.localeCode}"
                                     timeZone="UTC"
+                                    mode="inline"
+                                    widgetVar="embargoDatePickerCalendar"
                             />
                             <p:calendar
                                     id="embargoDatePickerMaxLimited"
@@ -820,6 +822,8 @@
                                     validator="#{DatasetPage.validateEmbargoDate}"
                                     locale="#{dataverseSession.localeCode}"
                                     timeZone="UTC"
+                                    mode="inline"
+                                    widgetVar="embargoDatePickerMaxLimitedCalendar"
                             />
                             <p:message id="embargoMsg" for="embargoDatePicker" display="text" />
                             <p:message id="embargoMsgMaxLimited" for="embargoDatePickerMaxLimited" display="text" />
@@ -841,6 +845,29 @@
                                              resetValues="true"
                             />
                         </div>
+                        <script type="text/javascript">
+                            // Move input to the correct place and make it usable
+                            
+                            $(document).ready(function() {
+                                var datePickerInput = $("#datasetForm\\:embargoDatePicker_input");
+                                var calendar = (PF("embargoDatePickerCalendar") ? PF("embargoDatePickerCalendar") : PF("embargoDatePickerMaxLimitedCalendar"));
+
+                                if (calendar) {
+                                    datePickerInput.val($.datepicker.formatDate("yy-mm-dd", calendar.getDate()));
+                                }
+
+                                if (datePickerInput.length  > 0) {
+                                    datePickerInput.attr("type", "text")
+                                    datePickerInput.insertAfter($("label[for*=embargoDatePicker_input]").next());
+    
+                                    datePickerInput.on("input", function() {
+                                        if (calendar) {
+                                            calendar.setDate(this.value);
+                                        }
+                                    });
+                                }
+                            });
+                        </script>
                     </p:fragment>
                 </p:dialog>
                 <!-- Confirm embargo lift -->

--- a/dataverse-webapp/src/main/webapp/loginpage.xhtml
+++ b/dataverse-webapp/src/main/webapp/loginpage.xhtml
@@ -93,12 +93,12 @@
                                     </div>
                                     
                                     <div class="form-group">
-                                        <div class="col-sm-offset-4 col-sm-9 button-block">
+                                        <div class="col-sm-offset-4 col-sm-8 button-block">
                                             <p:commandButton id="login" styleClass="btn btn-default" value="#{bundle.login}" update="@all" action="#{LoginPage.login}"/>
                                         </div>
                                     </div>
                                     <div class="form-group">
-                                        <div class="col-sm-offset-4 col-sm-9">
+                                        <div class="col-sm-offset-4 col-sm-8">
                                             <a href="passwordreset.xhtml">
                                                 #{bundle['login.forgot.text']}
                                             </a>

--- a/dataverse-webapp/src/main/webapp/resources/vecler/theme-base.scss
+++ b/dataverse-webapp/src/main/webapp/resources/vecler/theme-base.scss
@@ -3571,6 +3571,11 @@ div.filesTable {
 			@include btn-access;
 			box-shadow: 0 2px 5px rgba(0, 0, 0, 0.07);
 		}
+
+		&.ui-state-active:not(input):not(textarea):not(th):not(ul):not(.ui-radiobutton-box) {
+			background: $link-color;
+			color: #fff;
+		}
 	}
 
 	.ui-icon {
@@ -3753,6 +3758,18 @@ input[type=password].form-control {
 /* Fix for the unnecessary scrollbar in some modals */
 div.ui-dialog.largePopUp {
 	overflow: hidden;
+}
+
+/* Fix embargo modal on mobile */
+@media screen and (max-width: $screen-xs-max), screen and (max-height: 760px) {
+	#datasetForm\:SetEmbargo {
+		top: 0 !important;
+	}
+}
+
+/* DatePicker */
+.ui-datepicker-inline {
+	margin: 1em auto 0;
 }
 
 /* Modal end */
@@ -4460,8 +4477,15 @@ body.font-size-percent-200 {
 	}
 
 	.ui-dialog.ui-widget-content {
-		.ui-state-default:not(input):not(textarea):not(th):not(ul):not(.ui-radiobutton-box), a.btn:not(input):not(textarea):not(th):not(ul):not(.ui-radiobutton-box) {
-			@include contrast-button($contrast-background-color, $contrast-foreground-color, $contrast-hover-color, $contrast-link-color);
+		.ui-state-default, a.btn {
+			&:not(input):not(textarea):not(th):not(ul):not(.ui-radiobutton-box){
+				@include contrast-button($contrast-background-color, $contrast-foreground-color, $contrast-hover-color, $contrast-link-color);
+			}
+
+			&.ui-state-active:not(input):not(textarea):not(th):not(ul):not(.ui-radiobutton-box) {
+				background: $contrast-link-color;
+				color: $contrast-background-color;
+			}
 		}
 
 		.button-block {


### PR DESCRIPTION
The `datePicker` component was changed to inline - now it's always shown. This is due to the fact that the default "drop-down" `datePicker` does not behave correctly when inside a modal window.

Inline `datePicker` does not show the input by default - this was fixed via JavaScript to make it visible and usable.