### PR TITLE
Refactored persistence integration tests not to require Glassfish

### DIFF
--- a/dataverse-persistence/pom.xml
+++ b/dataverse-persistence/pom.xml
@@ -62,6 +62,13 @@
             <artifactId>javax.json</artifactId>
             <scope>test</scope>
         </dependency>
+
+   <!--    <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>org.eclipse.persistence.jpa</artifactId>
+            <version>2.6.1</version>
+            <scope>test</scope>
+        </dependency>-->
     </dependencies>
 
     <build>

--- a/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/datafile/FileMetadataRepository.java
+++ b/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/datafile/FileMetadataRepository.java
@@ -3,6 +3,8 @@ package edu.harvard.iq.dataverse.persistence.datafile;
 import edu.harvard.iq.dataverse.persistence.JpaRepository;
 
 import javax.ejb.Stateless;
+import javax.persistence.EntityManager;
+
 import java.util.Collection;
 import java.util.List;
 
@@ -13,6 +15,12 @@ public class FileMetadataRepository extends JpaRepository<Long, FileMetadata> {
 
     public FileMetadataRepository() {
         super(FileMetadata.class);
+    }
+    
+    public FileMetadataRepository(final EntityManager em) {
+        
+        super(FileMetadata.class);
+        super.em = em;
     }
 
     // -------------------- LOGIC --------------------

--- a/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/datafile/license/LicenseRepository.java
+++ b/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/datafile/license/LicenseRepository.java
@@ -4,19 +4,21 @@ import edu.harvard.iq.dataverse.persistence.JpaRepository;
 
 import javax.ejb.Stateless;
 import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
 import java.util.List;
 import java.util.Optional;
 
 @Stateless
 public class LicenseRepository extends JpaRepository<Long, License> {
 
-    @PersistenceContext(unitName = "VDCNet-ejbPU")
-    private EntityManager em;
-
 
     public LicenseRepository() {
         super(License.class);
+    }
+    
+    public LicenseRepository(final EntityManager em) {
+        
+        super(License.class);
+        super.em = em;
     }
 
     //-------------------- LOGIC --------------------

--- a/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/dataset/DatasetCitationsCountRepository.java
+++ b/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/dataset/DatasetCitationsCountRepository.java
@@ -3,6 +3,7 @@ package edu.harvard.iq.dataverse.persistence.dataset;
 import edu.harvard.iq.dataverse.persistence.JpaRepository;
 
 import javax.ejb.Stateless;
+import javax.persistence.EntityManager;
 
 import java.util.Optional;
 
@@ -13,6 +14,12 @@ public class DatasetCitationsCountRepository extends JpaRepository<Long, Dataset
 
     public DatasetCitationsCountRepository() {
         super(DatasetCitationsCount.class);
+    }
+    
+    public DatasetCitationsCountRepository(final EntityManager em) {
+        
+        super(DatasetCitationsCount.class);
+        super.em = em;
     }
 
     // -------------------- LOGIC --------------------

--- a/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/dataset/DatasetRepository.java
+++ b/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/dataset/DatasetRepository.java
@@ -3,6 +3,8 @@ package edu.harvard.iq.dataverse.persistence.dataset;
 import edu.harvard.iq.dataverse.persistence.JpaRepository;
 
 import javax.ejb.Singleton;
+import javax.persistence.EntityManager;
+
 import java.util.List;
 
 @Singleton
@@ -12,6 +14,12 @@ public class DatasetRepository extends JpaRepository<Long, Dataset> {
 
     public DatasetRepository() {
         super(Dataset.class);
+    }
+    
+    public DatasetRepository(final EntityManager em) {
+        
+        super(Dataset.class);
+        super.em = em;
     }
 
     // -------------------- LOGIC --------------------

--- a/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/dataverse/DataverseFeaturedDataverseRepository.java
+++ b/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/dataverse/DataverseFeaturedDataverseRepository.java
@@ -1,19 +1,25 @@
 package edu.harvard.iq.dataverse.persistence.dataverse;
 
-import edu.harvard.iq.dataverse.persistence.JpaRepository;
+import java.util.List;
 
 import javax.ejb.Stateless;
-import java.util.List;
-import java.util.logging.Logger;
+import javax.persistence.EntityManager;
+
+import edu.harvard.iq.dataverse.persistence.JpaRepository;
 
 @Stateless
 public class DataverseFeaturedDataverseRepository extends JpaRepository<Long, DataverseFeaturedDataverse> {
-    private static final Logger logger = Logger.getLogger(DataverseFeaturedDataverseRepository.class.getCanonicalName());
 
     // -------------------- CONSTRUCTORS --------------------
 
     public DataverseFeaturedDataverseRepository() {
         super(DataverseFeaturedDataverse.class);
+    }
+    
+    public DataverseFeaturedDataverseRepository(final EntityManager em) {
+        
+        super(DataverseFeaturedDataverse.class);
+        super.em = em;
     }
 
     // -------------------- LOGIC --------------------

--- a/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/dataverse/DataverseRepository.java
+++ b/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/dataverse/DataverseRepository.java
@@ -3,6 +3,8 @@ package edu.harvard.iq.dataverse.persistence.dataverse;
 import edu.harvard.iq.dataverse.persistence.JpaRepository;
 
 import javax.ejb.Singleton;
+import javax.persistence.EntityManager;
+
 import java.util.List;
 
 @Singleton
@@ -12,6 +14,12 @@ public class DataverseRepository extends JpaRepository<Long, Dataverse> {
 
     public DataverseRepository() {
         super(Dataverse.class);
+    }
+    
+    public DataverseRepository(final EntityManager em) {
+        
+        super(Dataverse.class);
+        super.em = em;
     }
 
     // -------------------- LOGIC --------------------

--- a/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/group/MailDomainGroupRepository.java
+++ b/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/group/MailDomainGroupRepository.java
@@ -3,6 +3,8 @@ package edu.harvard.iq.dataverse.persistence.group;
 import edu.harvard.iq.dataverse.persistence.JpaRepository;
 
 import javax.ejb.Singleton;
+import javax.persistence.EntityManager;
+
 import java.util.Optional;
 
 @Singleton
@@ -12,6 +14,12 @@ public class MailDomainGroupRepository extends JpaRepository<Long, MailDomainGro
 
     public MailDomainGroupRepository() {
         super(MailDomainGroup.class);
+    }
+    
+    public MailDomainGroupRepository(final EntityManager em) {
+        
+        super(MailDomainGroup.class);
+        super.em = em;
     }
 
     // -------------------- LOGIC --------------------

--- a/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/harvest/OAIRecordRepository.java
+++ b/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/harvest/OAIRecordRepository.java
@@ -3,6 +3,7 @@ package edu.harvard.iq.dataverse.persistence.harvest;
 import edu.harvard.iq.dataverse.persistence.JpaRepository;
 
 import javax.ejb.Stateless;
+import javax.persistence.EntityManager;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Predicate;
@@ -18,6 +19,12 @@ public class OAIRecordRepository extends JpaRepository<Long, OAIRecord> {
 
     public OAIRecordRepository() {
         super(OAIRecord.class);
+    }
+    
+    public OAIRecordRepository(final EntityManager em) {
+        
+        super(OAIRecord.class);
+        super.em = em;
     }
 
     // -------------------- LOGIC --------------------

--- a/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/harvest/OAISet.java
+++ b/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/harvest/OAISet.java
@@ -74,6 +74,12 @@ public class OAISet implements Serializable, JpaEntity<Long> {
 
     public OAISet() {
     }
+    
+    public OAISet(final String name, final String specName) {
+        
+        this.name = name;
+        this.spec = specName;
+    }
 
     // -------------------- GETTERS --------------------
 

--- a/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/harvest/OAISetRepository.java
+++ b/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/harvest/OAISetRepository.java
@@ -3,6 +3,7 @@ package edu.harvard.iq.dataverse.persistence.harvest;
 import edu.harvard.iq.dataverse.persistence.JpaRepository;
 
 import javax.ejb.Stateless;
+import javax.persistence.EntityManager;
 
 import java.util.List;
 import java.util.Optional;
@@ -15,6 +16,12 @@ public class OAISetRepository extends JpaRepository<Long, OAISet> {
     public OAISetRepository() {
         super(OAISet.class);
     }
+    public OAISetRepository(final EntityManager em) {
+        
+        super(OAISet.class);
+        super.em = em;
+    }
+    
 
     // -------------------- LOGIC --------------------
 

--- a/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/ror/RorDataRepository.java
+++ b/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/ror/RorDataRepository.java
@@ -3,6 +3,7 @@ package edu.harvard.iq.dataverse.persistence.ror;
 import edu.harvard.iq.dataverse.persistence.JpaRepository;
 
 import javax.ejb.Singleton;
+import javax.persistence.EntityManager;
 import javax.persistence.Query;
 
 @Singleton
@@ -12,6 +13,12 @@ public class RorDataRepository extends JpaRepository<Long, RorData> {
 
     public RorDataRepository() {
         super(RorData.class);
+    }
+    
+    public RorDataRepository(final EntityManager em) {
+        
+        super(RorData.class);
+        super.em = em;
     }
 
     // -------------------- LOGIC --------------------

--- a/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/user/AuthenticatedUserRepository.java
+++ b/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/user/AuthenticatedUserRepository.java
@@ -3,6 +3,7 @@ package edu.harvard.iq.dataverse.persistence.user;
 import edu.harvard.iq.dataverse.persistence.JpaRepository;
 
 import javax.ejb.Stateless;
+import javax.persistence.EntityManager;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Predicate;
@@ -16,6 +17,12 @@ public class AuthenticatedUserRepository extends JpaRepository<Long, Authenticat
 
     public AuthenticatedUserRepository() {
         super(AuthenticatedUser.class);
+    }
+    
+    public AuthenticatedUserRepository(final EntityManager em) {
+        
+        super(AuthenticatedUser.class);
+        super.em = em;
     }
 
     // -------------------- LOGIC --------------------

--- a/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/user/DataverseRoleRepository.java
+++ b/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/user/DataverseRoleRepository.java
@@ -3,6 +3,7 @@ package edu.harvard.iq.dataverse.persistence.user;
 import edu.harvard.iq.dataverse.persistence.JpaRepository;
 
 import javax.ejb.Singleton;
+import javax.persistence.EntityManager;
 
 import java.util.List;
 import java.util.Optional;
@@ -14,6 +15,12 @@ public class DataverseRoleRepository extends JpaRepository<Long, DataverseRole> 
 
     public DataverseRoleRepository() {
         super(DataverseRole.class);
+    }
+    
+    public DataverseRoleRepository(final EntityManager em) {
+        
+        super(DataverseRole.class);
+        super.em = em;
     }
 
     // -------------------- LOGIC --------------------

--- a/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/user/RoleAssignmentRepository.java
+++ b/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/user/RoleAssignmentRepository.java
@@ -6,6 +6,7 @@ import edu.harvard.iq.dataverse.persistence.dataset.Dataset;
 import javax.ejb.Singleton;
 import javax.persistence.NoResultException;
 import javax.persistence.NonUniqueResultException;
+import javax.persistence.EntityManager;
 import javax.persistence.Query;
 
 import static java.util.stream.Collectors.joining;
@@ -20,6 +21,12 @@ public class RoleAssignmentRepository extends JpaRepository<Long, RoleAssignment
 
     public RoleAssignmentRepository() {
         super(RoleAssignment.class);
+    }
+    
+    public RoleAssignmentRepository(final EntityManager em) {
+        
+        super(RoleAssignment.class);
+        super.em = em;
     }
 
     // -------------------- LOGIC --------------------

--- a/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/user/UserNotificationRepository.java
+++ b/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/user/UserNotificationRepository.java
@@ -7,7 +7,6 @@ import org.apache.commons.lang3.StringUtils;
 
 import javax.ejb.Stateless;
 import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Predicate;
@@ -23,13 +22,16 @@ import java.util.Set;
 public class UserNotificationRepository extends JpaRepository<Long, UserNotification> {
     private final static int DELETE_BATCH_SIZE = 100;
 
-    @PersistenceContext(unitName = "VDCNet-ejbPU")
-    private EntityManager em;
-
     // -------------------- CONSTRUCTORS --------------------
 
     public UserNotificationRepository() {
         super(UserNotification.class);
+    }
+    
+    public UserNotificationRepository(final EntityManager em) {
+        
+        super(UserNotification.class);
+        super.em = em;
     }
 
     // -------------------- LOGIC --------------------
@@ -106,11 +108,13 @@ public class UserNotificationRepository extends JpaRepository<Long, UserNotifica
     }
 
     public int updateEmailSent(long userNotificationId) {
-        return em.createQuery("UPDATE UserNotification notification SET notification.emailed = :emailSent" +
+        final int result =  em.createQuery("UPDATE UserNotification notification SET notification.emailed = :emailSent" +
                                       " WHERE notification.id = :userNotificationId")
                 .setParameter("emailSent", true)
                 .setParameter("userNotificationId", userNotificationId)
                 .executeUpdate();
+        em.clear();
+        return result;
     }
 
     public UserNotification findLastSubmitNotificationByObjectId(long datasetId) {

--- a/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/workflow/WorkflowExecutionRepository.java
+++ b/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/workflow/WorkflowExecutionRepository.java
@@ -3,6 +3,8 @@ package edu.harvard.iq.dataverse.persistence.workflow;
 import edu.harvard.iq.dataverse.persistence.JpaRepository;
 
 import javax.ejb.Singleton;
+import javax.persistence.EntityManager;
+
 import java.util.Optional;
 
 @Singleton
@@ -14,6 +16,13 @@ public class WorkflowExecutionRepository extends JpaRepository<Long, WorkflowExe
         super(WorkflowExecution.class);
     }
 
+    public WorkflowExecutionRepository(final EntityManager em) {
+        
+        super(WorkflowExecution.class);
+        super.em = em;
+    }
+    
+    
     // -------------------- LOGIC --------------------
 
     /**

--- a/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/workflow/WorkflowRepository.java
+++ b/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/workflow/WorkflowRepository.java
@@ -1,15 +1,23 @@
 package edu.harvard.iq.dataverse.persistence.workflow;
 
-import edu.harvard.iq.dataverse.persistence.JpaRepository;
-
 import javax.ejb.Singleton;
+import javax.persistence.EntityManager;
+
+import edu.harvard.iq.dataverse.persistence.JpaRepository;
 
 @Singleton
 public class WorkflowRepository extends JpaRepository<Long, Workflow> {
 
-    // -------------------- CONSTRUCTORS --------------------
-
+    // -------------------------------------------------------------------------
     public WorkflowRepository() {
+        
         super(Workflow.class);
+    }
+
+    // -------------------------------------------------------------------------
+    public WorkflowRepository(final EntityManager em) {
+        
+        super(Workflow.class);
+        super.em = em;
     }
 }

--- a/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/common/AuthenticatedUserUtilTest.java
+++ b/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/common/AuthenticatedUserUtilTest.java
@@ -33,7 +33,6 @@ public class AuthenticatedUserUtilTest {
      */
     @Test
     public void testGetFriendlyName() {
-        System.out.println("getAuthenticationProviderFriendlyName");
 
         Map<String, String> bundleTestMap = this.getBundleTestMap();
 

--- a/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/common/DBItegrationTest.java
+++ b/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/common/DBItegrationTest.java
@@ -1,0 +1,189 @@
+package edu.harvard.iq.dataverse.common;
+
+import static java.lang.Thread.currentThread;
+import static java.util.Arrays.asList;
+import static java.util.Collections.enumeration;
+import static javax.persistence.Persistence.createEntityManagerFactory;
+import static org.eclipse.persistence.sessions.DatabaseLogin.TRANSACTION_READ_UNCOMMITTED;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.persistence.EntityManager;
+import javax.sql.DataSource;
+
+import org.eclipse.persistence.internal.jpa.EntityManagerImpl;
+import org.eclipse.persistence.sessions.DatabaseLogin;
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.postgresql.ds.PGSimpleDataSource;
+
+public class DBItegrationTest {
+
+    private final EntityManager entityManager = createEntityManager();
+
+    private static final Path persistenceXMLPath = Paths.get("").resolve("src")
+            .resolve("test").resolve("resources")
+            .resolve("dbintegration_test_persistence.xml");
+
+    static {
+        try {
+            initDB();
+        } catch (final Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    protected EntityManager getEntityManager() {
+        return this.entityManager;
+    }
+
+    // @BeforeAll
+    public static void initDB() throws Exception {
+        final DataSource datadource = createDataSource();
+        try (final Connection c = datadource.getConnection()) {
+            dropAllTables(c);
+            dropAllSequences(c);
+        }
+
+        Flyway.configure().dataSource(datadource).validateOnMigrate(false)
+                .baselineOnMigrate(true).load().migrate();
+
+        insertInitialData(datadource);
+    }
+
+    @BeforeEach
+    public void beginTransaction() throws SQLException {
+        this.entityManager.getTransaction().begin();
+    }
+
+    @AfterEach
+    public void clearDB() {
+        this.entityManager.getTransaction().rollback();
+        this.entityManager.close();
+    }
+
+    private static DataSource createDataSource() {
+
+        final PGSimpleDataSource ds = new PGSimpleDataSource();
+        ds.setServerNames(new String[] { "localhost" });
+        ds.setPortNumbers(new int[] { 5432 });
+        ds.setDatabaseName("dvndb-test");
+        ds.setUser("dvnapp");
+        ds.setPassword("secret");
+
+        return ds;
+    }
+
+    public EntityManager createEntityManager() {
+        try {
+            final Map<String, Object> props = new HashMap<String, Object>();
+            final String persistenceXmlPathString = persistenceXMLPath.toString();
+            final URL persistenceXmlURL = persistenceXMLPath.toAbsolutePath().toUri()
+                    .toURL();
+
+            props.put("eclipselink.persistencexml", persistenceXmlPathString);
+            props.put("javax.persistence.nonJtaDataSource", createDataSource());
+
+            // trick eclipselink to use different persistence.xml
+            currentThread().setContextClassLoader(new ClassLoader() {
+                @Override
+                public Enumeration<URL> getResources(final String name)
+                        throws IOException {
+
+                    if (name.equals(persistenceXmlPathString)) {
+                        return enumeration(asList(persistenceXmlURL));
+                    } else {
+                        return super.getResources(name);
+                    }
+                }
+            });
+
+            return createEntityManagerFactory("dvndb-test", props).createEntityManager();
+        } catch (final MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    
+    private static void dropAllTables(final Connection connection)
+            throws SQLException {
+        try (final Statement s = connection.createStatement()) {
+            s.execute("DO $$ DECLARE\n" + "    r RECORD;\n" + "BEGIN\n"
+                    + "    FOR r IN (SELECT tablename FROM pg_tables WHERE schemaname = current_schema()) LOOP\n"
+                    + "        EXECUTE 'DROP TABLE IF EXISTS ' || quote_ident(r.tablename) || ' CASCADE';\n"
+                    + "    END LOOP;\n" + "END $$;");
+        }
+    }
+
+    private static void dropAllSequences(final Connection connection)
+            throws SQLException {
+        try (final Statement s = connection.createStatement()) {
+            s.execute("DO $$ DECLARE\n" + "    r RECORD;\n" + "BEGIN\n"
+                    + "    FOR r IN (SELECT relname FROM pg_class c WHERE (c.relkind = 'S')) LOOP\n"
+                    + "        EXECUTE 'DROP SEQUENCE ' || quote_ident(r.relname);\n"
+                    + "    END LOOP;\n" + "END $$;");
+        }
+    }
+
+    private static void insertInitialData(final DataSource datadource)
+            throws Exception {
+        try (final BufferedReader lineReader = openInitDbSql()) {
+            final StringBuilder command = new StringBuilder();
+
+            try (final Connection c = datadource.getConnection()) {
+                String line = null;
+                while ((line = lineReader.readLine()) != null) {
+
+                    String trimmedLine = line.trim();
+                    if (trimmedLine.length() == 0 || trimmedLine.startsWith("//")
+                            || trimmedLine.startsWith("--")) {
+                        continue;
+                    }
+                    if (!trimmedLine.endsWith(";")) {
+                        command.append(line);
+                        command.append(" ");
+                        continue;
+                    }
+
+                    command.append(line.substring(0, line.lastIndexOf(";")));
+                    command.append(" ");
+
+                    try (final Statement s = c.createStatement()) {
+                        s.execute(command.toString());
+                    }
+
+                    command.setLength(0);
+                }
+            }
+        }
+    }
+
+    private static BufferedReader openInitDbSql() throws UnsupportedEncodingException {
+        return new BufferedReader(new InputStreamReader(
+                DBItegrationTest.class.getResourceAsStream("/dbinit.sql"), "UTF-8"));
+    }
+
+    // clears database
+    public static void main(String[] args) throws Exception {
+
+        final DataSource datadource = createDataSource();
+        try (final Connection c = datadource.getConnection()) {
+            dropAllTables(c);
+            dropAllSequences(c);
+            System.out.println("Database clear.");
+        }
+    }
+}

--- a/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/GlobalIdTest.java
+++ b/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/GlobalIdTest.java
@@ -15,7 +15,6 @@ public class GlobalIdTest {
 
     @Test
     public void testValidDOI() {
-        System.out.println("testValidDOI");
         GlobalId instance = new GlobalId("doi:10.5072/FK2/BYM3IW");
 
         assertEquals("doi", instance.getProtocol());
@@ -26,7 +25,6 @@ public class GlobalIdTest {
 
     @Test
     public void testValidHandle() {
-        System.out.println("testValidDOI");
         GlobalId instance = new GlobalId("hdl:1902.1/111012");
 
         assertEquals("hdl", instance.getProtocol());
@@ -51,7 +49,6 @@ public class GlobalIdTest {
 
     @Test
     public void testInject() {
-        System.out.println("testInject (weak test)");
 
         String badProtocol = "hdl:'Select value from datasetfieldvalue';/ha";
 
@@ -67,7 +64,6 @@ public class GlobalIdTest {
 
     @Test
     public void testUnknownProtocol() {
-        System.out.println("testUnknownProtocol");
 
         String badProtocol = "doy:10.5072/FK2/BYM3IW";
 
@@ -77,7 +73,6 @@ public class GlobalIdTest {
 
     @Test
     public void testBadIdentifierOnePart() {
-        System.out.println("testBadIdentifierOnePart");
 
         Exception thrown = assertThrows(IllegalArgumentException.class, () -> new GlobalId("1part"));
         assertEquals("Failed to parse identifier: 1part", thrown.getMessage());
@@ -85,7 +80,6 @@ public class GlobalIdTest {
 
     @Test
     public void testBadIdentifierTwoParts() {
-        System.out.println("testBadIdentifierTwoParts");
 
         Exception thrown = assertThrows(IllegalArgumentException.class, () -> new GlobalId("doi:2part/blah"));
         assertEquals("Failed to parse identifier: doi:2part/blah", thrown.getMessage());

--- a/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/SqlScriptRunner.java
+++ b/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/SqlScriptRunner.java
@@ -30,7 +30,15 @@ public class SqlScriptRunner {
 
     @PersistenceContext(unitName = "VDCNet-ejbPU")
     private EntityManager entityManager;
+    
+    public SqlScriptRunner() {
 
+    }
+
+    public SqlScriptRunner(final EntityManager entityManager) {
+
+        this.entityManager = entityManager;
+    }
 
     // -------------------- LOGIC --------------------
 

--- a/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/datafile/FileMetadataRepositoryIT.java
+++ b/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/datafile/FileMetadataRepositoryIT.java
@@ -1,21 +1,20 @@
 package edu.harvard.iq.dataverse.persistence.datafile;
 
-import edu.harvard.iq.dataverse.persistence.PersistenceArquillianDeployment;
-import org.assertj.core.util.Lists;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.assertj.core.util.Lists;
+import org.junit.jupiter.api.Test;
+
+import edu.harvard.iq.dataverse.common.DBItegrationTest;
 
 
-public class FileMetadataRepositoryIT extends PersistenceArquillianDeployment {
+public class FileMetadataRepositoryIT extends DBItegrationTest {
 
-    @Inject
-    private FileMetadataRepository fileMetadataRepository;
+    private FileMetadataRepository fileMetadataRepository = new FileMetadataRepository(getEntityManager());
 
     @Test
     public void findFileMetadataByDatasetVersionIdWithPagination() {

--- a/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/datafile/license/LicenseRepositoryIT.java
+++ b/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/datafile/license/LicenseRepositoryIT.java
@@ -1,22 +1,20 @@
 package edu.harvard.iq.dataverse.persistence.datafile.license;
 
-import edu.harvard.iq.dataverse.persistence.PersistenceArquillianDeployment;
-import org.junit.jupiter.api.Test;
-
-import javax.inject.Inject;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
+
+import edu.harvard.iq.dataverse.common.DBItegrationTest;
 
 /**
  * @author madryk
  */
-public class LicenseRepositoryIT extends PersistenceArquillianDeployment {
+public class LicenseRepositoryIT extends DBItegrationTest {
 
-    @Inject
-    private LicenseRepository licenseRepository;
+    private LicenseRepository licenseRepository = new LicenseRepository(getEntityManager());
 
 
     //-------------------- TESTS --------------------

--- a/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/dataset/DatasetCitationsCountRepositoryIT.java
+++ b/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/dataset/DatasetCitationsCountRepositoryIT.java
@@ -1,18 +1,16 @@
 package edu.harvard.iq.dataverse.persistence.dataset;
 
-import edu.harvard.iq.dataverse.persistence.PersistenceArquillianDeployment;
-import org.junit.jupiter.api.Test;
-
-import javax.inject.Inject;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
 
-public class DatasetCitationsCountRepositoryIT extends PersistenceArquillianDeployment {
+import edu.harvard.iq.dataverse.common.DBItegrationTest;
 
-    @Inject
-    private DatasetCitationsCountRepository repository;
+public class DatasetCitationsCountRepositoryIT extends DBItegrationTest {
+
+    private DatasetCitationsCountRepository repository = new DatasetCitationsCountRepository(getEntityManager());
 
 
     //-------------------- TESTS --------------------

--- a/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/dataset/DatasetRepositoryIT.java
+++ b/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/dataset/DatasetRepositoryIT.java
@@ -1,22 +1,21 @@
 package edu.harvard.iq.dataverse.persistence.dataset;
 
-import edu.harvard.iq.dataverse.persistence.DvObject;
-import edu.harvard.iq.dataverse.persistence.PersistenceArquillianDeployment;
-import org.junit.jupiter.api.Test;
-
-import javax.inject.Inject;
-import java.util.List;
-
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class DatasetRepositoryIT extends PersistenceArquillianDeployment {
+import java.util.List;
 
-    @Inject
-    private DatasetRepository datasetRepository;
+import org.junit.jupiter.api.Test;
+
+import edu.harvard.iq.dataverse.common.DBItegrationTest;
+import edu.harvard.iq.dataverse.persistence.DvObject;
+
+public class DatasetRepositoryIT extends DBItegrationTest {
+
+    private DatasetRepository datasetRepository = new DatasetRepository(getEntityManager());
 
 
     //-------------------- TESTS --------------------

--- a/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/dataverse/DataverseFeaturedDataverseRepositoryIT.java
+++ b/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/dataverse/DataverseFeaturedDataverseRepositoryIT.java
@@ -1,25 +1,15 @@
 package edu.harvard.iq.dataverse.persistence.dataverse;
 
-import edu.harvard.iq.dataverse.persistence.DvObject;
-import edu.harvard.iq.dataverse.persistence.PersistenceArquillianDeployment;
-import edu.harvard.iq.dataverse.persistence.dataset.DatasetRepository;
-import org.jboss.arquillian.transaction.api.annotation.TransactionMode;
-import org.jboss.arquillian.transaction.api.annotation.Transactional;
-import org.junit.jupiter.api.Test;
-
-import javax.inject.Inject;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
-@Transactional(TransactionMode.ROLLBACK)
-public class DataverseFeaturedDataverseRepositoryIT extends PersistenceArquillianDeployment {
+import org.junit.jupiter.api.Test;
 
-    @Inject
-    private DataverseFeaturedDataverseRepository repository;
-    @Inject
-    private DataverseRepository dvRepository;
-    @Inject
-    private DatasetRepository dsRepository;
+import edu.harvard.iq.dataverse.common.DBItegrationTest;
+import edu.harvard.iq.dataverse.persistence.DvObject;
+
+public class DataverseFeaturedDataverseRepositoryIT extends DBItegrationTest {
+
+    private DataverseFeaturedDataverseRepository repository = new DataverseFeaturedDataverseRepository(getEntityManager());
 
     //-------------------- TESTS --------------------
 

--- a/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/group/MailDomainGroupRepositoryIT.java
+++ b/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/group/MailDomainGroupRepositoryIT.java
@@ -1,18 +1,17 @@
 package edu.harvard.iq.dataverse.persistence.group;
 
-import edu.harvard.iq.dataverse.persistence.PersistenceArquillianDeployment;
-import org.junit.jupiter.api.Test;
-
-import javax.inject.Inject;
-import java.util.Optional;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Optional;
 
-public class MailDomainGroupRepositoryIT extends PersistenceArquillianDeployment {
+import org.junit.jupiter.api.Test;
 
-    @Inject
-    private MailDomainGroupRepository repository;
+import edu.harvard.iq.dataverse.common.DBItegrationTest;
+
+
+public class MailDomainGroupRepositoryIT extends DBItegrationTest {
+
+    private MailDomainGroupRepository repository = new MailDomainGroupRepository(getEntityManager());
 
     // -------------------- TESTS --------------------
 

--- a/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/harvest/OAIRecordRepositoryIT.java
+++ b/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/harvest/OAIRecordRepositoryIT.java
@@ -1,24 +1,23 @@
 package edu.harvard.iq.dataverse.persistence.harvest;
 
-import com.google.common.collect.Lists;
-import edu.harvard.iq.dataverse.persistence.PersistenceArquillianDeployment;
-import org.apache.commons.lang3.StringUtils;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
-import javax.inject.Inject;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import java.time.Instant;
 import java.util.Date;
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.tuple;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class OAIRecordRepositoryIT extends PersistenceArquillianDeployment {
+import com.google.common.collect.Lists;
 
-    @Inject
-    private OAIRecordRepository repository;
+import edu.harvard.iq.dataverse.common.DBItegrationTest;
+
+public class OAIRecordRepositoryIT extends DBItegrationTest {
+
+    private OAIRecordRepository repository = new OAIRecordRepository(getEntityManager());
 
     @BeforeEach
     public void setUp() {

--- a/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/harvest/OAISetRepositoryIT.java
+++ b/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/harvest/OAISetRepositoryIT.java
@@ -1,28 +1,26 @@
 package edu.harvard.iq.dataverse.persistence.harvest;
 
-import edu.harvard.iq.dataverse.persistence.PersistenceArquillianDeployment;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
-import javax.inject.Inject;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import java.util.List;
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.tuple;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class OAISetRepositoryIT extends PersistenceArquillianDeployment {
+import edu.harvard.iq.dataverse.common.DBItegrationTest;
 
-    @Inject
-    private OAISetRepository repository;
+public class OAISetRepositoryIT extends DBItegrationTest {
+
+    private OAISetRepository repository = new OAISetRepository(getEntityManager());
 
 
     @BeforeEach
     public void setUp() {
-        repository.save(buildOaiSet("Oai Set 1", "oai_set_1"));
-        repository.save(buildOaiSet("Oai Set 2", "oai_set_2"));
-        repository.save(buildOaiSet("Oai Set 3", "oai_set_3"));
+        repository.save(new OAISet("Oai Set 1", "oai_set_1"));
+        repository.save(new OAISet("Oai Set 2", "oai_set_2"));
+        repository.save(new OAISet("Oai Set 3", "oai_set_3"));
     }
     
     // -------------------- TESTS --------------------
@@ -49,14 +47,5 @@ public class OAISetRepositoryIT extends PersistenceArquillianDeployment {
                     tuple("Oai Set 1", "oai_set_1"),
                     tuple("Oai Set 3", "oai_set_3")
             );
-    }
-    
-    // -------------------- PRIVATE --------------------
-    
-    private OAISet buildOaiSet(String name, String specName) {
-        OAISet oaiSet = new OAISet();
-        oaiSet.setName(name);
-        oaiSet.setSpec(specName);
-        return oaiSet;
     }
 }

--- a/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/ror/RorDataRepositoryIT.java
+++ b/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/ror/RorDataRepositoryIT.java
@@ -1,19 +1,15 @@
 package edu.harvard.iq.dataverse.persistence.ror;
 
-import edu.harvard.iq.dataverse.persistence.PersistenceArquillianDeployment;
-import org.assertj.core.api.Assertions;
-import org.jboss.arquillian.transaction.api.annotation.TransactionMode;
-import org.jboss.arquillian.transaction.api.annotation.Transactional;
-import org.junit.jupiter.api.Test;
-
-import javax.inject.Inject;
 import java.util.List;
 
-@Transactional(TransactionMode.ROLLBACK)
-public class RorDataRepositoryIT extends PersistenceArquillianDeployment {
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-    @Inject
-    private RorDataRepository rorDataRepository;
+import edu.harvard.iq.dataverse.common.DBItegrationTest;
+
+public class RorDataRepositoryIT extends DBItegrationTest {
+
+    private RorDataRepository rorDataRepository = new RorDataRepository(getEntityManager());
 
     @Test
     public void truncateAll(){

--- a/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/user/AuthenticatedUserRepositoryIT.java
+++ b/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/user/AuthenticatedUserRepositoryIT.java
@@ -1,19 +1,18 @@
 package edu.harvard.iq.dataverse.persistence.user;
 
-import edu.harvard.iq.dataverse.persistence.PersistenceArquillianDeployment;
-import org.apache.commons.lang3.StringUtils;
-import org.junit.jupiter.api.*;
-
-import javax.inject.Inject;
-import java.util.List;
-
-import static edu.harvard.iq.dataverse.persistence.user.AuthenticatedUserRepository.SortKey;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class AuthenticatedUserRepositoryIT extends PersistenceArquillianDeployment {
+import java.util.List;
 
-    @Inject
-    private AuthenticatedUserRepository authenticatedUserRepository;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Test;
+
+import edu.harvard.iq.dataverse.common.DBItegrationTest;
+import edu.harvard.iq.dataverse.persistence.user.AuthenticatedUserRepository.SortKey;
+
+public class AuthenticatedUserRepositoryIT extends DBItegrationTest {
+
+    private AuthenticatedUserRepository authenticatedUserRepository = new AuthenticatedUserRepository(getEntityManager());
 
     //-------------------- TESTS --------------------
 

--- a/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/user/AuthenticatedUserTest.java
+++ b/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/user/AuthenticatedUserTest.java
@@ -37,14 +37,14 @@ public class AuthenticatedUserTest {
 
     @Test
     public void testGetIdentifier() {
-        System.out.println("getIdentifier for testUser");
+        
         String result = testUser.getIdentifier();
         assertEquals(testUser.getIdentifier(), result);
     }
 
     @Test
     public void testApplyDisplayInfo() {
-        System.out.println("applyDisplayInfo");
+
         AuthenticatedUserDisplayInfo inf = new AuthenticatedUserDisplayInfo("Homer", "Simpson", "Homer.Simpson@someU.edu",
                 "0000-0001-2345-6789", "UnitTester", "https://ror.org/04k0tth05", "In-Memory user");
         testUser.applyDisplayInfo(inf);
@@ -53,7 +53,7 @@ public class AuthenticatedUserTest {
 
     @Test
     public void testGetDisplayInfo() {
-        System.out.println("getDisplayInfo");
+
         // given
         testUser.setOrcid("0000-0001-2345-6789");
         testUser.setAffiliationROR("https://ror.org/04k0tth05");
@@ -69,7 +69,7 @@ public class AuthenticatedUserTest {
 
     @Test
     public void testIsAuthenticated() {
-        System.out.println("isAuthenticated");
+
         boolean expResult = true;
         boolean result = testUser.isAuthenticated();
         assertEquals(expResult, result);
@@ -77,14 +77,14 @@ public class AuthenticatedUserTest {
 
     @Test
     public void testGetId() {
-        System.out.println("getId");
+
         Long expResult = testUser.getId();
         assertEquals(expResult, testUser.getId());
     }
 
     @Test
     public void testSetId() {
-        System.out.println("setId");
+
         Long id = 1776L;
         testUser.setId(id);
         assertEquals(id, testUser.getId());
@@ -92,14 +92,14 @@ public class AuthenticatedUserTest {
 
     @Test
     public void testGetUserIdentifier() {
-        System.out.println("getUserIdentifier");
+
         String expResult = testUser.getUserIdentifier();
         assertEquals(expResult, testUser.getUserIdentifier());
     }
 
     @Test
     public void testSetUserIdentifier() {
-        System.out.println("setUserIdentifier");
+
         String userIdentifier = "Davis";
         testUser.setUserIdentifier(userIdentifier);
         assertEquals(testUser.getUserIdentifier(), userIdentifier);
@@ -107,7 +107,7 @@ public class AuthenticatedUserTest {
 
     @Test
     public void testGetName() {
-        System.out.println("getName");
+
         String expResult = testUser.getName();
         String result = testUser.getName();
         assertEquals(expResult, result);
@@ -115,14 +115,14 @@ public class AuthenticatedUserTest {
 
     @Test
     public void testGetEmail() {
-        System.out.println("getEmail");
+
         String expResult = testUser.getEmail();
         assertEquals(expResult, testUser.getEmail());
     }
 
     @Test
     public void testSetEmail() {
-        System.out.println("setEmail");
+ 
         String email = "HomerSimpson@someU.edu";
         testUser.setEmail(email);
         assertEquals(testUser.getEmail(), email);
@@ -130,7 +130,7 @@ public class AuthenticatedUserTest {
 
     @Test
     public void testGetAffiliation() {
-        System.out.println("getAffiliation");
+
         String expResult = "UnitTester";
         String result = testUser.getAffiliation();
         assertEquals(expResult, result);
@@ -138,7 +138,7 @@ public class AuthenticatedUserTest {
 
     @Test
     public void testSetAffiliation() {
-        System.out.println("setAffiliation");
+
         String affiliation = "FamilyMan";
         testUser.setAffiliation(affiliation);
         assertEquals(affiliation, testUser.getAffiliation());
@@ -146,21 +146,21 @@ public class AuthenticatedUserTest {
 
     @Test
     public void testGetPosition() {
-        System.out.println("getPosition");
+
         String result = testUser.getPosition();
         assertEquals("In-Memory user", result);
     }
 
     @Test
     public void testSetPosition() {
-        System.out.println("setPosition");
+
         String position = "";
         testUser.setPosition(position);
     }
 
     @Test
     public void testGetLastName() {
-        System.out.println("getLastName");
+
         String expResult = "Simpson";
         String result = testUser.getLastName();
         assertEquals(expResult, result);
@@ -168,28 +168,28 @@ public class AuthenticatedUserTest {
 
     @Test
     public void testSetLastName() {
-        System.out.println("setLastName");
+
         String lastName = "";
         testUser.setLastName(lastName);
     }
 
     @Test
     public void testGetFirstName() {
-        System.out.println("getFirstName");
+ 
         String result = testUser.getFirstName();
         assertEquals("Homer", result);
     }
 
     @Test
     public void testSetFirstName() {
-        System.out.println("setFirstName");
+
         String firstName = "";
         testUser.setFirstName(firstName);
     }
 
     @Test
     public void testGetEmailConfirmed() {
-        System.out.println("getEmailConfirmed");
+
         Timestamp expResult = null;
         Timestamp result = testUser.getEmailConfirmed();
         assertEquals(expResult, result);
@@ -197,21 +197,21 @@ public class AuthenticatedUserTest {
 
     @Test
     public void testSetEmailConfirmed() {
-        System.out.println("setEmailConfirmed");
+  
         Timestamp emailConfirmed = null;
         testUser.setEmailConfirmed(emailConfirmed);
     }
 
     @Test
     public void testGetShibIdentityProvider() {
-        System.out.println("getShibIdentityProvider");
+
         String expResult = testUser.getShibIdentityProvider();
         assertEquals(expResult, testUser.getShibIdentityProvider());
     }
 
     @Test
     public void testSetShibIdentityProvider() {
-        System.out.println("setShibIdentityProvider");
+
         String shibIdentityProvider = "Davis";
         testUser.setShibIdentityProvider(shibIdentityProvider);
         String result = testUser.getShibIdentityProvider();
@@ -220,7 +220,7 @@ public class AuthenticatedUserTest {
 
     @Test
     public void testToString() {
-        System.out.println("toString");
+
         String expResult = "[AuthenticatedUser identifier:" + testUser.getIdentifier() + "]";
         String result = testUser.toString();
         assertEquals(expResult, result);
@@ -228,7 +228,7 @@ public class AuthenticatedUserTest {
 
     @Test
     public void testGetSortByString() {
-        System.out.println("getSortByString");
+
         String expResult = testUser.getLastName() + " " + testUser.getFirstName() + " " + testUser.getUserIdentifier();
         String result = testUser.getSortByString();
         assertEquals(expResult, result);
@@ -236,7 +236,7 @@ public class AuthenticatedUserTest {
 
     @Test
     public void testSetLastLoginTime() {
-        System.out.println("setLastLogin");
+
         testUser.setLastLoginTime(loginTime);
         Timestamp lastLogin = testUser.getLastLoginTime();
         assertEquals(loginTime, lastLogin);
@@ -244,21 +244,21 @@ public class AuthenticatedUserTest {
 
     @Test
     public void testGetLastLoginTime() {
-        System.out.println("getLastLoginTime");
+
         Timestamp expResult = testUser.getLastLoginTime();
         assertEquals(expResult, testUser.getLastLoginTime());
     }
 
     @Test
     public void testGetCreatedTime() {
-        System.out.println("getCreatedTime");
+
         Timestamp result = testUser.getCreatedTime();
         assertEquals(testUser.getCreatedTime(), result);
     }
 
     @Test
     public void testSetCreatedTime() {
-        System.out.println("setCreatedTime");
+
         Timestamp createdTime = new Timestamp(new Date().getTime());
         testUser.setCreatedTime(createdTime);
         assertEquals(testUser.getCreatedTime(), createdTime);
@@ -266,14 +266,14 @@ public class AuthenticatedUserTest {
 
     @Test
     public void testGetLastApiUseTime() {
-        System.out.println("getLastApiUseTime");
+
         Timestamp result = testUser.getLastApiUseTime();
         assertEquals(testUser.getLastApiUseTime(), result);
     }
 
     @Test
     public void testSetLastApiUseTime() {
-        System.out.println("setLastApiUseTime");
+
         Timestamp lastApiUseTime = new Timestamp(new Date().getTime());
         testUser.setLastApiUseTime(lastApiUseTime);
         assertEquals(testUser.getLastApiUseTime(), lastApiUseTime);
@@ -281,7 +281,7 @@ public class AuthenticatedUserTest {
 
     @Test
     public void testSetLastApiUseToCurrentTime() {
-        System.out.println("setLastApiUseToCurrentTime");
+
         testUser.setLastApiUseTime(new Timestamp(new Date().getTime()));
         Timestamp expResult = testUser.getLastApiUseTime();
         assertEquals(expResult, testUser.getLastApiUseTime());
@@ -289,7 +289,7 @@ public class AuthenticatedUserTest {
 
     @Test
     public void testIsSuperuser() {
-        System.out.println("isSuperuser");
+
         boolean expResult = false;
         boolean result = testUser.isSuperuser();
         assertEquals(expResult, result);
@@ -297,7 +297,7 @@ public class AuthenticatedUserTest {
 
     @Test
     public void testSetSuperuser() {
-        System.out.println("setSuperuser");
+ 
         boolean superuser = true;
         testUser.setSuperuser(superuser);
         assertEquals(testUser.isSuperuser(), true);
@@ -305,14 +305,14 @@ public class AuthenticatedUserTest {
 
     @Test
     public void testGetAuthenticatedUserLookup() {
-        System.out.println("getAuthenticatedUserLookup");
+ 
         AuthenticatedUserLookup result = testUser.getAuthenticatedUserLookup();
         assertEquals(testUser.getAuthenticatedUserLookup(), result);
     }
 
     @Test
     public void testSetAuthenticatedUserLookup() {
-        System.out.println("setAuthenticatedUserLookup");
+
         AuthenticatedUserLookup authenticatedUserLookup = testUser.getAuthenticatedUserLookup();
         testUser.setAuthenticatedUserLookup(authenticatedUserLookup);
         assertEquals(authenticatedUserLookup, testUser.getAuthenticatedUserLookup());
@@ -320,38 +320,10 @@ public class AuthenticatedUserTest {
 
     @Test
     public void testHashCode() {
-        System.out.println("hashCode");
+ 
         AuthenticatedUser instance = new AuthenticatedUser();
         int expResult = 0;
         int result = instance.hashCode();
         assertEquals(expResult, result);
     }
-    /**
-     * All commented tests below have only been generated / are not complete for
-     * AuthenticatedUser.java The tests above should all run fine, due to time
-     * constraints on this issue these 1+1=2 type tests weren't all done.
-     */
-
-//    @Test
-//    public void testEquals() {
-//        System.out.println("equals");
-//        Object object = (testUser instanceof AuthenticatedUser);
-//        boolean expResult = true;
-//        boolean result = testUser.equals(object);
-//        assertEquals(expResult, result);
-//    }
-//    @Test
-//    public void testGetDatasetLocks() {
-//        System.out.println("getDatasetLocks");
-//        List<DatasetLock> expResult = null;
-//        List<DatasetLock> result = instance.getDatasetLocks();
-//        assertEquals(expResult, result);
-//    }
-//
-//    @Test
-//    public void testSetDatasetLocks() {
-//        System.out.println("setDatasetLocks");
-//        List<DatasetLock> datasetLocks = null;
-//        instance.setDatasetLocks(datasetLocks);
-//    }
 }

--- a/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/user/DataverseRoleRepositoryIT.java
+++ b/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/user/DataverseRoleRepositoryIT.java
@@ -1,14 +1,5 @@
 package edu.harvard.iq.dataverse.persistence.user;
 
-import edu.harvard.iq.dataverse.persistence.PersistenceArquillianDeployment;
-import edu.harvard.iq.dataverse.persistence.user.DataverseRole.BuiltInRole;
-import org.junit.jupiter.api.Test;
-
-import javax.inject.Inject;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
-
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -16,10 +7,18 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class DataverseRoleRepositoryIT extends PersistenceArquillianDeployment {
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
 
-    @Inject
-    private DataverseRoleRepository dataverseRoleRepository;
+import org.junit.jupiter.api.Test;
+
+import edu.harvard.iq.dataverse.common.DBItegrationTest;
+import edu.harvard.iq.dataverse.persistence.user.DataverseRole.BuiltInRole;
+
+public class DataverseRoleRepositoryIT extends DBItegrationTest {
+
+    private DataverseRoleRepository dataverseRoleRepository = new DataverseRoleRepository(getEntityManager());
 
     //-------------------- TESTS --------------------
 

--- a/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/user/RoleAssignmentRepositoryIT.java
+++ b/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/user/RoleAssignmentRepositoryIT.java
@@ -1,22 +1,22 @@
 package edu.harvard.iq.dataverse.persistence.user;
 
-import com.google.common.collect.Lists;
-import edu.harvard.iq.dataverse.persistence.PersistenceArquillianDeployment;
-import org.junit.jupiter.api.Test;
-
-import javax.inject.Inject;
-import java.util.ArrayList;
-import java.util.List;
-
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 
-public class RoleAssignmentRepositoryIT extends PersistenceArquillianDeployment {
+import java.util.ArrayList;
+import java.util.List;
 
-    @Inject
-    private RoleAssignmentRepository roleAssignmentRepository;
+import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.Lists;
+
+import edu.harvard.iq.dataverse.common.DBItegrationTest;
+
+public class RoleAssignmentRepositoryIT extends DBItegrationTest {
+
+    private RoleAssignmentRepository roleAssignmentRepository = new RoleAssignmentRepository(getEntityManager());
 
     //-------------------- TESTS --------------------
 

--- a/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/user/UserNotificationRepositoryIT.java
+++ b/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/user/UserNotificationRepositoryIT.java
@@ -1,22 +1,17 @@
 package edu.harvard.iq.dataverse.persistence.user;
 
-import edu.harvard.iq.dataverse.persistence.PersistenceArquillianDeployment;
-import org.assertj.core.api.InstanceOfAssertFactories;
-import org.jboss.arquillian.transaction.api.annotation.TransactionMode;
-import org.jboss.arquillian.transaction.api.annotation.Transactional;
-import org.junit.jupiter.api.Test;
-
-import javax.inject.Inject;
-import java.util.List;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class UserNotificationRepositoryIT extends PersistenceArquillianDeployment {
+import java.util.List;
 
-    @Inject
-    private UserNotificationRepository userNotificationRepository;
-    @Inject
-    private AuthenticatedUserRepository authenticatedUserRepository;
+import org.junit.jupiter.api.Test;
+
+import edu.harvard.iq.dataverse.common.DBItegrationTest;
+
+public class UserNotificationRepositoryIT extends DBItegrationTest {
+
+    private UserNotificationRepository userNotificationRepository = new UserNotificationRepository(getEntityManager());
+    private AuthenticatedUserRepository authenticatedUserRepository = new AuthenticatedUserRepository(getEntityManager());
 
     // -------------------- TESTS --------------------
 
@@ -58,21 +53,18 @@ public class UserNotificationRepositoryIT extends PersistenceArquillianDeploymen
     }
 
     @Test
-    @Transactional(TransactionMode.DISABLED)
     public void updateEmailSent() {
         // given
         Long notEmailedNotificationId = userNotificationRepository.findAll().stream()
             .filter(notification -> !notification.isEmailed())
             .findFirst().get().getId();
-
         // when
         int modifiedRecordsCount = userNotificationRepository.updateEmailSent(notEmailedNotificationId);
         // then
         assertThat(modifiedRecordsCount).isEqualTo(1);
-        assertThat(userNotificationRepository.getById(notEmailedNotificationId))
-            .extracting(UserNotification::isEmailed)
-            .asInstanceOf(InstanceOfAssertFactories.BOOLEAN)
-            .isTrue();
+        
+        UserNotification notification = userNotificationRepository.getById(notEmailedNotificationId);
+        assertThat(notification.isEmailed()).isTrue();
     }
 
     @Test

--- a/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/workflow/WorkflowExecutionRepositoryIT.java
+++ b/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/workflow/WorkflowExecutionRepositoryIT.java
@@ -1,15 +1,5 @@
 package edu.harvard.iq.dataverse.persistence.workflow;
 
-import edu.harvard.iq.dataverse.persistence.PersistenceArquillianDeployment;
-import edu.harvard.iq.dataverse.persistence.dataset.Dataset;
-import edu.harvard.iq.dataverse.persistence.dataset.DatasetRepository;
-import edu.harvard.iq.dataverse.test.WithTestClock;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
-import javax.inject.Inject;
-import java.util.Optional;
-
 import static edu.harvard.iq.dataverse.persistence.dataset.DatasetMother.givenDataset;
 import static edu.harvard.iq.dataverse.persistence.workflow.WorkflowMother.givenWorkflow;
 import static edu.harvard.iq.dataverse.persistence.workflow.WorkflowMother.givenWorkflowExecution;
@@ -17,11 +7,21 @@ import static edu.harvard.iq.dataverse.persistence.workflow.WorkflowMother.given
 import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class WorkflowExecutionRepositoryIT extends PersistenceArquillianDeployment implements WithTestClock {
+import java.util.Optional;
 
-    @Inject DatasetRepository datasets;
-    @Inject WorkflowRepository workflows;
-    @Inject WorkflowExecutionRepository executions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import edu.harvard.iq.dataverse.common.DBItegrationTest;
+import edu.harvard.iq.dataverse.persistence.dataset.Dataset;
+import edu.harvard.iq.dataverse.persistence.dataset.DatasetRepository;
+import edu.harvard.iq.dataverse.test.WithTestClock;
+
+public class WorkflowExecutionRepositoryIT extends DBItegrationTest implements WithTestClock {
+    
+    private DatasetRepository datasets = new DatasetRepository(getEntityManager());
+    private WorkflowRepository workflows = new WorkflowRepository(getEntityManager());
+    private WorkflowExecutionRepository executions = new WorkflowExecutionRepository(getEntityManager());
 
     Dataset dataset;
     Workflow workflow;

--- a/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/workflow/WorkflowRepositoryIT.java
+++ b/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/workflow/WorkflowRepositoryIT.java
@@ -1,39 +1,38 @@
 package edu.harvard.iq.dataverse.persistence.workflow;
 
-import edu.harvard.iq.dataverse.persistence.PersistenceArquillianDeployment;
-import org.junit.jupiter.api.Test;
 
-import javax.inject.Inject;
-import java.util.Optional;
-
-import static edu.harvard.iq.dataverse.persistence.workflow.WorkflowMother.givenWorkflow;
-import static edu.harvard.iq.dataverse.persistence.workflow.WorkflowMother.givenWorkflowStep;
 import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class WorkflowRepositoryIT extends PersistenceArquillianDeployment {
+import java.util.Optional;
 
-    @Inject WorkflowRepository workflows;
+import org.junit.jupiter.api.Test;
+
+import edu.harvard.iq.dataverse.common.DBItegrationTest;
+ import edu.harvard.iq.dataverse.persistence.workflow.WorkflowMother;
+
+public class WorkflowRepositoryIT extends DBItegrationTest {
+
+    private WorkflowRepository workflows = new WorkflowRepository(getEntityManager());
 
     @Test
     public void shouldSaveNewWorkflow() {
         // given
-        Workflow workflow = givenWorkflow();
+        Workflow workflow = WorkflowMother.givenWorkflow();
         // when
         workflows.saveFlushAndClear(workflow);
         // then
         Optional<Workflow> found = workflows.findById(workflow.getId());
         assertThat(found).isPresent();
         assertThat(found.get().getName()).isEqualTo(workflow.getName());
+
     }
 
     @Test
     public void shouldSaveWorkflowWithSteps() {
         // given
-        Workflow workflow = givenWorkflow(
-                givenWorkflowStep("step1"),
-                givenWorkflowStep("step2")
-        );
+        Workflow workflow = WorkflowMother.givenWorkflow(WorkflowMother.givenWorkflowStep("step1"),
+                WorkflowMother.givenWorkflowStep("step2"));
         // when
         workflows.saveFlushAndClear(workflow);
         // then
@@ -43,7 +42,8 @@ public class WorkflowRepositoryIT extends PersistenceArquillianDeployment {
         assertThat(found.get().getSteps()).hasSize(2);
         found.get().getSteps().forEach(step -> {
             assertThat(step.getParent()).isSameAs(found.get());
-            assertThat(step.getStepParameters()).containsAllEntriesOf(singletonMap("param", "value"));
+            assertThat(step.getStepParameters())
+                    .containsAllEntriesOf(singletonMap("param", "value"));
         });
     }
 }

--- a/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/worldmap/WorldMapTokenTest.java
+++ b/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/worldmap/WorldMapTokenTest.java
@@ -21,18 +21,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  */
 public class WorldMapTokenTest {
 
-
-    public void msg(String s) {
-        System.out.println(s);
-    }
-
-    public void msgt(String s) {
-        msg("------------------------------------------------------------");
-        msg(s);
-        msg("------------------------------------------------------------");
-    }
-
-
     private TokenApplicationType makeTokenApplicationType(int timeLimitMinutes) {
         TokenApplicationType tat = new TokenApplicationType();
         tat.setName("GeoConnect");
@@ -57,7 +45,6 @@ public class WorldMapTokenTest {
     @Tag("NonEssentialTests")
     @Test
     public void testTokenValues() {
-        msgt("WorldMapTokenTest!");
         TokenApplicationType tat = this.makeTokenApplicationType(30);
 
         WorldMapToken token = this.makeNewToken(tat);
@@ -77,63 +64,31 @@ public class WorldMapTokenTest {
     @Tag("NonEssentialTests")
     @Test
     public void testTokenTimes() {
-        msgt("testTokenTimes");
 
         TokenApplicationType tat = this.makeTokenApplicationType(30);
 
         assertEquals(30 * 60, tat.getTimeLimitSeconds());
-        msg("time limit seconds: " + tat.getTimeLimitSeconds());
         tat.setTimeLimitMinutes(1);
-        msg("time limit seconds (2): " + tat.getTimeLimitSeconds());
         assertEquals(1 * 60, tat.getTimeLimitSeconds());
 
         tat.setTimeLimitMinutes(30);
         WorldMapToken token = this.makeNewToken(tat);
         assertEquals(token.hasTokenExpired(), false);
 
-        //msg("Future token time (31 min): " + getFutureTimeStamp(31));
-        msg("token time limit (minutes): " + token.getApplication().getTimeLimitMinutes());
-        msg("Did token expire in 10 minutes? (should be no)");
-        //msg("expired? " +  token.hasTokenExpired(getFutureTimeStamp(10)));
-
         assertEquals(token.hasTokenExpired(getFutureTimeStamp(10)), false);
-
-        msg("Did token expire? (automatically check current time)");
         assertEquals(token.hasTokenExpired(), false);
-
-        msg("Did token expire at 30 minutes? (should be no)");
         assertEquals(token.hasTokenExpired(getFutureTimeStamp(30)), false);
-
-        msg("Did token expire in 31 minutes? (should be yes)");
         assertEquals(token.hasTokenExpired(getFutureTimeStamp(31)), true);
-
-        msg("Did token expire in 45 minutes? (should be yes)");
         assertEquals(token.hasTokenExpired(getFutureTimeStamp(45)), true);
-
-        msg("token time limit (minutes): 10 minutes");
         token.getApplication().setTimeLimitMinutes(10);
         assertEquals(token.getApplication().getTimeLimitMinutes(), 10);
-
-        msg("Did token expire if null sent? (should be yes)");
         assertEquals(token.hasTokenExpired(null), true);
-
-        msg("Refresh token (but fails b/c sending null automatically expires it");
         token.refreshToken();
-        msg("Did token expire in 5 minutes? (should be no)");
         assertEquals(token.hasTokenExpired(getFutureTimeStamp(5)), true);
-        msg("Did token expire? (auto-check current time)");
         assertEquals(token.hasTokenExpired(), true);
-
-        msgt("Get a new Token");
         WorldMapToken token2 = this.makeNewToken(tat);
-
-
-        msg("Did token expire? (automatically check current time)");
         assertEquals(token2.hasTokenExpired(), false);
-
-        msg("Manually expire token: setHasExpired(true)");
         token2.setHasExpired(true);
-        msg("Did token expire in 1 minute? (should be yes--b/c manually expired)");
         assertEquals(token2.hasTokenExpired(getFutureTimeStamp(1)), true);
 
 

--- a/dataverse-persistence/src/test/resources/dbintegration_test_persistence.xml
+++ b/dataverse-persistence/src/test/resources/dbintegration_test_persistence.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<persistence version="1.0"
+	xmlns="http://java.sun.com/xml/ns/persistence"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_1_0.xsd">
+
+	<persistence-unit name="dvndb-test"
+		transaction-type="RESOURCE_LOCAL">
+		<provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
+		<exclude-unlisted-classes>false</exclude-unlisted-classes>
+		<jar-file>file:./target/classes</jar-file>
+		<properties>		
+			<!-- NOTE: Enabling changetracking weaving will cause issues with dataset 
+				creation -->
+			<property name="eclipselink.weaving.changetracking"
+				value="false" />
+			<property name="eclipselink.weaving.lazy" value="true" />
+			<property name="eclipselink.weaving.eager" value="true" /> 
+			<property name="eclipselink.weaving.fetchgroups"
+				value="true" />
+			<property name="eclipselink.weaving.internal" value="true" /> 
+
+			<property name="eclipselink.ddl-generation" value="none" />
+			<property name="eclipselink.cache.shared.default"
+				value="false" />
+			<!-- The following property allows primary keys of 0 -->
+			<property name="eclipselink.id-validation" value="NULL" />
+			<!-- <property name="eclipselink.logging.level.sql" value="FINE"/> -->
+		</properties>
+	</persistence-unit>
+</persistence>


### PR DESCRIPTION
The proposal is to remove the necessity of running Glassfish to run integration tests. By manually instantiating EntityManager, integration tests are run just like ordinary JUnit tests. This also speeds up test suite execution.

The intention is to refactor integration tests in dataverse-webapp to use this solution and not require Glassfish at all.

I am aware that this does not mimic she Glassfish runtime (transactions not present), and some rare bugs might not be detected, but I think that having a fast, sefl-contained test suite that can be run more frequently offsets this. 