### PR TITLE
Closes #2300: Add possibility to display additional logo (superior logo) in header

### DIFF
--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
@@ -567,6 +567,48 @@ public class SettingsServiceBean {
         SiteFullName,
 
         /**
+         * Target link for the "superior logo".
+         * Setting can be postfixed with language code to
+         * obtain path a language-specific link.
+         */
+        SuperiorLogoLink,
+
+        /**
+         * Path to a "superior logo" to be presented in the header.
+         * Setting can be postfixed with language code to
+         * obtain path to a translated logo.
+         */
+        SuperiorLogoPath,
+
+        /**
+         * Path to a compact "superior logo" to be presented in the header.
+         * Setting can be postfixed with language code to
+         * obtain the path to a translated logo.
+         */
+        SuperiorLogoResponsivePath,
+
+        /**
+         * Path to a "superior logo" (high contrast version) to be presented in the header.
+         * Setting can be postfixed with language code to
+         * obtain path to a translated logo.
+         */
+        SuperiorLogoContrastPath,
+
+        /**
+         * Path to a compact "superior logo" (high contrast version) to be presented in the header.
+         * Setting can be postfixed with language code to
+         * obtain the path to a translated logo.
+         */
+        SuperiorLogoContrastResponsivePath,
+
+        /**
+         * Description (alt text) for the "superior logo".
+         * Setting can be postfixed with language code to
+         * obtain translated versions.
+         */
+        SuperiorLogoAlt,
+
+        /**
          * Indicates if antivirus scanner is enabled
          */
         AntivirusScannerEnabled,

--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/util/SystemConfig.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/util/SystemConfig.java
@@ -168,6 +168,34 @@ public class SystemConfig {
         return getLocalizedProperty(Key.SiteFullName, locale);
     }
 
+    public boolean isSuperiorLogoDefined(Locale locale) {
+        return !getLocalizedProperty(Key.SuperiorLogoPath, locale).isEmpty() || !getLocalizedProperty(Key.SuperiorLogoResponsivePath, locale).isEmpty();
+    }
+
+    public String getSuperiorLogoLink(Locale locale) {
+        return getLocalizedProperty(Key.SuperiorLogoLink, locale);
+    }
+
+    public String getSuperiorLogoPath(Locale locale) {
+        return getLocalizedProperty(Key.SuperiorLogoPath, locale);
+    }
+
+    public String getSuperiorLogoResponsivePath(Locale locale) {
+        return getLocalizedProperty(Key.SuperiorLogoResponsivePath, locale);
+    }
+
+    public String getSuperiorLogoContrastPath(Locale locale) {
+        return getLocalizedProperty(Key.SuperiorLogoContrastPath, locale);
+    }
+
+    public String getSuperiorLogoContrastResponsivePath(Locale locale) {
+        return getLocalizedProperty(Key.SuperiorLogoContrastResponsivePath, locale);
+    }
+
+    public String getSuperiorLogoAlt(Locale locale) {
+        return getLocalizedProperty(Key.SuperiorLogoAlt, locale);
+    }
+
     public String getGuidesBaseUrl(Locale locale) {
         String guidesBaseUrl = settingsService.getValueForKey(SettingsServiceBean.Key.GuidesBaseUrl);
         return guidesBaseUrl + "/" + locale;

--- a/dataverse-webapp/src/main/resources/config/dataverse.default.properties
+++ b/dataverse-webapp/src/main/resources/config/dataverse.default.properties
@@ -98,6 +98,19 @@ RserveUser=rserve
 RservePassword=rserve
 RserveTempDir=/tmp/
 
+SuperiorLogoLink=
+SuperiorLogoLink.pl=
+SuperiorLogoPath=
+SuperiorLogoPath.pl=
+SuperiorLogoResponsivePath=
+SuperiorLogoResponsivePath.pl=
+SuperiorLogoContrastPath=
+SuperiorLogoContrastPath.pl=
+SuperiorLogoContrastResponsivePath=
+SuperiorLogoContrastResponsivePath.pl=
+SuperiorLogoAlt=
+SuperiorLogoAlt.pl=
+
 # MaximumEmbargo (in months)
 MaximumEmbargoLength=0
 

--- a/dataverse-webapp/src/main/webapp/dataverse_header.xhtml
+++ b/dataverse-webapp/src/main/webapp/dataverse_header.xhtml
@@ -48,22 +48,44 @@
                     <span class="icon-bar"></span>
                     <span class="icon-bar"></span>
                 </button>
-                <a href="/" class="navbar-brand">
-                    <ui:fragment rendered="#{empty settingsWrapper.getSettingValue(':LogoCustomizationFile')}">
-                        <i id="site-logo" class="icon-dataverse"></i>
-                        <span>
-                            <span id="site-title">
-                                <h:outputText value="#{systemConfig.getSiteName(dataverseSession.locale)}" escape="false"/>
-                            </span>
-                            <span id="site-subtitle">
-                                <h:outputText value="#{systemConfig.getSiteFullName(dataverseSession.locale)}" escape="false"/>
-                            </span>
-                        </span>
+                <div class="logos-container">
+                    <ui:fragment rendered="#{systemConfig.isSuperiorLogoDefined(dataverseSession.locale)}">
+                        <div class="superior-logo-container">
+                            <a href="#{systemConfig.getSuperiorLogoLink(dataverseSession.locale)}" target="_blank" title="#{bundle['opensInNewTab']}" class="superior-logo-link">
+                                <img src="#{resource[systemConfig.getSuperiorLogoPath(dataverseSession.locale)]}"
+                                     jsf:rendered="#{not empty systemConfig.getSuperiorLogoPath(dataverseSession.locale)}" 
+                                     alt="#{systemConfig.getSuperiorLogoAlt(dataverseSession.locale)}" class="superior-logo regular big"></img>
+                                <img src="#{resource[systemConfig.getSuperiorLogoResponsivePath(dataverseSession.locale)]}"
+                                     jsf:rendered="#{not empty systemConfig.getSuperiorLogoResponsivePath(dataverseSession.locale)}" 
+                                     alt="#{systemConfig.getSuperiorLogoAlt(dataverseSession.locale)}" class="superior-logo regular responsive"></img>
+                                <img src="#{resource[systemConfig.getSuperiorLogoContrastPath(dataverseSession.locale)]}"
+                                     jsf:rendered="#{not empty systemConfig.getSuperiorLogoContrastPath(dataverseSession.locale)}"
+                                     alt="#{systemConfig.getSuperiorLogoAlt(dataverseSession.locale)}" class="superior-logo contrast big"></img>
+                                <img src="#{resource[systemConfig.getSuperiorLogoContrastResponsivePath(dataverseSession.locale)]}"
+                                     jsf:rendered="#{not empty systemConfig.getSuperiorLogoContrastResponsivePath(dataverseSession.locale)}"
+                                     alt="#{systemConfig.getSuperiorLogoAlt(dataverseSession.locale)}" class="superior-logo contrast responsive"></img>
+                            </a>
+                        </div>
                     </ui:fragment>
-                    <h:graphicImage rendered="#{!empty settingsWrapper.getSettingValue(':LogoCustomizationFile')}"
-                                    url="#{settingsWrapper.getSettingValue(':LogoCustomizationFile')}"
-                                    styleClass="navbar-brand custom-logo"/>
-                </a>
+                    <div class="main-logo-container">
+                        <a href="/" class="navbar-brand">
+                            <ui:fragment rendered="#{empty settingsWrapper.getSettingValue(':LogoCustomizationFile')}">
+                                <i id="site-logo" class="icon-dataverse"></i>
+                                <span>
+                                    <span id="site-title">
+                                        <h:outputText value="#{systemConfig.getSiteName(dataverseSession.locale)}" escape="false"/>
+                                    </span>
+                                    <span id="site-subtitle">
+                                        <h:outputText value="#{systemConfig.getSiteFullName(dataverseSession.locale)}" escape="false"/>
+                                    </span>
+                                </span>
+                            </ui:fragment>
+                            <h:graphicImage rendered="#{!empty settingsWrapper.getSettingValue(':LogoCustomizationFile')}"
+                                            url="#{settingsWrapper.getSettingValue(':LogoCustomizationFile')}"
+                                            styleClass="navbar-brand custom-logo"/>
+                        </a>
+                    </div>
+                </div>
             </div>
             <div class="collapse navbar-collapse" id="topNavBar">
                 <nav class="pull-right">

--- a/dataverse-webapp/src/main/webapp/resources/vecler/theme-base.scss
+++ b/dataverse-webapp/src/main/webapp/resources/vecler/theme-base.scss
@@ -2089,6 +2089,39 @@ $navbar-height: 102px;
 	}
 }
 
+.logos-container,
+.main-logo-container,
+.superior-logo-container {
+	display: inline-block;
+}
+
+.superior-logo-container {
+	height: $navbar-height;
+	vertical-align: bottom;
+
+	a {
+		height: 100%;
+		display: inline-block;
+	}
+
+	+ .main-logo-container {
+		margin-left: 2rem;
+	}
+}
+
+.main-logo-container {
+	margin-bottom: -0.333em;
+}
+
+.superior-logo {
+	height: 100%;
+}
+
+body.high-contrast-yellow-on-black .superior-logo.regular,
+body:not(.high-contrast-yellow-on-black) .superior-logo.contrast {
+	display: none;
+}
+
 .language-select.dropdown-menu a {
 	padding: 3px 20px;
 	clear: both;


### PR DESCRIPTION
User can define different logo images for the responsive and high contrast versions, as well as different languages. The image that's displayed to the user is chosen via CSS rules (other are set to `display: none;`). Not the most elegant solution, but it works, and it's WCAG compliant as far as I'm aware. Responsive logo is optional.

This commit includes some basic styling, but the exact CSS rules should be defined in extension repos depending on the logo image used. Please note that the breakpoints when (if ever) to switch to responsive are not included here; again, this should be set in extension repos. Making some default breakpoints here and forcing them to be overridden via extensions sounds like a headache.

In this MR I've included a sample set of logos for testing. Extract these to `/dataverse-webapp/src/main/webapp/resources/images/superior-logo/`.

[superior-logo.zip](https://github.com/CeON/dataverse/files/10696185/superior-logo.zip)

Settings to show only the regular logo:

```
SuperiorLogoLink=https://en.uw.edu.pl
SuperiorLogoLink.pl=https://www.uw.edu.pl
SuperiorLogoPath=/images/superior-logo/logo-uw-en.svg
SuperiorLogoPath.pl=/images/superior-logo/logo-uw-pl.svg
SuperiorLogoResponsivePath=
SuperiorLogoResponsivePath.pl=
SuperiorLogoContrastPath=/images/superior-logo/logo-uw-en-contrast.svg
SuperiorLogoContrastPath.pl=/images/superior-logo/logo-uw-pl-contrast.svg
SuperiorLogoContrastResponsivePath=
SuperiorLogoContrastResponsivePath.pl=
SuperiorLogoAlt=Warsaw University logo
SuperiorLogoAlt.pl=Logo Uniwersytetu Warszawskiego
```

Settings to show only the responsive logo:

```
SuperiorLogoLink=https://en.uw.edu.pl
SuperiorLogoLink.pl=https://www.uw.edu.pl
SuperiorLogoPath=
SuperiorLogoPath.pl=
SuperiorLogoResponsivePath=/images/superior-logo/logo-uw-en-responsive.svg
SuperiorLogoResponsivePath.pl=/images/superior-logo/logo-uw-pl-responsive.svg
SuperiorLogoContrastPath=
SuperiorLogoContrastPath.pl=
SuperiorLogoContrastResponsivePath=/images/superior-logo/logo-uw-en-contrast-responsive.svg
SuperiorLogoContrastResponsivePath.pl=/images/superior-logo/logo-uw-pl-contrast-responsive.svg
SuperiorLogoAlt=Warsaw University logo
SuperiorLogoAlt.pl=Logo Uniwersytetu Warszawskiego
```