### PR TITLE
Excluded ORCIDs from harvested datasets from purge.

### DIFF
--- a/scripts/database/delete_unfixable_orcids.sql
+++ b/scripts/database/delete_unfixable_orcids.sql
@@ -3,7 +3,15 @@
 DO $$
 DECLARE
     ids numeric[];
+    harvested_versions numeric [];
 BEGIN
+	-- get harvested dataset versions
+    select array(select datasetversion.id as id
+        from datasetversion join dataset on datasetversion.dataset_id = dataset.id
+        where dataset.harvestingclient_id is not null)
+    into harvested_versions;
+	
+	
     -- find indetifiers of all dataset fields with supposed ORCID values 
     -- that don't match ORCIS format
     SELECT ARRAY(select id
@@ -28,12 +36,12 @@ BEGIN
         and fieldvalue is not null)
     INTO ids;
 
-    -- clear all unfixable orcid values
+    -- clear all unfixable orcid values in non-harvested datasets
     update datasetfield 
     set 
     fieldvalue = null
     where 
-    id = any(ids);
+    id = any(ids) and datasetversion_id != all(harvested_versions);
 
     -- clear indetified schema selections for deleted ORCIDs
     delete 


### PR DESCRIPTION
Additional request: As there is no point in changing ORCIDs for records harvested from external sources (our main problem is with editing and these datasets are not editable), we should filter out these records and change only the "internal", editable datasets.