### PR TITLE
Closes #2396: Fix indexing when returning dataset to author

### DIFF
--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/ReturnDatasetToAuthorCommand.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/ReturnDatasetToAuthorCommand.java
@@ -48,7 +48,7 @@ public class ReturnDatasetToAuthorCommand extends AbstractDatasetCommand<Dataset
         updateDatasetUser(ctxt);
         Dataset savedDataset = ctxt.em().merge(dataset);
         ctxt.em().flush();
-        ctxt.engine().submit(new RemoveLockCommand(getRequest(), getDataset(), DatasetLock.Reason.InReview));
+        ctxt.engine().submit(new RemoveLockCommand(getRequest(), savedDataset, DatasetLock.Reason.InReview));
 
         sendNotification(ctxt, savedDataset);
 


### PR DESCRIPTION
We are passing `savedDataset` to `RemoveLockCommand` command to have up to date dataset (without in review lock) passed to `indexDataset` method