### PR TITLE
refactorings

### DIFF
--- a/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/DvObject.java
+++ b/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/DvObject.java
@@ -6,24 +6,29 @@ import edu.harvard.iq.dataverse.persistence.dataverse.Dataverse;
 import edu.harvard.iq.dataverse.persistence.user.AuthenticatedUser;
 import edu.harvard.iq.dataverse.persistence.user.RoleAssignment;
 
-import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.DiscriminatorColumn;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Index;
 import javax.persistence.Inheritance;
-import javax.persistence.InheritanceType;
 import javax.persistence.ManyToOne;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import javax.persistence.Temporal;
-import javax.persistence.TemporalType;
 import javax.persistence.UniqueConstraint;
+
+import static javax.persistence.CascadeType.ALL;
+import static javax.persistence.CascadeType.MERGE;
+import static javax.persistence.CascadeType.PERSIST;
+import static javax.persistence.CascadeType.REMOVE;
+import static javax.persistence.GenerationType.IDENTITY;
+import static javax.persistence.InheritanceType.JOINED;
+import static javax.persistence.TemporalType.TIMESTAMP;
+
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
@@ -63,7 +68,7 @@ import java.util.Set;
 // dataverse, dataset and datafile. The ids from the main table will be reused
 // in the child tables. (i.e., the id sequences will be "sparse" in the 3 
 // child tables). Tested, appears to be working properly. -- L.A. Nov. 4 2014
-@Inheritance(strategy = InheritanceType.JOINED)
+@Inheritance(strategy = JOINED)
 @DiscriminatorColumn(name = "dtype")
 @Table(indexes = {@Index(columnList = "dtype")
         , @Index(columnList = "owner_id")
@@ -113,7 +118,7 @@ public abstract class DvObject extends DataverseEntity implements java.io.Serial
     };
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue(strategy = IDENTITY)
     private Long id;
 
     @ManyToOne
@@ -157,15 +162,18 @@ public abstract class DvObject extends DataverseEntity implements java.io.Serial
     private String protocol;
     private String authority;
 
-    @Temporal(value = TemporalType.TIMESTAMP)
+    @Temporal(value = TIMESTAMP)
     private Date globalIdCreateTime;
 
     private String identifier;
 
     private boolean identifierRegistered;
 
-    @OneToMany(mappedBy = "dvObject", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "dvObject", cascade = ALL, orphanRemoval = true)
     private Set<AlternativePersistentIdentifier> alternativePersistentIndentifiers;
+    
+    @OneToMany(mappedBy = "definitionPoint", cascade = {REMOVE, MERGE, PERSIST}, orphanRemoval = true)
+    private List<RoleAssignment> roleAssignments;
 
     public Set<AlternativePersistentIdentifier> getAlternativePersistentIndentifiers() {
         return alternativePersistentIndentifiers;
@@ -340,6 +348,14 @@ public abstract class DvObject extends DataverseEntity implements java.io.Serial
             ? this.indexTime.before(this.modificationTime)
             : true;
     }
+    
+    public boolean isRoot() {
+        return this.getOwner() == null;
+    }
+    
+    public boolean isNotRoot() {
+        return this.getOwner() != null;
+    }
 
     public void setIdentifierRegistered(boolean identifierRegistered) {
         this.identifierRegistered = identifierRegistered;
@@ -431,52 +447,25 @@ public abstract class DvObject extends DataverseEntity implements java.io.Serial
     }
 
     public Dataverse getDataverseContext() {
-        if (this instanceof Dataverse) {
-            return (Dataverse) this;
-        } else if (this.getOwner() != null) {
-            return this.getOwner().getDataverseContext();
-        }
-
-        return null;
+        return getOwner().getDataverseContext();
     }
 
-    public String getAuthorString() {
-        if (this instanceof Dataverse) {
-            throw new UnsupportedOperationException("Not supported yet.");
-        }
-        if (this instanceof Dataset) {
-            Dataset dataset = (Dataset) this;
-            return dataset.getLatestVersion().getAuthorsStr();
-        }
-        if (this instanceof DataFile) {
-            Dataset dataset = (Dataset) this.getOwner();
-            return dataset.getLatestVersion().getAuthorsStr();
-        }
-        throw new UnsupportedOperationException("Not supported yet. New DVObject Instance?");
-    }
+    public abstract String getAuthorString();
 
-    public String getTargetUrl() {
-        if (this instanceof Dataverse) {
-            throw new UnsupportedOperationException("Not supported yet.");
-        }
-        if (this instanceof Dataset) {
-            return Dataset.TARGET_URL;
-        }
-        if (this instanceof DataFile) {
-            return DataFile.TARGET_URL;
-        }
-        throw new UnsupportedOperationException("Not supported yet. New DVObject Instance?");
-
-    }
+    public abstract String getTargetUrl();
 
     public String getYearPublishedCreated() {
+        return new SimpleDateFormat("yyyy").format(getPublishedCreated());
+    }
+    
+    private Date getPublishedCreated() {
         //if published get the year if draft get when created
         if (this.isReleased()) {
-            return new SimpleDateFormat("yyyy").format(this.getPublicationDate());
+            return getPublicationDate();
         } else if (this.getCreateDate() != null) {
-            return new SimpleDateFormat("yyyy").format(this.getCreateDate());
+            return this.getCreateDate();
         } else {
-            return new SimpleDateFormat("yyyy").format(new Date());
+            return new Date();
         }
     }
 
@@ -493,10 +482,6 @@ public abstract class DvObject extends DataverseEntity implements java.io.Serial
      * @return {@code true} iff {@code other} is {@code this} or below {@code this} in the containment hierarchy.
      */
     public abstract boolean isAncestorOf(DvObject other);
-
-    @OneToMany(mappedBy = "definitionPoint", cascade = {CascadeType.REMOVE, CascadeType.MERGE, CascadeType.PERSIST}, orphanRemoval = true)
-    private List<RoleAssignment> roleAssignments;
-
     
     public List<RoleAssignment> getRoleAssignments() {
         return roleAssignments;

--- a/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/datafile/DataFile.java
+++ b/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/datafile/DataFile.java
@@ -185,6 +185,14 @@ public class DataFile extends DvObject implements Comparable<DataFile> {
     }
 
     // -------------------- GETTERS --------------------
+    @Override
+    public String getAuthorString() {
+        return this.getOwner().getLatestVersion().getAuthorsStr();
+    }
+    @Override
+    public String getTargetUrl() {
+        return TARGET_URL;
+    }
 
     public List<GuestbookResponse> getGuestbookResponses() {
         return guestbookResponses;

--- a/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/dataset/Dataset.java
+++ b/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/dataset/Dataset.java
@@ -266,6 +266,15 @@ public class Dataset extends DvObjectContainer {
         this.guestbook = guestbook;
     }
 
+    @Override
+    public String getAuthorString() {
+        return getLatestVersion().getAuthorsStr();
+    }
+    @Override
+    public String getTargetUrl() {
+        return TARGET_URL;
+    }
+    
     /**
      * Time of last changes that could affect exporters results, but are not related to specific dataset version.
      * Example: Guestbook assigning and embargo date change can happen after dataset

--- a/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/dataset/DatasetFieldType.java
+++ b/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/dataset/DatasetFieldType.java
@@ -1,22 +1,34 @@
 package edu.harvard.iq.dataverse.persistence.dataset;
 
-import edu.harvard.iq.dataverse.common.BundleUtil;
-import edu.harvard.iq.dataverse.persistence.JpaEntity;
-import edu.harvard.iq.dataverse.persistence.config.JsonMapConverter;
-import edu.harvard.iq.dataverse.persistence.dataverse.DataverseFacet;
-import edu.harvard.iq.dataverse.persistence.dataverse.DataverseFieldTypeInputLevel;
-import org.apache.commons.lang3.StringUtils;
+import static edu.harvard.iq.dataverse.persistence.dataset.FieldType.NONE;
+import static edu.harvard.iq.dataverse.persistence.dataset.FieldType.TEXT;
+import static edu.harvard.iq.dataverse.persistence.dataset.FieldType.TEXTBOX;
+import static java.util.Collections.emptyMap;
+import static javax.persistence.CascadeType.MERGE;
+import static javax.persistence.CascadeType.PERSIST;
+import static javax.persistence.CascadeType.REMOVE;
+import static javax.persistence.GenerationType.IDENTITY;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeMap;
 
 import javax.faces.model.SelectItem;
 import javax.faces.model.SelectItemGroup;
-import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Convert;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Index;
 import javax.persistence.ManyToOne;
@@ -26,18 +38,14 @@ import javax.persistence.OneToMany;
 import javax.persistence.OrderBy;
 import javax.persistence.Table;
 import javax.persistence.Transient;
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.TreeMap;
+
+import org.apache.commons.lang3.StringUtils;
+
+import edu.harvard.iq.dataverse.common.BundleUtil;
+import edu.harvard.iq.dataverse.persistence.JpaEntity;
+import edu.harvard.iq.dataverse.persistence.config.JsonMapConverter;
+import edu.harvard.iq.dataverse.persistence.dataverse.DataverseFacet;
+import edu.harvard.iq.dataverse.persistence.dataverse.DataverseFieldTypeInputLevel;
 
 /**
  * Defines the meaning and constraints of a metadata field and its values.
@@ -62,7 +70,7 @@ import java.util.TreeMap;
 public class DatasetFieldType implements Serializable, Comparable<DatasetFieldType>, JpaEntity<Long> {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue(strategy = IDENTITY)
     private Long id;
 
     /** The internal, DDI-like name, no spaces, etc. */
@@ -80,7 +88,7 @@ public class DatasetFieldType implements Serializable, Comparable<DatasetFieldTy
     /** Metatype of the field. */
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private FieldType fieldType;
+    private FieldType fieldType = NONE;
 
     /** Whether the value must be taken from a controlled vocabulary. */
     private boolean allowControlledVocabulary;
@@ -124,7 +132,7 @@ public class DatasetFieldType implements Serializable, Comparable<DatasetFieldTy
     private boolean displayOnCreate;
 
     /** The {@code MetadataBlock} this field type belongs to. */
-    @ManyToOne(cascade = CascadeType.MERGE)
+    @ManyToOne(cascade = MERGE)
     private MetadataBlock metadataBlock;
 
     /** A formal URI for the field used in json-ld exports */
@@ -133,20 +141,20 @@ public class DatasetFieldType implements Serializable, Comparable<DatasetFieldTy
 
     /** The list of controlled vocabulary terms that may be used as values for
      * fields of this field type. */
-    @OneToMany(mappedBy = "datasetFieldType", cascade = {CascadeType.REMOVE, CascadeType.MERGE, CascadeType.PERSIST})
+    @OneToMany(mappedBy = "datasetFieldType", cascade = {REMOVE, MERGE, PERSIST})
     @OrderBy("displayOrder ASC")
     private Collection<ControlledVocabularyValue> controlledVocabularyValues;
 
     /** Collection of field types that are children of this field type.
      * A field type may consist of one or more child field types, but only one parent. */
-    @OneToMany(mappedBy = "parentDatasetFieldType", cascade = {CascadeType.REMOVE, CascadeType.MERGE, CascadeType.PERSIST})
+    @OneToMany(mappedBy = "parentDatasetFieldType", cascade = {REMOVE, MERGE, PERSIST})
     @OrderBy("displayOrder ASC")
     private List<DatasetFieldType> childDatasetFieldTypes = new ArrayList<>();
 
-    @ManyToOne(cascade = CascadeType.MERGE)
+    @ManyToOne(cascade = MERGE)
     private DatasetFieldType parentDatasetFieldType;
 
-    @OneToMany(mappedBy = "datasetField", cascade = {CascadeType.REMOVE, CascadeType.MERGE, CascadeType.PERSIST})
+    @OneToMany(mappedBy = "datasetField", cascade = {REMOVE, MERGE, PERSIST})
     private List<DatasetFieldDefaultValue> datasetFieldDefaultValues;
 
     /** Determines whether fields of this field type are always required. A
@@ -160,7 +168,7 @@ public class DatasetFieldType implements Serializable, Comparable<DatasetFieldTy
 
     @Column(name="metadata", nullable = false)
     @Convert(converter = JsonMapConverter.class)
-    private Map<String, Object> metadata = Collections.emptyMap();
+    private Map<String, Object> metadata = emptyMap();
 
     // -------------------- CONSTRUCTORS --------------------
 
@@ -304,16 +312,17 @@ public class DatasetFieldType implements Serializable, Comparable<DatasetFieldTy
     // -------------------- LOGIC --------------------
 
     public Boolean isSanitizeHtml() {
-        return FieldType.URL.equals(this.fieldType) || FieldType.TEXTBOX.equals(this.fieldType);
+        return this.fieldType.sanitizeHtml();
     }
 
     public Boolean isEscapeOutputText() {
-        if (FieldType.URL.equals(this.fieldType) || FieldType.TEXTBOX.equals(this.fieldType)) {
+        if (this.fieldType.sanitizeHtml()) {
             return false;
+        } else {
+            return !(TEXT.equals(this.fieldType)
+                    && this.displayFormat != null
+                    && this.displayFormat.contains("<a"));
         }
-        return !(FieldType.TEXT.equals(this.fieldType)
-                && this.displayFormat != null
-                && this.displayFormat.contains("<a"));
     }
 
     public boolean isControlledVocabulary() {
@@ -398,16 +407,7 @@ public class DatasetFieldType implements Serializable, Comparable<DatasetFieldTy
     }
 
     public boolean isHasRequiredChildren() {
-        if (this.childDatasetFieldTypes.isEmpty()) {
-            return false;
-        } else {
-            for (DatasetFieldType childFieldType : this.childDatasetFieldTypes) {
-                if (childFieldType.isRequired()) {
-                    return true;
-                }
-            }
-        }
-        return false;
+        return this.childDatasetFieldTypes.stream().anyMatch(DatasetFieldType::isRequired);
     }
 
     public boolean isHasParent() {
@@ -476,8 +476,8 @@ public class DatasetFieldType implements Serializable, Comparable<DatasetFieldTy
                 && (isCompound()
                         ? childDatasetFieldTypes.stream()
                             .map(DatasetFieldType::getFieldType)
-                            .anyMatch(FieldType.TEXTBOX::equals)
-                        : fieldType.equals(FieldType.TEXTBOX));
+                            .anyMatch(TEXTBOX::equals)
+                        : fieldType.equals(TEXTBOX));
     }
 
     public Object getMetadata(String key) {

--- a/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/dataset/FieldType.java
+++ b/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/dataset/FieldType.java
@@ -4,5 +4,9 @@ package edu.harvard.iq.dataverse.persistence.dataset;
  * The set of possible metatypes of the field. Used for validation and layout.
  */
 public enum FieldType {
-    TEXT, TEXTBOX, DATE, EMAIL, URL, FLOAT, INT, CHECKBOX, NONE, GEOBOX
+    TEXT, TEXTBOX, DATE, EMAIL, URL, FLOAT, INT, CHECKBOX, NONE, GEOBOX;
+    
+    public boolean sanitizeHtml() {
+        return this.equals(URL) || this.equals(TEXTBOX);
+    }
 }

--- a/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/dataverse/Dataverse.java
+++ b/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/dataverse/Dataverse.java
@@ -192,6 +192,18 @@ public class Dataverse extends DvObjectContainer {
                 return "";
         }
     }
+    @Override
+    public String getAuthorString() {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+    
+    public String getTargetUrl() {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+    @Override
+    public Dataverse getDataverseContext() {
+        return this;
+    }
 
     public String getIndexableCategoryName() {
         return getCategoryNameForIndex();
@@ -368,14 +380,6 @@ public class Dataverse extends DvObjectContainer {
         return harvestingClient != null;
     }
     */
-
-    public boolean isRoot() {
-        return this.getOwner() == null;
-    }
-    
-    public boolean isNotRoot() {
-        return this.getOwner() != null;
-    }
 
     public List<Guestbook> getParentGuestbooks() {
         List<Guestbook> retList = new ArrayList<>();

--- a/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/dataset/DatasetFieldTypeTest.java
+++ b/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/dataset/DatasetFieldTypeTest.java
@@ -15,7 +15,6 @@ public class DatasetFieldTypeTest {
 
     @Test
     public void testIsSanitizeHtml() {
-        System.out.println("isSanitizeHtml");
         DatasetFieldType instance = new DatasetFieldType();
         instance.setFieldType(FieldType.TEXT);
         Boolean result = instance.isSanitizeHtml();
@@ -39,7 +38,6 @@ public class DatasetFieldTypeTest {
 
     @Test
     public void testIsEscapeOutputText() {
-        System.out.println("testIsEscapeOutputText");
         DatasetFieldType instance = new DatasetFieldType();
         instance.setFieldType(FieldType.TEXT);
         Boolean result = instance.isEscapeOutputText();
@@ -128,4 +126,28 @@ public class DatasetFieldTypeTest {
         // then
         assertThat(separableOnGui).isEqualTo(shouldBeSeparable);
     }
+    
+    @Test
+    public void test_isHasRequiredChildren() {
+        DatasetFieldType fieldType = new DatasetFieldType("type1", FieldType.TEXT, false);
+        
+        assertThat(fieldType.getChildDatasetFieldTypes().size()).isEqualTo(0);
+        assertThat(fieldType.isHasRequiredChildren()).isFalse();
+        
+        fieldType.getChildDatasetFieldTypes().add(new DatasetFieldType());
+        
+        assertThat(fieldType.getChildDatasetFieldTypes().size()).isEqualTo(1);
+        assertThat(fieldType.isHasRequiredChildren()).isFalse();
+        
+        fieldType.getChildDatasetFieldTypes().get(0).setRequired(true);
+        
+        assertThat(fieldType.getChildDatasetFieldTypes().size()).isEqualTo(1);
+        assertThat(fieldType.isHasRequiredChildren()).isTrue();
+        
+        fieldType.getChildDatasetFieldTypes().add(new DatasetFieldType());
+        
+        assertThat(fieldType.getChildDatasetFieldTypes().size()).isEqualTo(2);
+        assertThat(fieldType.isHasRequiredChildren()).isTrue();
+    }
+    
 }

--- a/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/dataset/DatasetTest.java
+++ b/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/dataset/DatasetTest.java
@@ -132,14 +132,17 @@ public class DatasetTest {
         assertThat(root.getOwner()).isNull();
         assertThat(root.isRoot()).isTrue();
         assertThat(root.isNotRoot()).isFalse();
+        assertThat(root.getDataverseContext()).isSameAs(root);
         
         assertThat(child.getOwner()).isSameAs(root);
         assertThat(child.isRoot()).isFalse();
         assertThat(child.isNotRoot()).isTrue();       
         assertThat(child.getRoot()).isSameAs(root);
+        assertThat(child.getDataverseContext()).isSameAs(child);
         
         assertThat(grandChild.getOwner()).isSameAs(child);
         assertThat(grandChild.getRoot()).isSameAs(root);
+        assertThat(grandChild.getDataverseContext()).isSameAs(child);
     }
 
     // -------------------- PRIVATE --------------------


### PR DESCRIPTION
DVObject:
- moved isRoot() and isNotRoot() from Dataverse
- rewritten getDataverseContext(), getAuthorString() and getTargetUrl() into OO style overriding them in Dataverse, Dataset and 
   Datafile classes
- extracted private methods from getYearPublishedCreated()
- moved roleAssignments to the top of file
- added tests

DatasetFieldType:
- extrated common code from isSanitizeHtml() and isEscapeOutputText() 
- added test


