### PR TITLE
Closes #2278 #2307 add dataset: using search: tweak adjustment of column width in prompt table

### DIFF
--- a/dataverse-webapp/src/main/webapp/dataverse_header.xhtml
+++ b/dataverse-webapp/src/main/webapp/dataverse_header.xhtml
@@ -500,7 +500,7 @@
                                         placeholder="#{bundle['add.dataset.dialog.lookup.placeholder']}"
                                         minQueryLength="3" queryDelay="1000" size="50"
                                         completeMethod="#{CreateDatasetDialog.fetchLookupData}"
-                                        panelStyleClass="DropdownPopupPanel"
+                                        panelStyleClass="DropdownPopupPanel autocomplete-panel-maxwidth"
                                         required="#{CreateDatasetDialog.selectedMode eq Mode.LOOKUP}"
                                         requiredMessage="#{bundle['add.dataset.dialog.lookup.required']}"
                                         disabled="#{CreateDatasetDialog.selectedMode ne Mode.LOOKUP}"

--- a/dataverse-webapp/src/main/webapp/resources/vecler/theme-base.scss
+++ b/dataverse-webapp/src/main/webapp/resources/vecler/theme-base.scss
@@ -1345,6 +1345,7 @@ input.fancy-checkbox[type=checkbox] {
 }
 
 .ui-autocomplete-panel {
+	word-break: break-word;
 	border: none;
 	border-radius: 9px;
 
@@ -1380,10 +1381,22 @@ input.fancy-checkbox[type=checkbox] {
 	}
 }
 
-// FIXME: This adresses issue with too wide autocomplete suggestion
-// only for widescreen viewport
-.ui-autocomplete-panel.autocomplete-panel-maxwidth {
-    max-width: 800px;
+@media screen and (max-width: $screen-sm-max) {
+	.ui-autocomplete-panel.autocomplete-panel-maxwidth {
+		max-width: 100vw;
+	}
+}
+
+@media screen and (min-width: $screen-md-min) {
+	.ui-autocomplete-panel.autocomplete-panel-maxwidth {
+		max-width: calc(#{$screen-md-min} * 3 / 4);
+	}
+}
+
+@media screen and (min-width: $screen-lg-min) {
+	.ui-autocomplete-panel.autocomplete-panel-maxwidth {
+		max-width: calc(#{$screen-lg-min} * 3 / 4);
+	}
 }
 
 .ui-autocomplete-emptyMessage {


### PR DESCRIPTION
There wasn't really an easy and elegant way to fix the autocomplete panel width issue. I've decided to implement a width limit and make the text word-breakable. It looked like there was a similar issue somewhere else, so I've decided to use the same class, fixing the `FIXME` along the way.

Aside from that, there didn't seem to be anything wrong with the "Add dataset" modal, so I'm closing this issue as well.

