### PR TITLE
Closes #2064: Navigating through multi-step modal windows can cause JS errors, breaking the site

### DIFF
--- a/dataverse-webapp/src/main/webapp/dataset-deaccession-dialog.xhtml
+++ b/dataverse-webapp/src/main/webapp/dataset-deaccession-dialog.xhtml
@@ -76,7 +76,7 @@
             
             <div class="button-block">
                 <p:commandLink styleClass="btn btn-default" value="#{bundle.deaccession}"  
-                               oncomplete="if (args &amp;&amp; !args.validationFailed) primeFacesShowModal('deaccessionConfirmation', this);">
+                               oncomplete="if (args &amp;&amp; !args.validationFailed) PF('deaccessionConfirmation').show();">
                 </p:commandLink>
                 <p:commandLink type="button" styleClass="btn btn-default" value="#{bundle.cancel}"
                         immediate ="true" 

--- a/dataverse-webapp/src/main/webapp/dataset.xhtml
+++ b/dataverse-webapp/src/main/webapp/dataset.xhtml
@@ -832,7 +832,7 @@
                                              oncomplete="if (args &amp;&amp; !args.validationFailed) { PF('setEmbargoConfirmation').hide(); } else { #{DatasetPage.initCurrentEmbargo()}; }"
                             />
                             <p:commandButton value="#{bundle['dataset.embargo.lift.button']}"
-                                             onclick="PF('setEmbargoConfirmation').hide();primeFacesShowModal('removeEmbargoConfirmation', this)"
+                                             onclick="PF('setEmbargoConfirmation').hide();PF('removeEmbargoConfirmation').show()"
                                              rendered="#{DatasetPage.isUserAbleToLiftEmbargo()}" update="setEmbargoPanel"/>
                             <p:commandButton styleClass="btn btn-default"
                                              value="#{bundle.close}"
@@ -859,7 +859,7 @@
                                          update="setEmbargoPanel,:messagePanel, dataset-summary-metadata"
                                          onclick="PF('removeEmbargoConfirmation').hide();"/>
                         <p:commandButton value="#{bundle.cancel}"
-                                         onclick="PF('removeEmbargoConfirmation').hide();primeFacesShowModal('setEmbargoConfirmation', this);"
+                                         onclick="PF('removeEmbargoConfirmation').hide();PF('setEmbargoConfirmation').show();"
                                          type="button"/>
                     </div>
                 </p:dialog>
@@ -912,7 +912,7 @@
                                              rendered="#{empty(DatasetPage.privateUrl)}" />
                             <p:commandButton value="#{bundle['dataset.privateurl.disablePrivateUrl']}"
                                              action="#{DatasetPage.setPrivateUrlJustCreatedToFalse()}"
-                                             onclick="PF('privateUrlConfirmation').hide();primeFacesShowModal('disablePrivateUrlConfirmation', this)"
+                                             onclick="PF('privateUrlConfirmation').hide();PF('disablePrivateUrlConfirmation').show()"
                                              rendered="#{!empty(DatasetPage.privateUrl)}" update="privateUrlPanel, staticMessagesPanel"/>
                             <p:commandButton styleClass="btn btn-default" value="#{bundle.close}"
                                              onclick="PF('privateUrlConfirmation').hide();"
@@ -931,7 +931,7 @@
                                          update="privateUrlPanel staticMessagesPanel, :messagePanel"
                                          onclick="PF('disablePrivateUrlConfirmation').hide();"/>
                         <p:commandButton value="#{bundle.cancel}"
-                                         onclick="PF('disablePrivateUrlConfirmation').hide();primeFacesShowModal('privateUrlConfirmation', this);"
+                                         onclick="PF('disablePrivateUrlConfirmation').hide();PF('privateUrlConfirmation').show();"
                                          type="button"/>
                     </div>
                 </p:dialog>
@@ -943,7 +943,7 @@
                             <h:outputFormat value="#{bundle['dataverse.link.dataset.choose']}" escape="false">
                                 <o:param>
                                     <p:commandLink value="#{installationConfig.supportTeamName}"
-                                                   oncomplete="PF('linkDatasetForm').hide();primeFacesShowModal('contactForm', this)"
+                                                   oncomplete="PF('linkDatasetForm').hide();PF('contactForm').show()"
                                                    update=":contactDialog"
                                                    actionListener="#{sendFeedbackDialog.initUserInput}">
                                         <f:setPropertyActionListener target="#{sendFeedbackDialog.messageSubject}"

--- a/dataverse-webapp/src/main/webapp/harvestclients.xhtml
+++ b/dataverse-webapp/src/main/webapp/harvestclients.xhtml
@@ -273,7 +273,7 @@
                                         <p:commandLink type="button" rendered="#{!harvestingClientsPage.initialSettingsValidated}"
                                                         id="validateInitialSettingsBtn"
                                                         styleClass="btn btn-default"
-                                                        oncomplete="primeFacesShowModal('newHarvestingClientForm', this);"
+                                                        oncomplete="PF('newHarvestingClientForm').show();"
                                                         update=":harvestingClientsForm:newHarvestingClientDialog"
                                                         action="#{harvestingClientsPage.validateInitialSettings()}">
                                             <span class="glyphicon glyphicon-menu-right"/> #{bundle.next}
@@ -353,7 +353,7 @@
                                                         id="createStepTwoPrevious"
                                                         styleClass="btn btn-default"
                                                         update=":harvestingClientsForm:newHarvestingClientDialog"
-                                                        oncomplete="primeFacesShowModal('newHarvestingClientForm', this);"
+                                                        oncomplete="PF('newHarvestingClientForm').show();"
                                                         action="#{harvestingClientsPage.backToStepOne()}">
                                             <span class="glyphicon glyphicon-menu-left"/> #{bundle.previous}
                                         </p:commandLink>
@@ -449,7 +449,7 @@
                                                         id="createStepThreePrevious"
                                                         styleClass="btn btn-default"
                                                         update=":harvestingClientsForm:newHarvestingClientDialog"
-                                                        oncomplete="primeFacesShowModal('newHarvestingClientForm', this);"
+                                                        oncomplete="PF('newHarvestingClientForm').show();"
                                                         action="#{harvestingClientsPage.backToStepTwo()}">
                                             <span class="glyphicon glyphicon-menu-left"/> #{bundle.previous}
                                         </p:commandLink>
@@ -457,7 +457,7 @@
                                                         id="createStepThreeNext"
                                                         styleClass="btn btn-default"
                                                         update=":harvestingClientsForm:newHarvestingClientDialog"
-                                                        oncomplete="primeFacesShowModal('newHarvestingClientForm', this);"
+                                                        oncomplete="PF('newHarvestingClientForm').show();"
                                                         action="#{harvestingClientsPage.goToStepFour()}">
                                             <span class="glyphicon glyphicon-menu-right"/> #{bundle.next}
                                         </p:commandLink>
@@ -510,7 +510,7 @@
                                                         id="createStepFourPrevious"
                                                         styleClass="btn btn-default"
                                                         update=":harvestingClientsForm:newHarvestingClientDialog"
-                                                        oncomplete="primeFacesShowModal('newHarvestingClientForm', this);"
+                                                        oncomplete="PF('newHarvestingClientForm').show();"
                                                         action="#{harvestingClientsPage.backToStepThree()}">
                                             <span class="glyphicon glyphicon-menu-left"/> #{bundle.previous}
                                         </p:commandLink>
@@ -520,7 +520,7 @@
                                                        value="#{bundle['harvestclients.newClientDialog.btn.create']}"
                                                        update="newHarvestingClientDialogContent :messagePanel :harvestingClientsForm clientsTable emptyClientsTable"
                                                        actionListener="#{harvestingClientsPage.createClient}"
-                                                       oncomplete="if (args &amp;&amp; !args.validationFailed) PF('newHarvestingClientForm').hide(); else primeFacesShowModal('newHarvestingClientForm', this);">
+                                                       oncomplete="if (args &amp;&amp; !args.validationFailed) PF('newHarvestingClientForm').hide(); else PF('newHarvestingClientForm').show();">
                                             <f:param name="DO_VALIDATION" value="true"/>
                                         </p:commandLink>
                                         <p:commandLink type="button" styleClass="btn btn-default"
@@ -528,7 +528,7 @@
                                                        value="#{bundle['harvestclients.viewEditDialog.btn.save']}"
                                                        update="newHarvestingClientDialogContent :messagePanel :harvestingClientsForm clientsTable emptyClientsTable"
                                                        actionListener="#{harvestingClientsPage.saveClient}"
-                                                       oncomplete="if (args &amp;&amp; !args.validationFailed) PF('newHarvestingClientForm').hide(); else primeFacesShowModal('newHarvestingClientForm', this);"/>
+                                                       oncomplete="if (args &amp;&amp; !args.validationFailed) PF('newHarvestingClientForm').hide(); else PF('newHarvestingClientForm').show();"/>
                                         <button type="button" jsf:rendered="#{harvestingClientsPage.initialSettingsValidated}" class="btn btn-default" onclick="PF('newHarvestingClientForm').hide()" value="#{bundle.cancel}">#{bundle.cancel}</button>
                                     </div>
                                 </div>

--- a/dataverse-webapp/src/main/webapp/harvestsets.xhtml
+++ b/dataverse-webapp/src/main/webapp/harvestsets.xhtml
@@ -247,7 +247,7 @@
                                         <p:commandLink type="button" 
                                                          id="validateSetQueryBtn"
                                                          styleClass="btn btn-default"
-                                                         oncomplete="primeFacesShowModal('newOAISetForm', this);"
+                                                         oncomplete="PF('newOAISetForm').show();"
                                                          update=":harvestingSetsForm:newOAISetDialog"
                                                          action="#{harvestingSetsPage.validateSetQuery()}">
                                             <span class="glyphicon glyphicon-menu-right"/> #{bundle.next}
@@ -302,7 +302,7 @@
                                                         id="backToQuery"
                                                         styleClass="btn btn-default"
                                                         update=":harvestingSetsForm:newOAISetDialog"
-                                                        oncomplete="primeFacesShowModal('newOAISetForm', this);"
+                                                        oncomplete="PF('newOAISetForm').show();"
                                                         action="#{harvestingSetsPage.backToQuery()}">
                                             <span class="glyphicon glyphicon-menu-left"/> #{bundle.previous}
                                             </p:commandLink>
@@ -311,7 +311,7 @@
                                                            value="#{bundle['harvestserver.newSetDialog.btn.create']}"
                                                            update="newOAISetDialogContent :messagePanel :harvestingSetsForm setsTable emptySetsTable"
                                                            actionListener="#{harvestingSetsPage.createSet}"
-                                                           oncomplete="if (args &amp;&amp; !args.validationFailed) PF('newOAISetForm').hide(); else primeFacesShowModal('newOAISetForm', this);">
+                                                           oncomplete="if (args &amp;&amp; !args.validationFailed) PF('newOAISetForm').hide(); else PF('newOAISetForm').show();">
                                                 <f:param name="DO_VALIDATION" value="true"/>
                                             </p:commandLink>
                                             <p:commandLink type="button" styleClass="btn btn-default"
@@ -319,7 +319,7 @@
                                                            value="#{bundle['harvestserver.viewEditDialog.btn.save']}"
                                                            update="newOAISetDialogContent :messagePanel :harvestingSetsForm setsTable emptySetsTable"
                                                            actionListener="#{harvestingSetsPage.saveSet}"
-                                                           oncomplete="if (args &amp;&amp; !args.validationFailed) PF('newOAISetForm').hide(); else primeFacesShowModal('newOAISetForm', this);"/>
+                                                           oncomplete="if (args &amp;&amp; !args.validationFailed) PF('newOAISetForm').hide(); else PF('newOAISetForm').show();"/>
                                             <button type="button" jsf:rendered="#{harvestingSetsPage.setQueryValidated}" class="btn btn-default" onclick="PF('newOAISetForm').hide()" value="#{bundle.cancel}">#{bundle.cancel}</button>
                                         </div>
                                     </div>

--- a/dataverse-webapp/src/main/webapp/permissions-manage-files.xhtml
+++ b/dataverse-webapp/src/main/webapp/permissions-manage-files.xhtml
@@ -239,7 +239,7 @@
                         </div>
                         <div class="button-block">
                             <p:commandLink type="button" styleClass="btn btn-default"
-                                           update="userGroups restrictedFiles @([id$=Messages])" onclick="primeFacesShowModal('confirmation', this)">
+                                           update="userGroups restrictedFiles @([id$=Messages])" onclick="PF('confirmation').show()">
                                 <span class="glyphicon glyphicon-remove"/>
                                 <h:outputText value="#{bundle['dataverse.permissionsFiles.viewRemoveDialog.removeBtn']}"/>
                             </p:commandLink>

--- a/dataverse-webapp/src/main/webapp/provenance-popups-fragment.xhtml
+++ b/dataverse-webapp/src/main/webapp/provenance-popups-fragment.xhtml
@@ -152,7 +152,7 @@
                                  value="#{bundle.continue}"
                                  disabled="#{provPopupFragmentBean.isDataFilePublishedWithDraftRendering() and !provPopupFragmentBean.isDatasetInDraftRendering()}"
                                  update="provPopupOutput,assignMessages,confirmProvenancePopup"
-                                 oncomplete="if (args &amp;&amp; !args.validationFailed) { PF('editProvenancePopup').hide();PF('confirmProvenancePopup'); }" />
+                                 oncomplete="if (args &amp;&amp; !args.validationFailed) { PF('editProvenancePopup').hide();PF('confirmProvenancePopup').show(); }" />
 
                 <p:commandButton id="editProvenancePopupCancelButton" value="#{bundle.cancel}"
                                  update="provPopupOutput,assignMessages,confirmProvenancePopup"

--- a/dataverse-webapp/src/main/webapp/provenance-popups-fragment.xhtml
+++ b/dataverse-webapp/src/main/webapp/provenance-popups-fragment.xhtml
@@ -152,7 +152,7 @@
                                  value="#{bundle.continue}"
                                  disabled="#{provPopupFragmentBean.isDataFilePublishedWithDraftRendering() and !provPopupFragmentBean.isDatasetInDraftRendering()}"
                                  update="provPopupOutput,assignMessages,confirmProvenancePopup"
-                                 oncomplete="if (args &amp;&amp; !args.validationFailed) { PF('editProvenancePopup').hide();primeFacesShowModal('confirmProvenancePopup', this); }" />
+                                 oncomplete="if (args &amp;&amp; !args.validationFailed) { PF('editProvenancePopup').hide();PF('confirmProvenancePopup'); }" />
 
                 <p:commandButton id="editProvenancePopupCancelButton" value="#{bundle.cancel}"
                                  update="provPopupOutput,assignMessages,confirmProvenancePopup"

--- a/dataverse-webapp/src/main/webapp/resources/js/dv_rebind_bootstrap_ui.js
+++ b/dataverse-webapp/src/main/webapp/resources/js/dv_rebind_bootstrap_ui.js
@@ -1260,7 +1260,9 @@ function setFocusReturn(element) {
         targetElement = document.getElementById(element.source);
     }
 
-    targetElement.dataset.returnFocus = true;
+    if (targetElement) {
+        targetElement.dataset.returnFocus = true;
+    }
 }
 function applyFocusReturn() {
     /* Do checks in case something bugs out and there are multiple/none focus return points set */


### PR DESCRIPTION
This was because the multi-step modal navigation is done by invoking the same modal again, which is something I didn't account for. The changes in `dv_rebind_bootstrap_ui.js` should fix the core reason for this issue.

I've also went ahead and changed every (hopefully) "modal within modal" invokation to the old way (`PF('name').show()`). This isn't necessary, but the new invokation (which attempts to set a focus return point) isn't really necessary in these cases either.