### PR TITLE
fixed undeterministic test depending on machine default locale

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ scripts/installer/default.config
 .project
 .settings
 .tern-project
+/dataverse-test-common/.factorypath
+/dataverse-webapp/.factorypath
+/switchTo8.bat

--- a/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/common/FileSizeUtil.java
+++ b/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/common/FileSizeUtil.java
@@ -1,24 +1,38 @@
 package edu.harvard.iq.dataverse.common;
 
-public class FileSizeUtil {
-    
-    /* This method turns a number of bytes into a human readable version
-     */
-    public static String bytesToHumanReadable(long v) {
-        return bytesToHumanReadable(v, 1);
-    }
+import static edu.harvard.iq.dataverse.common.BundleUtil.getCurrentLocale;
+import static edu.harvard.iq.dataverse.common.BundleUtil.getStringFromBundle;
+import static java.lang.Long.numberOfLeadingZeros;
+import static java.lang.String.format;
 
-    /* This method turns a number of bytes into a human readable version
-     * with figs decimal places
-     */
-    public static String bytesToHumanReadable(long v, int figs) {
-        if (v < 1024) {
-            return v + " " + BundleUtil.getStringFromBundle("file.addreplace.error.byte_abrev");
-        }
-        // 63 - because long has 63 binary digits
-        int trailingBin0s = (63 - Long.numberOfLeadingZeros(v)) / 10;
-        //String base = "%."+figs+"f %s"+ BundleUtil.getStringFromBundle("file.addreplace.error.byte_abrev");
-        return String.format("%." + figs + "f %s" + BundleUtil.getStringFromBundle("file.addreplace.error.byte_abrev"), (double) v / (1L << (trailingBin0s * 10)),
-                             " KMGTPE".charAt(trailingBin0s));
-    }
+public class FileSizeUtil {
+
+	/*
+	 * This method turns a number of bytes into a human readable version
+	 */
+	public static String bytesToHumanReadable(final long v) {
+
+		return bytesToHumanReadable(v, 1);
+	}
+
+	/*
+	 * This method turns a number of bytes into a human readable version with figs
+	 * decimal places
+	 */
+	public static String bytesToHumanReadable(final long v, final int figs) {
+
+		final String B = getStringFromBundle("file.addreplace.error.byte_abrev");
+
+		if (v < 1024) {
+			return v + " " + B;
+		} else {
+			final String formatStr = "%." + figs + "f %s" + B;
+			// 63 - because long has 63 binary digits
+			final int trailingBin0s = (63 - numberOfLeadingZeros(v)) / 10;
+			final char magnitude = " KMGTPE".charAt(trailingBin0s);
+			final double roundedValue = (double) v / (1L << (trailingBin0s * 10));
+			
+			return format(getCurrentLocale(), formatStr, roundedValue, magnitude);
+		}
+	}
 }

--- a/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/common/FileSizeUtil.java
+++ b/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/common/FileSizeUtil.java
@@ -7,32 +7,32 @@ import static java.lang.String.format;
 
 public class FileSizeUtil {
 
-	/*
-	 * This method turns a number of bytes into a human readable version
-	 */
-	public static String bytesToHumanReadable(final long v) {
+    /*
+     * This method turns a number of bytes into a human readable version
+     */
+    public static String bytesToHumanReadable(final long v) {
 
-		return bytesToHumanReadable(v, 1);
-	}
+        return bytesToHumanReadable(v, 1);
+    }
 
-	/*
-	 * This method turns a number of bytes into a human readable version with figs
-	 * decimal places
-	 */
-	public static String bytesToHumanReadable(final long v, final int figs) {
+    /*
+     * This method turns a number of bytes into a human readable version with figs
+     * decimal places
+     */
+    public static String bytesToHumanReadable(final long v, final int figs) {
 
-		final String B = getStringFromBundle("file.addreplace.error.byte_abrev");
+        final String B = getStringFromBundle("file.addreplace.error.byte_abrev");
 
-		if (v < 1024) {
-			return v + " " + B;
-		} else {
-			final String formatStr = "%." + figs + "f %s" + B;
-			// 63 - because long has 63 binary digits
-			final int trailingBin0s = (63 - numberOfLeadingZeros(v)) / 10;
-			final char magnitude = " KMGTPE".charAt(trailingBin0s);
-			final double roundedValue = (double) v / (1L << (trailingBin0s * 10));
-			
-			return format(getCurrentLocale(), formatStr, roundedValue, magnitude);
-		}
-	}
+        if (v < 1024) {
+            return v + " " + B;
+        } else {
+            final String formatStr = "%." + figs + "f %s" + B;
+            // 63 - because long has 63 binary digits
+            final int trailingBin0s = (63 - numberOfLeadingZeros(v)) / 10;
+            final char magnitude = " KMGTPE".charAt(trailingBin0s);
+            final double roundedValue = (double) v / (1L << (trailingBin0s * 10));
+
+            return format(getCurrentLocale(), formatStr, roundedValue, magnitude);
+        }
+    }
 }

--- a/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/common/FileSizeUtilTest.java
+++ b/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/common/FileSizeUtilTest.java
@@ -5,15 +5,11 @@
  */
 package edu.harvard.iq.dataverse.common;
 
-import org.junit.jupiter.api.Test;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
 import static edu.harvard.iq.dataverse.common.BundleUtil.getStringFromBundle;
-import static org.junit.jupiter.api.Assertions.assertAll;
+import static edu.harvard.iq.dataverse.common.FileSizeUtil.bytesToHumanReadable;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
 
 /**
  * @author oscardssmith
@@ -21,26 +17,23 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class FileSizeUtilTest {
 
     @Test
-    public void bytesToHumanReadable() {
-    	//GIVEN
-        long[] sizes = {1L, 1023L, 1986L, 125707L, 2759516000L, 12039650000000L};
-        List<String> ans = new ArrayList<>();
-        List<String> longAns = new ArrayList<>();
-
-		//WHEN
-		for (long size : sizes) {
-			ans.add(FileSizeUtil.bytesToHumanReadable(size));
-			longAns.add(FileSizeUtil.bytesToHumanReadable(size, 2));
-		}
-
-		//THEN
-		String B = getStringFromBundle("file.addreplace.error.byte_abrev");
-        List<String> expectedAns = Arrays.asList("1 " + B, "1023 " + B, "1.9 K" + B, "122.8 K" + B, "2.6 G" + B, "10.9 T" + B);
-        List<String> expectedLongAns = Arrays.asList("1 " + B, "1023 " + B, "1.94 K" + B, "122.76 K" + B, "2.57 G" + B, "10.95 T" + B);
-        assertAll(
-				() -> assertEquals(expectedAns, ans),
-				() -> assertEquals(expectedLongAns, longAns)
-        );
+    public void bytesToHumanReadable2() {
+    	
+    	String B = getStringFromBundle("file.addreplace.error.byte_abrev");
+    	
+    	assertEquals("1 " + B, bytesToHumanReadable(1L));
+    	assertEquals("1023 " + B, bytesToHumanReadable(1023L));
+    	assertEquals("1.9 K" + B, bytesToHumanReadable(1986L));
+    	assertEquals("122.8 K" + B, bytesToHumanReadable(125707L));
+    	assertEquals("2.6 G" + B, bytesToHumanReadable(2759516000L));
+    	assertEquals("10.9 T" + B, bytesToHumanReadable(12039650000000L));
+    	
+    	
+    	assertEquals("1 " + B, bytesToHumanReadable(1L, 2));
+    	assertEquals("1023 " + B, bytesToHumanReadable(1023L, 2));
+    	assertEquals("1.94 K" + B, bytesToHumanReadable(1986L, 2));
+    	assertEquals("122.76 K" + B, bytesToHumanReadable(125707L, 2));
+    	assertEquals("2.57 G" + B, bytesToHumanReadable(2759516000L, 2));
+    	assertEquals("10.95 T" + B, bytesToHumanReadable(12039650000000L, 2));
     }
-
 }


### PR DESCRIPTION
public static String format(String format,
                            Object... args)

with

public static String format(Locale l,
                            String format,
                            Object... args)

so that the same locale be used for both byte abbreviation and decimal separator



