### PR TITLE
Externalized cookie session configuration

### DIFF
--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/DataverseSessionConfigListener.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/DataverseSessionConfigListener.java
@@ -1,27 +1,42 @@
 package edu.harvard.iq.dataverse;
 
+import edu.harvard.iq.dataverse.util.SystemConfig;
+
+import javax.inject.Inject;
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 import javax.servlet.annotation.WebListener;
 import javax.servlet.SessionCookieConfig;
+import java.util.logging.Logger;
 
 @WebListener
 public class DataverseSessionConfigListener implements ServletContextListener {
+    private final SystemConfig systemConfig;
+    private static final Logger logger = Logger.getLogger(DataverseSessionConfigListener.class.getCanonicalName());
+
+    @Inject
+    public DataverseSessionConfigListener(SystemConfig systemConfig) {
+        this.systemConfig = systemConfig;
+    }
 
     @Override
     public void contextInitialized(ServletContextEvent sce) {
+        logger.info("Initializing session cookie configuration");
         SessionCookieConfig sessionCookieConfig = sce.getServletContext().getSessionCookieConfig();
-        String cookieName = System.getenv("COOKIE_NAME");
-        if (cookieName != null) {
+        String cookieName = systemConfig.getCookieName();
+        if (cookieName != null && !cookieName.isEmpty()) {
+            logger.info("Setting session cookie name to " + cookieName);
             sessionCookieConfig.setName(cookieName);
         }
-        String cookieDomain = System.getenv("COOKIE_DOMAIN");
-        if (cookieDomain != null) {
+        String cookieDomain = systemConfig.getCookieDomain();
+        if (cookieDomain != null && !cookieName.isEmpty()) {
+            logger.info("Setting session cookie domain to " + cookieDomain);
             sessionCookieConfig.setDomain(cookieDomain);
         }
-        String cookieSecure = System.getenv("COOKIE_SECURE");
-        if (cookieSecure != null) {
-            sessionCookieConfig.setSecure(Boolean.parseBoolean(cookieSecure));
+        Boolean cookieSecure = systemConfig.getCookieSecure();
+        if (cookieSecure != null && !cookieName.isEmpty()) {
+            logger.info("Setting session cookie secure to " + cookieSecure);
+            sessionCookieConfig.setSecure(cookieSecure);
         }
     }
 

--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/DataverseSessionConfigListener.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/DataverseSessionConfigListener.java
@@ -1,0 +1,32 @@
+package edu.harvard.iq.dataverse;
+
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+import javax.servlet.annotation.WebListener;
+import javax.servlet.SessionCookieConfig;
+
+@WebListener
+public class DataverseSessionConfigListener implements ServletContextListener {
+
+    @Override
+    public void contextInitialized(ServletContextEvent sce) {
+        SessionCookieConfig sessionCookieConfig = sce.getServletContext().getSessionCookieConfig();
+        String cookieName = System.getenv("COOKIE_NAME");
+        if (cookieName != null) {
+            sessionCookieConfig.setName(cookieName);
+        }
+        String cookieDomain = System.getenv("COOKIE_DOMAIN");
+        if (cookieDomain != null) {
+            sessionCookieConfig.setDomain(cookieDomain);
+        }
+        String cookieSecure = System.getenv("COOKIE_SECURE");
+        if (cookieSecure != null) {
+            sessionCookieConfig.setSecure(Boolean.parseBoolean(cookieSecure));
+        }
+    }
+
+    @Override
+    public void contextDestroyed(ServletContextEvent servletContextEvent) {
+        // nothing to do here
+    }
+}

--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
@@ -737,7 +737,11 @@ public class SettingsServiceBean {
          * Additional (localized) text to show at the top
          * of the "Add dataset" modal window.
          */
-        SelectDataverseInfo
+        SelectDataverseInfo,
+
+        CookieDomain,
+        CookieName,
+        CookieSecure,
         ;
 
 

--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/util/SystemConfig.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/util/SystemConfig.java
@@ -278,6 +278,18 @@ public class SystemConfig {
         return getLocalizedProperty(SettingsServiceBean.Key.SelectDataverseInfo, locale);
     }
 
+    public String getCookieName() {
+        return getLocalizedProperty(Key.CookieName, Locale.ENGLISH);
+    }
+
+    public String getCookieDomain() {
+        return getLocalizedProperty(Key.CookieDomain, Locale.ENGLISH);
+    }
+
+    public Boolean getCookieSecure() {
+        return Boolean.parseBoolean(getLocalizedProperty(Key.CookieSecure, Locale.ENGLISH));
+    }
+
     public long getTabularIngestSizeLimit() {
         // This method will return the blanket ingestable size limit, if
         // set on the system. I.e., the universal limit that applies to all

--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/util/SystemConfig.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/util/SystemConfig.java
@@ -279,15 +279,15 @@ public class SystemConfig {
     }
 
     public String getCookieName() {
-        return getLocalizedProperty(Key.CookieName, Locale.ENGLISH);
+        return settingsService.getValueForKey(Key.CookieName);
     }
 
     public String getCookieDomain() {
-        return getLocalizedProperty(Key.CookieDomain, Locale.ENGLISH);
+        return settingsService.getValueForKey(Key.CookieDomain);
     }
 
     public Boolean getCookieSecure() {
-        return Boolean.parseBoolean(getLocalizedProperty(Key.CookieSecure, Locale.ENGLISH));
+        return Boolean.parseBoolean(settingsService.getValueForKey(Key.CookieSecure));
     }
 
     public long getTabularIngestSizeLimit() {

--- a/dataverse-webapp/src/main/resources/config/dataverse.default.properties
+++ b/dataverse-webapp/src/main/resources/config/dataverse.default.properties
@@ -185,3 +185,10 @@ LoginInfo=
 # Select dataverse info with locale suffixes (eg. SelectDataverseInfo.pl; default english without suffix)
 # holds the text which will be shown on top of the "Add dataset" dialog
 SelectDataverseInfo=
+
+# Externalised session cookie configuration.
+# see: dataverse-webapp/src/main/webapp/WEB-INF/web.xml
+# see: dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/DataverseSessionConfigListener.java
+#CookieDomain=.fairbirds.com
+#CookieName=FAIRBIRDSSESSIONID
+#CookieSecure=true

--- a/dataverse-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/dataverse-webapp/src/main/webapp/WEB-INF/web.xml
@@ -175,6 +175,10 @@
         <!-- Uncomment the line below to disble `;jsessionid=` in URLs -->
 	    <tracking-mode>COOKIE</tracking-mode>
     </session-config>
+    <!-- Listener to override defaults with environment variables -->
+    <listener>
+        <listener-class>edu.harvard.iq.dataverse.DataverseSessionConfigListener</listener-class>
+    </listener>
     <!-- web fonts -->
     <mime-mapping>
         <extension>eot</extension>

--- a/dataverse-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/dataverse-webapp/src/main/webapp/WEB-INF/web.xml
@@ -175,7 +175,7 @@
         <!-- Uncomment the line below to disble `;jsessionid=` in URLs -->
 	    <tracking-mode>COOKIE</tracking-mode>
     </session-config>
-    <!-- Listener to override defaults with environment variables -->
+    <!-- Listener to override defaults values -->
     <listener>
         <listener-class>edu.harvard.iq.dataverse.DataverseSessionConfigListener</listener-class>
     </listener>


### PR DESCRIPTION
[dkorbel](https://github.com/dkorbel)
dkorbel commented [7 minutes ago](https://github.com/IQSS/dataverse/pull/10779#issue-2473448985)
This PR deliver feature to externalize JSESSIONID cookie configuration:
It enables you to use session cookie in subdomains.

To use it, you need to add application properties.