### PR TITLE
Closes #2468: Clean-up empty working directories during clear step

### DIFF
--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/workflow/step/ClearWorkingDirWorkflowStep.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/workflow/step/ClearWorkingDirWorkflowStep.java
@@ -3,13 +3,18 @@ package edu.harvard.iq.dataverse.workflow.step;
 import edu.harvard.iq.dataverse.workflow.execution.WorkflowExecutionStepContext;
 import edu.harvard.iq.dataverse.workflow.step.WorkflowStepResult.Source;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.file.PathUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Map;
 
 public class ClearWorkingDirWorkflowStep extends FilesystemAccessingWorkflowStep {
 
     public static final String STEP_ID = "clear-working-directory";
+    private static final Logger logger = LoggerFactory.getLogger(ClearWorkingDirWorkflowStep.class);
 
     // -------------------- CONSTRUCTORS --------------------
 
@@ -22,6 +27,9 @@ public class ClearWorkingDirWorkflowStep extends FilesystemAccessingWorkflowStep
     @Override
     protected Source runInternal(WorkflowExecutionStepContext context, Path workDir) throws Exception {
         FileUtils.deleteDirectory(workDir.toFile());
+        getBaseWorkDir()
+                .filter(workDir::startsWith)
+                .ifPresent(baseWorkDir -> cleanupEmptyParentsUpTo(baseWorkDir, workDir));
         return Success.successWith();
     }
 
@@ -32,5 +40,19 @@ public class ClearWorkingDirWorkflowStep extends FilesystemAccessingWorkflowStep
 
     @Override
     public void rollback(WorkflowExecutionStepContext context, Failure reason) {
+    }
+
+    // -------------------- PRIVATE --------------------
+
+    private void cleanupEmptyParentsUpTo(Path baseWorkDir, Path child) {
+        Path parent = child.getParent();
+        try {
+            if (parent.startsWith(baseWorkDir) && !parent.equals(baseWorkDir) && PathUtils.isEmptyDirectory(parent)) {
+                PathUtils.deleteDirectory(parent);
+                cleanupEmptyParentsUpTo(baseWorkDir, parent);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Couldn't clean-up directory: " + parent, e);
+        }
     }
 }

--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/workflow/step/FilesystemAccessingWorkflowStep.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/workflow/step/FilesystemAccessingWorkflowStep.java
@@ -131,6 +131,10 @@ public abstract class FilesystemAccessingWorkflowStep implements WorkflowStep {
         }
     }
 
+    public Optional<Path> getBaseWorkDir() {
+        return Optional.ofNullable(baseWorkDirParam).map(Paths::get);
+    }
+
     protected Optional<Path> resolveWorkDirFromOutputParams(WorkflowExecutionStep step) {
         return Optional.ofNullable(step.getOutputParams().get(WORK_DIR_PARAM_NAME)).map(Paths::get);
     }
@@ -144,6 +148,9 @@ public abstract class FilesystemAccessingWorkflowStep implements WorkflowStep {
     private HashMap<String, String> defaultOutputParams() {
         HashMap<String, String> outputParams = new HashMap<>();
         outputParams.put(WORK_DIR_PARAM_NAME, workDir.toAbsolutePath().toString());
+        if (baseWorkDirParam != null) {
+            outputParams.put(BASE_WORK_DIR_PARAM_NAME, Paths.get(baseWorkDirParam).toAbsolutePath().toString());
+        }
         return outputParams;
     }
 }


### PR DESCRIPTION
The clear step cleans now empty directory path located within the base directory of the workflow.

To discuss: Should we also delete directories which contain only empty directories?

Issue: #2468 