### PR TITLE
Fixed "Failed to delete temp like" in IngestableDataChecker under Win…

### DIFF
--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/ingest/IngestableDataChecker.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/ingest/IngestableDataChecker.java
@@ -20,9 +20,10 @@
 package edu.harvard.iq.dataverse.ingest;
 
 
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.builder.ToStringBuilder;
-import org.apache.commons.lang.builder.ToStringStyle;
+import static java.lang.System.err;
+import static java.lang.System.out;
+import static java.nio.channels.FileChannel.MapMode.READ_ONLY;
+import static org.apache.commons.lang.builder.ToStringStyle.MULTI_LINE_STYLE;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -32,6 +33,7 @@ import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.BufferUnderflowException;
+import java.nio.ByteBuffer;
 import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
@@ -44,8 +46,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.zip.GZIPInputStream;
 
-import static java.lang.System.err;
-import static java.lang.System.out;
+import org.apache.commons.lang.builder.ToStringBuilder;
 
 /**
  * This is a virtually unchanged DVN v2-3 implementation by
@@ -134,7 +135,7 @@ public class IngestableDataChecker implements java.io.Serializable {
     /**
      * test this byte buffer against SPSS-SAV spec
      */
-    public String testSAVformat(MappedByteBuffer buff) {
+    public String testSAVformat(ByteBuffer buff) {
         String result = null;
         buff.rewind();
         boolean DEBUG = false;
@@ -176,7 +177,7 @@ public class IngestableDataChecker implements java.io.Serializable {
     /**
      * test this byte buffer against STATA DTA spec
      */
-    public String testDTAformat(MappedByteBuffer buff) {
+    public String testDTAformat(ByteBuffer buff) {
         String result = null;
         buff.rewind();
         boolean DEBUG = false;
@@ -294,7 +295,7 @@ public class IngestableDataChecker implements java.io.Serializable {
     /**
      * test this byte buffer against SAS Transport(XPT) spec
      */
-    public String testXPTformat(MappedByteBuffer buff) {
+    public String testXPTformat(ByteBuffer buff) {
         String result = null;
         buff.rewind();
         boolean DEBUG = false;
@@ -341,7 +342,7 @@ public class IngestableDataChecker implements java.io.Serializable {
     /**
      * test this byte buffer against SPSS Portable (POR) spec
      */
-    public String testPORformat(MappedByteBuffer buff) {
+    public String testPORformat(ByteBuffer buff) {
         String result = null;
         buff.rewind();
         boolean DEBUG = false;
@@ -506,7 +507,7 @@ public class IngestableDataChecker implements java.io.Serializable {
     /**
      * test this byte buffer against R data file
      */
-    public String testRDAformat(MappedByteBuffer buff) {
+    public String testRDAformat(ByteBuffer buff) {
         String result = null;
         buff.rewind();
 
@@ -590,18 +591,18 @@ public class IngestableDataChecker implements java.io.Serializable {
     public String detectTabularDataFormat(File fh) {
         boolean DEBUG = false;
         String readableFormatType = null;
-        FileChannel srcChannel = null;
-        FileInputStream inp = null;
-        try {
+        
+        
+        try (final FileInputStream inp = new FileInputStream(fh)) {
+            
             int buffer_size = this.getBufferSize(fh);
             dbgLog.fine("buffer_size: " + buffer_size);
 
             // set-up a FileChannel instance for a given file object
-            inp = new FileInputStream(fh);
-            srcChannel = inp.getChannel();
+            final FileChannel srcChannel = inp.getChannel();
 
             // create a read-only MappedByteBuffer
-            MappedByteBuffer buff = srcChannel.map(FileChannel.MapMode.READ_ONLY, 0, buffer_size);
+            MappedByteBuffer buff = srcChannel.map(READ_ONLY, 0, buffer_size);
 
             //this.printHexDump(buff, "hex dump of the byte-buffer");
 
@@ -661,10 +662,7 @@ public class IngestableDataChecker implements java.io.Serializable {
         } catch (IOException ie) {
             dbgLog.fine("other io exception detected");
             ie.printStackTrace();
-        } finally {
-            IOUtils.closeQuietly(srcChannel);
-            IOUtils.closeQuietly(inp);
-        }
+        } 
         return readableFormatType;
     }
 
@@ -709,7 +707,7 @@ public class IngestableDataChecker implements java.io.Serializable {
         return BUFFER_SIZE;
     }
 
-    private int getGzipBufferSize(MappedByteBuffer buff) {
+    private int getGzipBufferSize(ByteBuffer buff) {
         int GZIP_BUFFER_SIZE = 120;
         /*
         note:
@@ -729,7 +727,7 @@ public class IngestableDataChecker implements java.io.Serializable {
     /**
      * dump the data buffer in HEX
      */
-    public void printHexDump(MappedByteBuffer buff, String hdr) {
+    public void printHexDump(ByteBuffer buff, String hdr) {
         int counter = 0;
         if (hdr != null) {
             out.println(hdr);
@@ -751,7 +749,6 @@ public class IngestableDataChecker implements java.io.Serializable {
 
     @Override
     public String toString() {
-        return ToStringBuilder.reflectionToString(this,
-                                                  ToStringStyle.MULTI_LINE_STYLE);
+        return ToStringBuilder.reflectionToString(this, MULTI_LINE_STYLE);
     }
 }

--- a/dataverse-webapp/src/test/java/edu/harvard/iq/dataverse/ingest/IngestableDataCheckerTest.java
+++ b/dataverse-webapp/src/test/java/edu/harvard/iq/dataverse/ingest/IngestableDataCheckerTest.java
@@ -22,7 +22,7 @@ public class IngestableDataCheckerTest {
         return buffer;
     }
 
-    private AbstractStringAssert<?> assertThatADATAFormat(final String content)
+    private AbstractStringAssert<?> assertThatDTAFormat(final String content)
             throws Exception {
         ByteBuffer buff = createBufferContaining(content);
 
@@ -38,23 +38,23 @@ public class IngestableDataCheckerTest {
 
     @Test
     public void testADATAformat_returnsMimeType_forProperContent() throws Exception {
-        assertThatADATAFormat("l   ").isEqualTo("application/x-stata");
-        assertThatADATAFormat(STATA_13_HEADER).isEqualTo("application/x-stata-13");
+        assertThatDTAFormat("l   ").isEqualTo("application/x-stata");
+        assertThatDTAFormat(STATA_13_HEADER).isEqualTo("application/x-stata-13");
     }
 
     @Test
     public void testADATAformat_returnsNull_forBrokenContent() throws Exception {
-        assertThatADATAFormat("").isNull();
-        assertThatADATAFormat("hello-non-stata-file-how-are-you").isNull();
+        assertThatDTAFormat("").isNull();
+        assertThatDTAFormat("hello-non-stata-file-how-are-you").isNull();
     }
 
     @Test
-    public void testingSAVformat_returnsMimeType_forProperContent() throws Exception {
+    public void testSAVformat_returnsMimeType_forProperContent() throws Exception {
         assertThatSAVFormat("$FL2").isEqualTo("application/x-spss-sav");
     }
 
     @Test
-    public void testingSAVformat_returnsNull_forBrokenContent() throws Exception {
+    public void testSAVformat_returnsNull_forBrokenContent() throws Exception {
         assertThatSAVFormat("").isNull();
         assertThatSAVFormat("i-am-not-a-x-spss-sav-file").isNull();
     }

--- a/dataverse-webapp/src/test/java/edu/harvard/iq/dataverse/ingest/IngestableDataCheckerTest.java
+++ b/dataverse-webapp/src/test/java/edu/harvard/iq/dataverse/ingest/IngestableDataCheckerTest.java
@@ -22,14 +22,14 @@ public class IngestableDataCheckerTest {
         return buffer;
     }
 
-    private AbstractStringAssert<?> assertThatADATA(final String content)
+    private AbstractStringAssert<?> assertThatADATAFormat(final String content)
             throws Exception {
         ByteBuffer buff = createBufferContaining(content);
 
         return assertThat(this.instance.testDTAformat(buff));
     }
 
-    private AbstractStringAssert<?> assertThatSAV(final String content)
+    private AbstractStringAssert<?> assertThatSAVFormat(final String content)
             throws Exception {
         ByteBuffer buff = createBufferContaining(content);
 
@@ -37,25 +37,25 @@ public class IngestableDataCheckerTest {
     }
 
     @Test
-    public void testingADATA_returnsMimeType_forProperContent() throws Exception {
-        assertThatADATA("l   ").isEqualTo("application/x-stata");
-        assertThatADATA(STATA_13_HEADER).isEqualTo("application/x-stata-13");
+    public void testADATAformat_returnsMimeType_forProperContent() throws Exception {
+        assertThatADATAFormat("l   ").isEqualTo("application/x-stata");
+        assertThatADATAFormat(STATA_13_HEADER).isEqualTo("application/x-stata-13");
     }
 
     @Test
-    public void testingADATA_returnsNull_forBrokenContent() throws Exception {
-        assertThatADATA("").isNull();
-        assertThatADATA("hello-non-stata-file-how-are-you").isNull();
+    public void testADATAformat_returnsNull_forBrokenContent() throws Exception {
+        assertThatADATAFormat("").isNull();
+        assertThatADATAFormat("hello-non-stata-file-how-are-you").isNull();
     }
 
     @Test
-    public void testingSAV_returnsMimeType_forProperContent() throws Exception {
-        assertThatSAV("$FL2").isEqualTo("application/x-spss-sav");
+    public void testingSAVformat_returnsMimeType_forProperContent() throws Exception {
+        assertThatSAVFormat("$FL2").isEqualTo("application/x-spss-sav");
     }
 
     @Test
-    public void testingSAV_returnsNull_forBrokenContent() throws Exception {
-        assertThatSAV("").isNull();
-        assertThatSAV("i-am-not-a-x-spss-sav-file").isNull();
+    public void testingSAVformat_returnsNull_forBrokenContent() throws Exception {
+        assertThatSAVFormat("").isNull();
+        assertThatSAVFormat("i-am-not-a-x-spss-sav-file").isNull();
     }
 }

--- a/dataverse-webapp/src/test/java/edu/harvard/iq/dataverse/ingest/IngestableDataCheckerTest.java
+++ b/dataverse-webapp/src/test/java/edu/harvard/iq/dataverse/ingest/IngestableDataCheckerTest.java
@@ -15,7 +15,6 @@ public class IngestableDataCheckerTest {
 
     private ByteBuffer createBufferContaining(final String fileContents)
             throws IOException {
-
         final ByteBuffer buffer = ByteBuffer.allocate(100);
         buffer.put(fileContents.getBytes());
         buffer.rewind();
@@ -25,7 +24,6 @@ public class IngestableDataCheckerTest {
 
     private AbstractStringAssert<?> assertThatADATA(final String content)
             throws Exception {
-
         ByteBuffer buff = createBufferContaining(content);
 
         return assertThat(this.instance.testDTAformat(buff));
@@ -33,7 +31,6 @@ public class IngestableDataCheckerTest {
 
     private AbstractStringAssert<?> assertThatSAV(final String content)
             throws Exception {
-
         ByteBuffer buff = createBufferContaining(content);
 
         return assertThat(this.instance.testSAVformat(buff));
@@ -41,27 +38,23 @@ public class IngestableDataCheckerTest {
 
     @Test
     public void testingADATA_returnsMimeType_forProperContent() throws Exception {
-
         assertThatADATA("l   ").isEqualTo("application/x-stata");
         assertThatADATA(STATA_13_HEADER).isEqualTo("application/x-stata-13");
     }
 
     @Test
     public void testingADATA_returnsNull_forBrokenContent() throws Exception {
-
         assertThatADATA("").isNull();
         assertThatADATA("hello-non-stata-file-how-are-you").isNull();
     }
 
     @Test
     public void testingSAV_returnsMimeType_forProperContent() throws Exception {
-
         assertThatSAV("$FL2").isEqualTo("application/x-spss-sav");
     }
 
     @Test
     public void testingSAV_returnsNull_forBrokenContent() throws Exception {
-
         assertThatSAV("").isNull();
         assertThatSAV("i-am-not-a-x-spss-sav-file").isNull();
     }

--- a/dataverse-webapp/src/test/java/edu/harvard/iq/dataverse/ingest/IngestableDataCheckerTest.java
+++ b/dataverse-webapp/src/test/java/edu/harvard/iq/dataverse/ingest/IngestableDataCheckerTest.java
@@ -1,170 +1,68 @@
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
 package edu.harvard.iq.dataverse.ingest;
 
-import org.apache.commons.io.FileUtils;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
+import static edu.harvard.iq.dataverse.ingest.IngestableDataChecker.STATA_13_HEADER;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.nio.MappedByteBuffer;
-import java.nio.channels.FileChannel;
-import java.nio.file.Path;
+import java.nio.ByteBuffer;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.assertj.core.api.AbstractStringAssert;
+import org.junit.jupiter.api.Test;
 
-/**
- * @author rmp553
- */
 public class IngestableDataCheckerTest {
 
-    @TempDir
-    Path tempFolder;
+    private final IngestableDataChecker instance = new IngestableDataChecker();
 
-    public IngestableDataCheckerTest() {
+    private ByteBuffer createBufferContaining(final String fileContents)
+            throws IOException {
+
+        final ByteBuffer buffer = ByteBuffer.allocate(100);
+        buffer.put(fileContents.getBytes());
+        buffer.rewind();
+
+        return buffer;
     }
 
-    @BeforeAll
-    public static void setUpClass() {
+    private AbstractStringAssert<?> assertThatADATA(final String content)
+            throws Exception {
+
+        ByteBuffer buff = createBufferContaining(content);
+
+        return assertThat(this.instance.testDTAformat(buff));
     }
 
-    @AfterAll
-    public static void tearDownClass() {
+    private AbstractStringAssert<?> assertThatSAV(final String content)
+            throws Exception {
 
+        ByteBuffer buff = createBufferContaining(content);
+
+        return assertThat(this.instance.testSAVformat(buff));
     }
 
-    @BeforeEach
-    public void setUp() {
-    }
-
-    @AfterEach
-    public void tearDown() {
-
-
-    }
-
-
-    private File createTempFile(String filename, String fileContents) throws IOException {
-
-        if (filename == null) {
-            return null;
-        }
-        File fh = tempFolder.resolve(filename).toFile();
-        fh.createNewFile();
-
-        if (fileContents != null) {
-            FileUtils.writeStringToFile(fh, fileContents);
-        }
-
-        return fh;
-    }
-
-    private MappedByteBuffer createTempFileAndGetBuffer(String filename, String fileContents) throws IOException {
-
-        File fh = this.createTempFile(filename, fileContents);
-
-        FileChannel srcChannel = new FileInputStream(fh).getChannel();
-
-        // create a read-only MappedByteBuffer
-        MappedByteBuffer buff = srcChannel.map(FileChannel.MapMode.READ_ONLY, 0, fh.length());
-
-        return buff;
-    }
-
-    private void msg(String m) {
-        System.out.println(m);
-    }
-
-
-    private void msgt(String m) {
-        msg("---------------------------");
-        msg(m);
-        msg("---------------------------");
-    }
-
-    /**
-     * Test of testDTAformat method, of class IngestableDataChecker.
-     *
-     * @throws java.io.IOException
-     */
     @Test
-    public void testTestDTAformat(@TempDir Path tempFolder) throws IOException {
-        msgt("(1) testDTAformat");
+    public void testingADATA_returnsMimeType_forProperContent() throws Exception {
 
-        msgt("(1a) Mock a Legit Stata File (application/x-stata)");
-        MappedByteBuffer buff = createTempFileAndGetBuffer("testDTA.txt", "l   ");
-
-        IngestableDataChecker instance = new IngestableDataChecker();
-        String result = instance.testDTAformat(buff);
-        msg("result 1a: " + result);
-        assertEquals(result, "application/x-stata");
-
-
-        msgt("(1b) File is empty string (non-DTA)");
-        buff = createTempFileAndGetBuffer("notDTA.txt", "");
-        instance = new IngestableDataChecker();
-        result = instance.testDTAformat(buff);
-        msg("result 1b: " + result);
-        assertEquals(result, null);
-
-
-        msgt("(1c) File is some random text (non-DTA)");
-        buff = createTempFileAndGetBuffer("notDTA2.txt", "hello-non-stata-file-how-are-you");
-        instance = new IngestableDataChecker();
-        result = instance.testDTAformat(buff);
-        msg("result 1c: " + result);
-        assertEquals(result, null);
-
-
-        msgt("(1d) Mock a Legit Stata File with STATA_13_HEADER");
-        buff = createTempFileAndGetBuffer("testDTA2.txt", IngestableDataChecker.STATA_13_HEADER);
-        result = instance.testDTAformat(buff);
-        msg("result 1d: " + result);
-        assertEquals(result, "application/x-stata-13");
-
-
+        assertThatADATA("l   ").isEqualTo("application/x-stata");
+        assertThatADATA(STATA_13_HEADER).isEqualTo("application/x-stata-13");
     }
 
-
-    /**
-     * Test of testSAVformat method, of class IngestableDataChecker.
-     */
     @Test
-    public void testTestSAVformat() throws IOException {
-        msgt("(2) testSAVformat");
+    public void testingADATA_returnsNull_forBrokenContent() throws Exception {
 
-        msgt("(2a) Mock a Legit SPSS-SAV File (application/x-spss-sav)");
-        MappedByteBuffer buff = createTempFileAndGetBuffer("testSAV.txt", "$FL2");
-
-        IngestableDataChecker instance = new IngestableDataChecker();
-        String result = instance.testSAVformat(buff);
-        msg("result 2a: " + result);
-        assertEquals(result, "application/x-spss-sav");
-
-        msgt("(2b) File is empty string");
-        buff = createTempFileAndGetBuffer("testNotSAV-empty.txt", "");
-
-        instance = new IngestableDataChecker();
-        result = instance.testSAVformat(buff);
-        msg("result 2b: " + result);
-        assertEquals(result, null);
-
-        msgt("(2c) File is non-SAV string");
-        buff = createTempFileAndGetBuffer("testNotSAV-string.txt", "i-am-not-a-x-spss-sav-file");
-        instance = new IngestableDataChecker();
-        result = instance.testSAVformat(buff);
-        msg("result 2c: " + result);
-        assertEquals(result, null);
-
+        assertThatADATA("").isNull();
+        assertThatADATA("hello-non-stata-file-how-are-you").isNull();
     }
 
+    @Test
+    public void testingSAV_returnsMimeType_forProperContent() throws Exception {
+
+        assertThatSAV("$FL2").isEqualTo("application/x-spss-sav");
+    }
+
+    @Test
+    public void testingSAV_returnsNull_forBrokenContent() throws Exception {
+
+        assertThatSAV("").isNull();
+        assertThatSAV("i-am-not-a-x-spss-sav-file").isNull();
+    }
 }


### PR DESCRIPTION
Refactored IngestableDataChecker to use generic ByteBuffer.

Refactored test to use in-momory buffers instaed of memory-mapped temporaty files.