### PR TITLE
Closes #2442: Validate author ORCID in dataset field

### DIFF
--- a/dataverse-persistence/src/main/resources/Bundle_en.properties
+++ b/dataverse-persistence/src/main/resources/Bundle_en.properties
@@ -3049,6 +3049,8 @@ dataset.metadata.inputRenderer.suggestion.ror.otherNames=Other names
 
 ror.invalid.format={0} is wrongly formed.
 ror.invalid.checksum={0} is invalid.
+orcid.invalid.format={0} is wrongly formed.
+orcid.invalid.checksum={0} is invalid.
 
 failed.login.title=Login failed
 failed.login.cause.invalid.data=The data provided by your institution are invalid.

--- a/dataverse-persistence/src/main/resources/Bundle_pl.properties
+++ b/dataverse-persistence/src/main/resources/Bundle_pl.properties
@@ -3000,6 +3000,8 @@ dataset.metadata.inputRenderer.suggestion.ror.otherNames=Inne nazwy
 
 ror.invalid.format=Pole "{0}" nie zawiera poprawnie zbudowanego identyfikatora ROR.
 ror.invalid.checksum=Pole "{0}" nie zawiera prawid\u0142owego identyfikatora ROR.
+orcid.invalid.format=Pole "{0}" nie zawiera poprawnie zbudowanego identyfikatora ORCID.
+orcid.invalid.checksum=Pole "{0}" nie zawiera prawid\u0142owego identyfikatora ORCID.
 
 failed.login.title=Logowanie nieudane
 failed.login.cause.invalid.data=Dane przekazane przez Twoj\u0105 instytucje s\u0105 niepoprawne.

--- a/dataverse-persistence/src/main/resources/db/migration/V73__orcidValidator.sql
+++ b/dataverse-persistence/src/main/resources/db/migration/V73__orcidValidator.sql
@@ -1,0 +1,3 @@
+UPDATE datasetfieldtype
+    SET validation = '[{"name":"orcid_validator","parameters":{"context":["DATASET"], "authorIdentifierScheme": "ORCID"}}]'
+    WHERE name = 'authorIdentifier';

--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/validators/AuthorIdentifierValidator.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/validators/AuthorIdentifierValidator.java
@@ -1,0 +1,46 @@
+package edu.harvard.iq.dataverse.validation.field.validators;
+
+import edu.harvard.iq.dataverse.common.DatasetFieldConstant;
+import edu.harvard.iq.dataverse.persistence.dataset.ValidatableField;
+import edu.harvard.iq.dataverse.validation.field.FieldValidationResult;
+import io.vavr.control.Option;
+
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
+
+/**
+ * Base class for author identifier validators. Implementing validators are expected to be configured with
+ * an `authorIdentifierScheme` parameter indicating for which type of identifier it should be
+ * applied. Validation is omitted for other types.
+ */
+public abstract class AuthorIdentifierValidator extends MultiValueValidatorBase {
+
+    private static final Logger logger = Logger.getLogger(AuthorIdentifierValidator.class.getCanonicalName());
+
+    public static final String IDENTIFIER_SCHEME_PARAM = "authorIdentifierScheme";
+
+    // -------------------- LOGIC --------------------
+
+    @Override
+    public FieldValidationResult validateValue(String value, ValidatableField field, Map<String, Object> params, Map<String, ? extends List<? extends ValidatableField>> fieldIndex) {
+        if (isSelectedIdentifierScheme(field, params)) {
+            return validateIdentifier(value, field, params, fieldIndex);
+        }
+        return FieldValidationResult.ok();
+    }
+
+    protected abstract FieldValidationResult validateIdentifier(String identifier, ValidatableField field, Map<String, Object> params, Map<String, ? extends List<? extends ValidatableField>> fieldIndex);
+
+    // -------------------- PRIVATE ---------------------
+
+    private static boolean isSelectedIdentifierScheme(ValidatableField field, Map<String, Object> params) {
+        return field.getParent()
+                .flatMap(f -> Option.ofOptional(f.getChildren().stream()
+                        .filter(c -> c.getDatasetFieldType().getName().equals(DatasetFieldConstant.authorIdType))
+                        .findFirst()))
+                .map(ValidatableField::getSingleValue)
+                .filter(type -> type.equals(params.get(IDENTIFIER_SCHEME_PARAM)))
+                .isDefined();
+    }
+}

--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/validators/OrcidFieldValidator.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/validators/OrcidFieldValidator.java
@@ -1,0 +1,39 @@
+package edu.harvard.iq.dataverse.validation.field.validators;
+
+import edu.harvard.iq.dataverse.common.BundleUtil;
+import edu.harvard.iq.dataverse.persistence.dataset.ValidatableField;
+import edu.harvard.iq.dataverse.validation.OrcidValidator;
+import edu.harvard.iq.dataverse.validation.field.FieldValidationResult;
+import edu.harvard.iq.dataverse.validation.ValidationResult;
+import org.omnifaces.cdi.Eager;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.util.List;
+import java.util.Map;
+
+@Eager
+@ApplicationScoped
+public class OrcidFieldValidator extends AuthorIdentifierValidator {
+
+    @Inject
+    private OrcidValidator orcidValidator;
+
+    // -------------------- LOGIC --------------------
+
+    @Override
+    public String getName() {
+        return "orcid_validator";
+    }
+
+    @Override
+    protected FieldValidationResult validateIdentifier(String orcid, ValidatableField field, Map<String, Object> params, Map<String, ? extends List<? extends ValidatableField>> fieldIndex) {
+        String fieldName = field.getDatasetFieldType().getDisplayName();
+        ValidationResult result = orcidValidator.validate(orcid);
+        if (result.isOk()) {
+            return FieldValidationResult.ok();
+        } else {
+            return FieldValidationResult.invalid(field, BundleUtil.getStringFromBundle(result.getErrorCode(), fieldName));
+        }
+    }
+}

--- a/dataverse-webapp/src/test/java/edu/harvard/iq/dataverse/validation/field/validators/OrcidFieldValidatorTest.java
+++ b/dataverse-webapp/src/test/java/edu/harvard/iq/dataverse/validation/field/validators/OrcidFieldValidatorTest.java
@@ -1,0 +1,107 @@
+package edu.harvard.iq.dataverse.validation.field.validators;
+
+import com.google.common.collect.ImmutableMap;
+import edu.harvard.iq.dataverse.persistence.dataset.DatasetField;
+import edu.harvard.iq.dataverse.persistence.dataset.DatasetFieldType;
+import edu.harvard.iq.dataverse.validation.OrcidValidator;
+import edu.harvard.iq.dataverse.validation.field.FieldValidationResult;
+import io.vavr.collection.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class OrcidFieldValidatorTest {
+
+    @Mock
+    private OrcidValidator orcidValidator;
+
+    @InjectMocks
+    private OrcidFieldValidator validator;
+
+    @Test
+    public void validateValue() {
+        // given
+        String orcid = "0000-0002-1825-0097";
+        DatasetField identifier = buildDatasetField(orcid, "ORCID");
+        Map<String, Object> params = ImmutableMap.of("authorIdentifierScheme", "ORCID");
+
+        when(orcidValidator.validate(orcid)).thenReturn(FieldValidationResult.ok());
+
+        // when
+        FieldValidationResult result = validator.validateValue(orcid, identifier, params, Collections.emptyMap());
+
+        // then
+        assertThat(result.isOk()).isTrue();
+        assertThat(result.getField()).isNull();
+        assertThat(result.getMessage()).isEmpty();
+    }
+
+    @Test
+    public void validateValue__invalid() {
+        // given
+        String orcid = "INVALID";
+        DatasetField identifierField = buildDatasetField(orcid, "ORCID");
+        Map<String, Object> params = ImmutableMap.of("authorIdentifierScheme", "ORCID");
+
+        when(orcidValidator.validate(orcid)).thenReturn(FieldValidationResult.invalid("INVALID_ORCID"));
+
+        // when
+        FieldValidationResult result = validator.validateValue(orcid, identifierField, params, Collections.emptyMap());
+
+        // then
+        assertThat(result.isOk()).isFalse();
+        assertThat(result.getField()).isEqualTo(identifierField);
+    }
+
+    @Test
+    public void validateValue__non_matching_identifier_type() {
+        // given
+        String isni = "0000000109010190";
+        DatasetField identifier = buildDatasetField(isni, "ISNI");
+        Map<String, Object> params = ImmutableMap.of("authorIdentifierScheme", "ORCID");
+
+        // when
+        FieldValidationResult result = validator.validateValue(isni, identifier, params, Collections.emptyMap());
+
+        // then
+        assertThat(result.isOk()).isTrue();
+        assertThat(result.getField()).isNull();
+        assertThat(result.getMessage()).isEmpty();
+        verify(orcidValidator, never()).validate(isni);
+    }
+
+    // -------------------- PRIVATE ---------------------
+
+    private static DatasetField buildDatasetField(String identifierValue, String identifierType) {
+        DatasetField authorField = new DatasetField();
+        authorField.setDatasetFieldType(new DatasetFieldType());
+        authorField.getDatasetFieldType().setName("author");
+
+        DatasetField identifierScheme = new DatasetField();
+        identifierScheme.setValue(identifierType);
+        identifierScheme.setDatasetFieldType(new DatasetFieldType());
+        identifierScheme.getDatasetFieldType().setName("authorIdentifierScheme");
+        identifierScheme.setDatasetFieldParent(authorField);
+
+        DatasetField identifier = new DatasetField();
+        identifier.setValue(identifierValue);
+        identifier.setDatasetFieldType(new DatasetFieldType());
+        identifier.getDatasetFieldType().setName("authorIdentifier");
+        identifier.setDatasetFieldParent(authorField);
+
+        authorField.setDatasetFieldsChildren(List.of(identifierScheme, identifier).asJava());
+
+        return identifier;
+    }
+}


### PR DESCRIPTION
Adding `AuthorIdentifierValidator` abstract validator which should allow to add subsequent validators depending on the selected `authorIdentifierScheme` (ORCID being the first one). Validators for other schemes (`authorIdentifierScheme` parameter) can be added to the `datasetfieldtype.validation` list.

Issue: #2442 