### PR TITLE
Closes #2444: Fill author ORCID and ROR citation fields from user profile

### DIFF
--- a/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/user/AuthenticatedUser.java
+++ b/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/user/AuthenticatedUser.java
@@ -264,12 +264,6 @@ public class AuthenticatedUser implements User, Serializable, JpaEntity<Long> {
         return String.format("%s %s %s", getLastName(), getFirstName(), getUserIdentifier());
     }
 
-    public String getOrcidId() {
-        String authProviderId = getAuthenticatedUserLookup().getAuthenticationProviderId();
-        return AuthenticatedUserLookup.ORCID_PROVIDER_ID_PRODUCTION.equals(authProviderId)
-                ? getAuthenticatedUserLookup().getPersistentUserId() : null;
-    }
-
     // -------------------- SETTERS --------------------
 
     public void setDatasetLocks(List<DatasetLock> datasetLocks) {

--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/authorization/providers/oauth2/impl/OrcidOAuth2AP.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/authorization/providers/oauth2/impl/OrcidOAuth2AP.java
@@ -108,7 +108,7 @@ public class OrcidOAuth2AP extends AbstractOAuth2AuthenticationProvider {
             AuthenticatedUserDisplayInfo orgData = getOrganizationalData(userEndpoint, accessToken.getAccessToken(), service);
             parsed.displayInfo.setAffiliation(orgData.getAffiliation());
             parsed.displayInfo.setPosition(orgData.getPosition());
-            parsed.displayInfo.setOrcId(orcidNumber);
+            parsed.displayInfo.setOrcid(orcidNumber);
 
             return new ExternalIdpUserRecord(getId(), orcidNumber,
                                         parsed.username,

--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/authorization/providers/oauth2/impl/OrcidOAuth2AP.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/authorization/providers/oauth2/impl/OrcidOAuth2AP.java
@@ -108,6 +108,7 @@ public class OrcidOAuth2AP extends AbstractOAuth2AuthenticationProvider {
             AuthenticatedUserDisplayInfo orgData = getOrganizationalData(userEndpoint, accessToken.getAccessToken(), service);
             parsed.displayInfo.setAffiliation(orgData.getAffiliation());
             parsed.displayInfo.setPosition(orgData.getPosition());
+            parsed.displayInfo.setOrcId(orcidNumber);
 
             return new ExternalIdpUserRecord(getId(), orcidNumber,
                                         parsed.username,

--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/dataset/UserDataFieldFiller.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/dataset/UserDataFieldFiller.java
@@ -36,8 +36,9 @@ public class UserDataFieldFiller {
 
         String userFullName = user.getLastName() + ", " + user.getFirstName();
         String userAffiliation = user.getAffiliation();
+        String userAffiliationROR = user.getAffiliationROR();
         String userEmail = user.getEmail();
-        String userOrcidId = user.getOrcidId();
+        String userOrcidId = user.getOrcId();
         String todayDate = LocalDate.now(clock).format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
 
         for (DatasetField dsf : datasetFields) {
@@ -69,6 +70,9 @@ public class UserDataFieldFiller {
                         }
                         if (subField.getTypeName().equals(DatasetFieldConstant.authorAffiliation)) {
                             subField.setFieldValue(userAffiliation);
+                        }
+                        if (subField.getTypeName().equals(DatasetFieldConstant.authorAffiliationIdentifier)) {
+                            subField.setFieldValue(userAffiliationROR);
                         }
                         if (userOrcidId != null) {
                             if (subField.getTypeName().equals(DatasetFieldConstant.authorIdValue)) {

--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/dataset/UserDataFieldFiller.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/dataset/UserDataFieldFiller.java
@@ -38,7 +38,7 @@ public class UserDataFieldFiller {
         String userAffiliation = user.getAffiliation();
         String userAffiliationROR = user.getAffiliationROR();
         String userEmail = user.getEmail();
-        String userOrcidId = user.getOrcId();
+        String userOrcidId = user.getOrcid();
         String todayDate = LocalDate.now(clock).format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
 
         for (DatasetField dsf : datasetFields) {

--- a/dataverse-webapp/src/test/java/edu/harvard/iq/dataverse/dataset/UserDataFieldFillerTest.java
+++ b/dataverse-webapp/src/test/java/edu/harvard/iq/dataverse/dataset/UserDataFieldFillerTest.java
@@ -191,7 +191,7 @@ public class UserDataFieldFillerTest {
     @Test
     public void fillUserDataInDatasetFields__FILL_AUTHOR_WITH_ORCID_AND_ROR() {
         // given
-        user.setOrcId("0000-0001-2345-6789");
+        user.setOrcid("0000-0001-2345-6789");
         user.setAffiliationROR("https://ror.org/04k0tth05");
 
         DatasetFieldType authorIdTypeDatasetFieldType = new DatasetFieldType(DatasetFieldConstant.authorIdType, FieldType.TEXT, false);

--- a/dataverse-webapp/src/test/java/edu/harvard/iq/dataverse/dataset/UserDataFieldFillerTest.java
+++ b/dataverse-webapp/src/test/java/edu/harvard/iq/dataverse/dataset/UserDataFieldFillerTest.java
@@ -189,10 +189,11 @@ public class UserDataFieldFillerTest {
     }
     
     @Test
-    public void fillUserDataInDatasetFields__FILL_AUTHOR_WITH_ORCID() {
+    public void fillUserDataInDatasetFields__FILL_AUTHOR_WITH_ORCID_AND_ROR() {
         // given
-        user.setAuthenticatedUserLookup(new AuthenticatedUserLookup("orcid_id", "orcid"));
-        
+        user.setOrcId("0000-0001-2345-6789");
+        user.setAffiliationROR("https://ror.org/04k0tth05");
+
         DatasetFieldType authorIdTypeDatasetFieldType = new DatasetFieldType(DatasetFieldConstant.authorIdType, FieldType.TEXT, false);
         Mockito.when(fieldService.findByName(DatasetFieldConstant.authorIdType)).thenReturn(authorIdTypeDatasetFieldType);
         
@@ -209,6 +210,7 @@ public class UserDataFieldFillerTest {
         authorType.getChildDatasetFieldTypes().addAll(Lists.newArrayList(
                 new DatasetFieldType(DatasetFieldConstant.authorName, FieldType.TEXT, false),
                 new DatasetFieldType(DatasetFieldConstant.authorAffiliation, FieldType.TEXT, false),
+                new DatasetFieldType(DatasetFieldConstant.authorAffiliationIdentifier, FieldType.TEXT, false),
                 new DatasetFieldType(DatasetFieldConstant.authorIdValue, FieldType.TEXT, false),
                 authorIdType
                 ));
@@ -222,7 +224,7 @@ public class UserDataFieldFillerTest {
         
         // then
         assertEquals(1, datasetFields.size());
-        assertEquals("Doe, John; Aff; orcid_id; ORCID", datasetFields.get(0).getCompoundRawValue());
+        assertEquals("Doe, John; Aff; https://ror.org/04k0tth05; 0000-0001-2345-6789; ORCID", datasetFields.get(0).getCompoundRawValue());
     }
     
     @Test


### PR DESCRIPTION
Identifiers have been added by #2449.

The ORCID field was already populated when using `OrcidOAuth2AP`. I've moved the attachment of the ORCID to the user during the initial registration to keep the ORCID in a common place for all cases.

Issue: #2444