### PR TITLE
Closes: Fieldset validator for releated fields

### DIFF
--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/validators/RequiredByValueDependantFieldValidator.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/validators/RequiredByValueDependantFieldValidator.java
@@ -1,0 +1,61 @@
+package edu.harvard.iq.dataverse.validation.field.validators;
+
+import edu.harvard.iq.dataverse.common.BundleUtil;
+import edu.harvard.iq.dataverse.persistence.dataset.ValidatableField;
+import edu.harvard.iq.dataverse.validation.field.FieldValidationResult;
+import org.apache.commons.lang3.StringUtils;
+import org.omnifaces.cdi.Eager;
+
+import javax.enterprise.context.ApplicationScoped;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Validates that a field that depends on another field value has a value.
+ * F.e.: "CustomerType" can be "Individual" or "Company".
+ * If "CustomerType" is "Company" then "Company Name" field is required.
+ * If "CustomerType" is "Individual" then "First Name" and "Last Name" fields
+ * are required.
+ * For usage, you need to declare validator on each dependant field, like:
+ * "First Name", "Last Name", "Company Name" as follows:
+ * <pre>
+ *  [{"name":"required_by_value_dependant","parameters":{"context":["DATASET"], "runOnEmpty":"true", "dependantField": "customerType", "dependantFieldValue": "individual"}}]
+ *  [{"name":"required_by_value_dependant","parameters":{"context":["DATASET"], "runOnEmpty":"true", "dependantField": "customerType", "dependantFieldValue": "company"}}]
+ * </pre>
+ *
+ * @see edu.harvard.iq.dataverse.persistence.dataset.ValidatableField
+ * @see edu.harvard.iq.dataverse.persistence.dataset.DatasetField
+ * @see edu.harvard.iq.dataverse.persistence.dataset.DatasetFieldType#getValidation()
+ *
+ * @author Filipe Dias Lewandowski, Krzysztof Mądry, Daniel Korbel, Sylwester Niewczas
+ */
+@Eager
+@ApplicationScoped
+public class RequiredByValueDependantFieldValidator extends DependantFieldValidator {
+    public static final String DEPENDANT_FIELD_VALUE_PARAM = "dependantFieldValue";
+
+    // -------------------- LOGIC --------------------
+
+    @Override
+    public String getName() {
+        return "required_by_value_dependant";
+    }
+
+    @Override
+    protected FieldValidationResult validateWithDependantField(
+            ValidatableField field,
+            ValidatableField dependantField,
+            Map<String, Object> params,
+            Map<String, ? extends List<? extends ValidatableField>> fieldIndex) {
+
+        if (dependantField.getValidatableValues().stream().anyMatch(actualValue ->
+                StringUtils.equalsIgnoreCase(actualValue, (String) params.get(DEPENDANT_FIELD_VALUE_PARAM)))) {
+            if (field.getValidatableValues().stream().noneMatch(StringUtils::isNotBlank)) {
+                return FieldValidationResult.invalid(field, BundleUtil.getStringFromBundle("isrequired",
+                        field.getDatasetFieldType().getDisplayName()));
+            }
+            return FieldValidationResult.ok();
+        }
+        return FieldValidationResult.ok();
+    }
+}

--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/validators/RequiredDependantFieldValidator.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/validators/RequiredDependantFieldValidator.java
@@ -10,6 +10,27 @@ import javax.enterprise.context.ApplicationScoped;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Validates that a field that depends on another field has a value.
+ * It works on pair of fields. If one of them is filled, then the other one is required.
+ * It can work in one direction and in both directions.
+ * F.e. "OriginTitle" field depends on "OtherTitle" field.
+ * If "OtherTitle" field is filled, then "OriginTitle" field is required.
+ * It can also be opposite to it:
+ * F.e. "OtherTitle" field depends on "OriginTitle" field. If "OriginTitle" field
+ * is filled, then "OtherTitle" field is required.
+ * To use this validator you need to set up `dependantField` parameter in your
+ * DatasetFieldType validator configuration
+ * <pre>
+ * F.e. `{"name":"required_dependant","parameters":{"context":["DATASET"], "dependantField": "OriginTitle"}}`
+ * F.e. `{"name":"required_dependant","parameters":{"context":["DATASET"], "dependantField": "OtherTitle"}}`
+ * </pre>
+ * @see edu.harvard.iq.dataverse.persistence.dataset.ValidatableField
+ * @see edu.harvard.iq.dataverse.persistence.dataset.DatasetField
+ * @see edu.harvard.iq.dataverse.persistence.dataset.DatasetFieldType#getValidation()
+ *
+ * @author Filipe Dias Lewandowski, Krzysztof Mądry, Daniel Korbel, Sylwester Niewczas
+ */
 @Eager
 @ApplicationScoped
 public class RequiredDependantFieldValidator extends DependantFieldValidator {
@@ -22,7 +43,12 @@ public class RequiredDependantFieldValidator extends DependantFieldValidator {
     }
 
     @Override
-    protected FieldValidationResult validateWithDependantField(ValidatableField field, ValidatableField dependantField, Map<String, Object> params, Map<String, ? extends List<? extends ValidatableField>> fieldIndex) {
+    protected FieldValidationResult validateWithDependantField(
+            ValidatableField field,
+            ValidatableField dependantField,
+            Map<String, Object> params,
+            Map<String, ? extends List<? extends ValidatableField>> fieldIndex) {
+
         if (dependantField.getValidatableValues().stream().noneMatch(StringUtils::isNotBlank)) {
             return FieldValidationResult.invalid(dependantField, BundleUtil.getStringFromBundle("isrequired",
                     dependantField.getDatasetFieldType().getDisplayName()));

--- a/dataverse-webapp/src/test/java/edu/harvard/iq/dataverse/validation/field/validators/RequiredByValueDependantFieldValidatorTest.java
+++ b/dataverse-webapp/src/test/java/edu/harvard/iq/dataverse/validation/field/validators/RequiredByValueDependantFieldValidatorTest.java
@@ -1,0 +1,113 @@
+package edu.harvard.iq.dataverse.validation.field.validators;
+
+import edu.harvard.iq.dataverse.common.BundleUtil;
+import edu.harvard.iq.dataverse.persistence.dataset.DatasetFieldType;
+import edu.harvard.iq.dataverse.persistence.dataset.ValidatableField;
+import edu.harvard.iq.dataverse.validation.field.FieldValidationResult;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * @author Filipe Dias Lewandowski, Krzysztof Mądry, Daniel Korbel, Sylwester Niewczas
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class RequiredByValueDependantFieldValidatorTest {
+
+    private RequiredByValueDependantFieldValidator validator;
+
+    @Mock
+    private ValidatableField field;
+
+    @Mock
+    private ValidatableField dependantField;
+
+    @Mock
+    private DatasetFieldType datasetFieldType;
+
+    @Before
+    public void setUp() {
+        validator = new RequiredByValueDependantFieldValidator();
+        when(field.getDatasetFieldType()).thenReturn(datasetFieldType);
+        when(datasetFieldType.getDisplayName()).thenReturn("Field Display Name");
+    }
+
+    @Test
+    public void testValidateWithDependantField_InvalidWhenCompanyWithoutCompanyName() {
+        // Given
+        Map<String, Object> params = new HashMap<>();
+        params.put(RequiredByValueDependantFieldValidator.DEPENDANT_FIELD_VALUE_PARAM, "company");
+
+        when(dependantField.getValidatableValues()).thenReturn(Collections.singletonList("company"));
+        when(field.getValidatableValues()).thenReturn(Collections.singletonList(""));
+
+        try (MockedStatic<BundleUtil> bundleUtilMock = mockStatic(BundleUtil.class)) {
+            bundleUtilMock.when(() -> BundleUtil.getStringFromBundle("isrequired", "Field Display Name"))
+                    .thenReturn("Field Display Name is required");
+
+            // When
+            FieldValidationResult result = validator.validateWithDependantField(field, dependantField, params, Collections.emptyMap());
+
+            // Then
+            assertFalse(result.isOk());
+        }
+    }
+
+    @Test
+    public void testValidateWithDependantField_ValidWhenCompanyWithCompanyName() {
+        // Given
+        Map<String, Object> params = new HashMap<>();
+        params.put(RequiredByValueDependantFieldValidator.DEPENDANT_FIELD_VALUE_PARAM, "company");
+
+        when(dependantField.getValidatableValues()).thenReturn(Collections.singletonList("company"));
+        when(field.getValidatableValues()).thenReturn(Collections.singletonList("Some Company Name"));
+
+        // When
+        FieldValidationResult result = validator.validateWithDependantField(field, dependantField, params, Collections.emptyMap());
+
+        // Then
+        assertTrue(result.isOk());
+    }
+
+    @Test
+    public void testValidateWithDependantField_ValidWhenIndividualWithFirstAndLastName() {
+        // Given
+        Map<String, Object> params = new HashMap<>();
+        params.put(RequiredByValueDependantFieldValidator.DEPENDANT_FIELD_VALUE_PARAM, "individual");
+
+        when(dependantField.getValidatableValues()).thenReturn(Collections.singletonList("individual"));
+        when(field.getValidatableValues()).thenReturn(Collections.singletonList("John"));
+
+        // When
+        FieldValidationResult result = validator.validateWithDependantField(field, dependantField, params, Collections.emptyMap());
+
+        // Then
+        assertTrue(result.isOk());
+    }
+
+    @Test
+    public void testValidateWithDependantField_ValidWhenNotMatchingDependantFieldValue() {
+        // Given
+        Map<String, Object> params = new HashMap<>();
+        params.put(RequiredByValueDependantFieldValidator.DEPENDANT_FIELD_VALUE_PARAM, "individual");
+        when(dependantField.getValidatableValues()).thenReturn(Collections.singletonList("company"));
+        // When
+        FieldValidationResult result = validator.validateWithDependantField(field, dependantField, params, Collections.emptyMap());
+
+        // Then
+        assertTrue(result.isOk());
+    }
+}

--- a/dataverse-webapp/src/test/java/edu/harvard/iq/dataverse/validation/field/validators/RequiredDependantFieldValidatorTest.java
+++ b/dataverse-webapp/src/test/java/edu/harvard/iq/dataverse/validation/field/validators/RequiredDependantFieldValidatorTest.java
@@ -12,6 +12,9 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * @author Filipe Dias Lewandowski, Krzysztof Mądry, Daniel Korbel, Sylwester Niewczas
+ */
 public class RequiredDependantFieldValidatorTest {
 
     private final RequiredDependantFieldValidator validator = new RequiredDependantFieldValidator();

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <spring.version>4.1.9.RELEASE</spring.version>
 
         <junit.version>5.5.2</junit.version>
-        <mockito.version>2.22.0</mockito.version>
+        <mockito.version>3.12.4</mockito.version>
         <!--
         Jacoco 0.8.2 seems to break Netbeans code coverage integration so we'll use 0.8.1 instead.
         See https://github.com/jacoco/jacoco/issues/772 for discussion of how the XML changed.
@@ -710,6 +710,12 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
             <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
**What this PR does / why we need it**:
This feature adds additional validator that work for multiply fields.

This is a new validator that works for a set of fields that are related to each other. Based on the value of one field, it can validate a subset of fields for that value.

For example, in a purchase contact information form, we need different values for a company and a person. So, we add a 'select' field where we can choose whose details we need: either a person or a company. Then, we add fields for both individuals and companies. The validator will only validate the fields indicated by the first 'select' field.

**Which issue(s) this PR closes**:
It comes from Fairbirds team.


Example usage:
#datasetField	name	title	validation
	responsible_party	Responsible party	"[{""name"":""standard_input""}]"
	responsible_party_type	Type	"[{""name"":""standard_input""}]"
	responsible_party_person_first_name	First name	"[{""name"":""required_by_value_dependant"",""parameters"":{""context"":[""DATASET""], ""runOnEmpty"":""true"", ""dependantField"": ""responsible_party_type"", ""dependantFieldValue"": ""person""}}]"
	responsible_party_person_surnames	Surname(s)	"[{""name"":""required_by_value_dependant"",""parameters"":{""context"":[""DATASET""], ""runOnEmpty"":""true"", ""dependantField"": ""responsible_party_type"", ""dependantFieldValue"": ""person""}}]"
	responsible_party_organization_name	Organization name	"[{""name"":""required_by_value_dependant"",""parameters"":{""context"":[""DATASET""], ""runOnEmpty"":""true"", ""dependantField"": ""responsible_party_type"", ""dependantFieldValue"": ""organization""}}]"
	responsible_party_organization_address_city	City	"[{""name"":""required_by_value_dependant"",""parameters"":{""context"":[""DATASET""], ""runOnEmpty"":""true"", ""dependantField"": ""responsible_party_type"", ""dependantFieldValue"": ""organization""}}]"
	responsible_party_organization_address_postal-code	Postal code	"[{""name"":""required_by_value_dependant"",""parameters"":{""context"":[""DATASET""], ""runOnEmpty"":""true"", ""dependantField"": ""responsible_party_type"", ""dependantFieldValue"": ""organization""}}]"
	responsible_party_organization_address_administrative-area	Administrative area	"[{""name"":""required_by_value_dependant"",""parameters"":{""context"":[""DATASET""], ""runOnEmpty"":""true"", ""dependantField"": ""responsible_party_type"", ""dependantFieldValue"": ""organization""}}]"
	responsible_party_organization_address_country	Country	"[{""name"":""required_by_value_dependant"",""parameters"":{""context"":[""DATASET""], ""runOnEmpty"":""true"", ""dependantField"": ""responsible_party_type"", ""dependantFieldValue"": ""organization""}}]"
	responsible_party_email_address	Email address	"[{""name"":""standard_input""}]"
	responsible_party_orcid	ORCID	"[{""name"":""standard_input""}]"
#controlledVocabulary	DatasetField	Value	identifier
	responsible_party_type	Person	person
	responsible_party_type	Organization	organization

[releatedFieldValidator.csv](https://github.com/user-attachments/files/16992492/releatedFieldValidator.csv)
