### PR TITLE
Closes #2586: Add boolean validator

### DIFF
--- a/dataverse-persistence/src/main/resources/Bundle_en.properties
+++ b/dataverse-persistence/src/main/resources/Bundle_en.properties
@@ -2813,6 +2813,7 @@ isNotValidDate={0} is not a valid date. "(-){1}" or "(-){2}" or "(-){3}" is a su
 isNotValidNumber={0} is not a valid number.
 isNotValidInteger={0} is not a valid integer.
 isNotValidUrl={0} {1} is not a valid URL.
+isNotValidValue={0} is not valid value.
 
 noFilesSelected=No files were selected.
 

--- a/dataverse-persistence/src/main/resources/Bundle_pl.properties
+++ b/dataverse-persistence/src/main/resources/Bundle_pl.properties
@@ -2763,6 +2763,7 @@ isNotValidDate=Pole "{0}" nie zawiera poprawnej daty. Poprawny format daty to (-
 isNotValidNumber=Pole "{0}" nie zawiera poprawnej liczby.
 isNotValidInteger=Pole "{0}" nie zawiera poprawnej liczby ca\u0142kowitej.
 isNotValidUrl=Warto\u015B\u0107 {1} pola "{0}" nie jest poprawnym adresem URL.
+isNotValidValue={0} nie jest poprawn\u0105 warto\u015bci\u0105.
 
 noFilesSelected=Nie zaznaczono \u017Cadnego pliku.
 

--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/validators/StandardBooleanValidator.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/validators/StandardBooleanValidator.java
@@ -1,0 +1,48 @@
+package edu.harvard.iq.dataverse.validation.field.validators;
+
+import edu.harvard.iq.dataverse.common.BundleUtil;
+import edu.harvard.iq.dataverse.persistence.dataset.ValidatableField;
+import edu.harvard.iq.dataverse.validation.field.FieldValidationResult;
+import org.omnifaces.cdi.Eager;
+
+import javax.enterprise.context.ApplicationScoped;
+import java.util.List;
+import java.util.Map;
+
+@Eager
+@ApplicationScoped
+public class StandardBooleanValidator extends MultiValueValidatorBase {
+    public static final String ACCEPTABLE_VALUE_KEY = "acceptableValue";
+
+    @Override
+    public String getName() {
+        return "standard_boolean";
+    }
+
+    @Override
+    public FieldValidationResult validateValue(String value, ValidatableField field, Map<String, Object> params,
+                                               Map<String, ? extends List<? extends ValidatableField>> fieldIndex) {
+
+        Object acceptableValue = params.getOrDefault(ACCEPTABLE_VALUE_KEY, "true");
+        if (!(acceptableValue instanceof String)) {
+            return FieldValidationResult.ok();
+        }
+        boolean valueToValidateParsed = parseToBoolean(value);
+        boolean acceptableValueParsed = parseToBoolean((String) acceptableValue);
+
+        if (valueToValidateParsed == acceptableValueParsed) {
+            return FieldValidationResult.ok();
+        } else {
+            return FieldValidationResult.invalid(field, BundleUtil.getStringFromBundle("isNotAcceptable", value));
+        }
+    }
+
+    public boolean parseToBoolean(String input) {
+        return input != null && (
+                input.equalsIgnoreCase("yes") ||
+                        input.equalsIgnoreCase("true") ||
+                        input.equalsIgnoreCase("y") ||
+                        input.equals("1")
+        );
+    }
+}

--- a/dataverse-webapp/src/test/java/edu/harvard/iq/dataverse/validation/field/validators/StandardBooleanValidatorTest.java
+++ b/dataverse-webapp/src/test/java/edu/harvard/iq/dataverse/validation/field/validators/StandardBooleanValidatorTest.java
@@ -1,0 +1,52 @@
+package edu.harvard.iq.dataverse.validation.field.validators;
+
+import edu.harvard.iq.dataverse.persistence.dataset.DatasetField;
+import edu.harvard.iq.dataverse.persistence.dataset.DatasetFieldType;
+import edu.harvard.iq.dataverse.validation.field.FieldValidationResult;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class StandardBooleanValidatorTest {
+
+    private StandardBooleanValidator validator = new StandardBooleanValidator();
+
+    @ParameterizedTest
+    @CsvSource({
+            "yes, yes, true",
+            "yes, true, true",
+            "true, true, true",
+            "1, yes, true",
+            "0, yes, false",
+            "no, no, true",
+            "false, false, true",
+            "true, false, false",
+            "unknown, true, false",
+            "yes, , true",
+            "true, , true",
+            "1, , true",
+            "0, , false",
+            "no, , false",
+            "false, , false"
+    })
+    void validate(String value, String acceptableValue, boolean expectedResult) {
+        // given
+        DatasetField datasetField = new DatasetField();
+        datasetField.setDatasetFieldType(new DatasetFieldType());
+        datasetField.setValue(value);
+
+        Map<String, Object> params = acceptableValue != null
+                ? Collections.singletonMap(StandardBooleanValidator.ACCEPTABLE_VALUE_KEY, acceptableValue)
+                : Collections.emptyMap();
+
+        // when
+        FieldValidationResult result = validator.validate(datasetField, params, Collections.emptyMap());
+
+        // then
+        assertThat(result.isOk()).isEqualTo(expectedResult);
+    }
+}


### PR DESCRIPTION
Added boolean validator, that can servers validation for consents input with controlled vocabullary values.

Co-authored-by: Szymon Drawski, Filipe Dias Lewandowski


