### PR TITLE
Fix maven groupId in assembly

### DIFF
--- a/dataverse-dist/src/main/assembly/dist-dir-assembly.xml
+++ b/dataverse-dist/src/main/assembly/dist-dir-assembly.xml
@@ -55,7 +55,7 @@
 
         <dependencySet>
             <includes>
-                <include>edu.harvard.iq:dataverse-webapp:war</include>
+                <include>pl.edu.icm.dataverse:dataverse-webapp:war</include>
             </includes>
             <outputDirectory>/</outputDirectory>
             <useProjectArtifact>false</useProjectArtifact>


### PR DESCRIPTION
The new groupId `pl.edu.icm.dataverse` wasn't set in the assembly configuration.