### PR TITLE
Closes: Fix saml login when dataverse is behind proxy

### DIFF
--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/authorization/providers/saml/SamlUserDataFactory.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/authorization/providers/saml/SamlUserDataFactory.java
@@ -15,7 +15,7 @@ import java.util.stream.Collectors;
 public class SamlUserDataFactory {
     private static final String[] NAME = new String[] {"urn:oid:2.5.4.42", "firstName", "givenName", "cn"};
     private static final String[] SURNAME = new String[] {"urn:oid:2.5.4.4", "lastName", "surname", "sn"};
-    private static final String[] EMAIL = new String[] {"urn:oid:1.2.840.113549.1.9.1", "email", "mail"};
+    private static final String[] EMAIL = new String[] {"urn:oid:1.2.840.113549.1.9.1", "urn:oid:0.9.2342.19200300.100.1.3", "email", "mail"};
 
     // -------------------- LOGIC --------------------
 

--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
@@ -694,7 +694,15 @@ public class SettingsServiceBean {
          * Default value: empty.
          */
         
-        ReindexAfterEmbargoTimerExpression
+        ReindexAfterEmbargoTimerExpression,
+        
+        /**
+         * Wrap http requests with url from SiteUrl property
+         * It is needed when glassfish is behind reverse proxy
+         * for matching url in saml assertions with the server
+         * url
+         */
+        SamlWrapHttpRequestUrl
         ;
 
 

--- a/dataverse-webapp/src/main/resources/config/dataverse.default.properties
+++ b/dataverse-webapp/src/main/resources/config/dataverse.default.properties
@@ -169,3 +169,6 @@ SingleUploadBatchMaxSize=0
 
 # Path for saml service provider properties
 SamlPropertiesPath=
+# Wrap http requests with url from SiteUrl property
+# It is needed when glassfish is behind reverse proxy
+SamlWrapHttpRequestUrl=true


### PR DESCRIPTION
ExternalIdpFirstLoginPage.java - changed the way saml user is obtained. Because this page is SessionScope and it was possible that `newUser` was prepopulated in previous saml login. And new login was taking this prepopulated value instead of a new one