### PR TITLE
Closes #2575: Add year only validator

### DIFF
--- a/dataverse-persistence/src/main/resources/Bundle_en.properties
+++ b/dataverse-persistence/src/main/resources/Bundle_en.properties
@@ -2810,6 +2810,7 @@ editfilesfragment.label5=US-ASCII
 isrequired={0} is required.
 isNotValidEntry={0} is not a valid entry.
 isNotValidDate={0} is not a valid date. "(-){1}" or "(-){2}" or "(-){3}" is a supported format.
+isNotValidYear={0} is not a valid year. "{1}" is a supported format.
 isNotValidNumber={0} is not a valid number.
 isNotValidInteger={0} is not a valid integer.
 isNotValidUrl={0} {1} is not a valid URL.

--- a/dataverse-persistence/src/main/resources/Bundle_pl.properties
+++ b/dataverse-persistence/src/main/resources/Bundle_pl.properties
@@ -2760,6 +2760,7 @@ editfilesfragment.label5=US-ASCII
 isrequired=Pole "{0}" jest wymagane.
 isNotValidEntry=Pole "{0}" nie zawiera poprawnego wyra\u017Cenia.
 isNotValidDate=Pole "{0}" nie zawiera poprawnej daty. Poprawny format daty to (-){1} lub (-){2} lub (-){3}.
+isNotValidYear={0} nie zawiera poprawnego roku. Poprawny format roku to {1}".
 isNotValidNumber=Pole "{0}" nie zawiera poprawnej liczby.
 isNotValidInteger=Pole "{0}" nie zawiera poprawnej liczby ca\u0142kowitej.
 isNotValidUrl=Warto\u015B\u0107 {1} pola "{0}" nie jest poprawnym adresem URL.

--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/validators/StandardDateValidator.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/validators/StandardDateValidator.java
@@ -24,7 +24,10 @@ public class StandardDateValidator extends MultiValueValidatorBase {
     private static final String YYYY_MM_FORMAT = "yyyy-MM";
     private static final String YYYY_FORMAT = "yyyy";
 
-    private static final List<DateTimeFormatter> PARSERS = Initializer.initializeParsers();
+    private static final List<DateTimeFormatter> ALL_PARSERS = Initializer.initializeAllParsers();
+    private static final DateTimeFormatter YEAR_ONLY_PARSER = Initializer.initializeYearOnlyParsers();
+
+    private static final String RESTRICT_TO_YEAR_ONLY_KEY = "restrictToYearOnly";
 
     @Override
     public String getName() {
@@ -36,7 +39,18 @@ public class StandardDateValidator extends MultiValueValidatorBase {
                                                Map<String, ? extends List<? extends ValidatableField>> fieldIndex) {
         value = value.startsWith("-") ? value.substring(1) : value;
 
-        for (DateTimeFormatter parser : PARSERS) {
+        Object yearOnlyRestriction = params.getOrDefault(RESTRICT_TO_YEAR_ONLY_KEY, false);
+
+        boolean restrictToYearOnly = Boolean.parseBoolean(yearOnlyRestriction.toString());
+        if (restrictToYearOnly) {
+            return validateOnlyYear(value, field);
+        } else {
+            return validateAllDateFormats(value, field);
+        }
+    }
+
+    private FieldValidationResult validateAllDateFormats(String value, ValidatableField field) {
+        for (DateTimeFormatter parser : ALL_PARSERS) {
             if (isValidDate(value, parser)) {
                 return FieldValidationResult.ok();
             }
@@ -45,14 +59,24 @@ public class StandardDateValidator extends MultiValueValidatorBase {
                 field.getDatasetFieldType().getDisplayName(), YYYY_MM_DD_FORMAT, YYYY_MM_FORMAT, YYYY_FORMAT));
     }
 
+    private FieldValidationResult validateOnlyYear(String value, ValidatableField field) {
+        if (isValidDate(value, YEAR_ONLY_PARSER)) {
+            return FieldValidationResult.ok();
+        }
+        return FieldValidationResult.invalid(field, BundleUtil.getStringFromBundle("isNotValidYear",
+                field.getDatasetFieldType().getDisplayName(), YYYY_FORMAT));
+    }
+
     // -------------------- LOGIC --------------------
 
     private boolean isValidDate(String value, DateTimeFormatter parser) {
         try {
             TemporalAccessor parsed = parser.parse(value);
-            int year = parsed.get(ChronoField.YEAR_OF_ERA);
-            if (year > 9999) {
-                return false;
+            if (parsed.isSupported(ChronoField.YEAR_OF_ERA)) {
+                int year = parsed.get(ChronoField.YEAR_OF_ERA);
+                if (year > 9999) {
+                    return false;
+                }
             }
         } catch (DateTimeException dte) {
             return false;
@@ -63,7 +87,7 @@ public class StandardDateValidator extends MultiValueValidatorBase {
     // -------------------- INNER CLASSES --------------------
 
     private static class Initializer {
-        static List<DateTimeFormatter> initializeParsers() {
+        static List<DateTimeFormatter> initializeAllParsers() {
             return Stream.of(YYYY_MM_DD_FORMAT, YYYY_MM_FORMAT, YYYY_FORMAT)
                     .map(p -> new DateTimeFormatterBuilder()
                             .appendPattern(p)
@@ -75,6 +99,14 @@ public class StandardDateValidator extends MultiValueValidatorBase {
                             .toFormatter()
                             .withResolverStyle(ResolverStyle.STRICT))
                     .collect(Collectors.toList());
+        }
+
+        static DateTimeFormatter initializeYearOnlyParsers() {
+            return new DateTimeFormatterBuilder()
+                    .appendPattern(YYYY_FORMAT)
+                    .parseDefaulting(ChronoField.ERA, 1)
+                    .toFormatter()
+                    .withResolverStyle(ResolverStyle.STRICT);
         }
     }
 }

--- a/dataverse-webapp/src/test/java/edu/harvard/iq/dataverse/validation/field/validators/StandardDateValidatorTest.java
+++ b/dataverse-webapp/src/test/java/edu/harvard/iq/dataverse/validation/field/validators/StandardDateValidatorTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 import java.util.Collections;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -44,6 +45,34 @@ class StandardDateValidatorTest {
 
         // when
         FieldValidationResult result = validator.validate(datasetField, Collections.emptyMap(), Collections.emptyMap());
+
+        // then
+        assertThat(result.isOk()).isEqualTo(expectedResult);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "1999, true",
+            "0966, true",
+            "10000, false",
+            "1999-01, false",
+            "2004-10-27, false",
+            "-1999, true",
+            "-0999, true",
+            "199, false",
+            "abcd, false",
+            "2020, true",
+    })
+    void validateYearOnly(String value, boolean expectedResult) {
+        // given
+        DatasetField datasetField = new DatasetField();
+        datasetField.setDatasetFieldType(new DatasetFieldType());
+        datasetField.setValue(value);
+
+        Map<String, Object> params = Collections.singletonMap("restrictToYearOnly", true);
+
+        // when
+        FieldValidationResult result = validator.validate(datasetField, params, Collections.emptyMap());
 
         // then
         assertThat(result.isOk()).isEqualTo(expectedResult);


### PR DESCRIPTION
Adds ability to validate only year in date input with pattern `YYYY`, f.e.: 2024.
Validation is quite simple. Takes only 4 integer digits in consideration.

Co-authored-by: Filipe Dias Lewandowski, Szymon Drawski


