### PR TITLE
Closes #2276: very long dataset or dataverse name breaks display (if no whitespace present)

### DIFF
--- a/dataverse-webapp/src/main/webapp/resources/vecler/theme-base.scss
+++ b/dataverse-webapp/src/main/webapp/resources/vecler/theme-base.scss
@@ -87,6 +87,7 @@ body {
 	font-family: $font-main;
 	font-size: 15px;
 	color: $main-text-color;
+	word-break: break-word;
 }
 
 h1 {


### PR DESCRIPTION
After some consideration, I've decided to add `word-break: break-word` rule to the `body`. I don't think there is any scenario when we'd want not to break long words when they break layout, and even then, since it's a `body` rule it generally won't override other rules, if any class happens to use other value for `word-break`.
