### PR TITLE
DataFile refactorings

### DIFF
--- a/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/datafile/DataFile.java
+++ b/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/datafile/DataFile.java
@@ -1,23 +1,20 @@
 package edu.harvard.iq.dataverse.persistence.datafile;
 
-import com.google.gson.annotations.Expose;
-import edu.harvard.iq.dataverse.common.BundleUtil;
-import edu.harvard.iq.dataverse.common.FileSizeUtil;
-import edu.harvard.iq.dataverse.common.FriendlyFileTypeUtil;
-import edu.harvard.iq.dataverse.common.files.mime.PackageMimeType;
-import edu.harvard.iq.dataverse.common.files.mime.ShapefileMimeType;
-import edu.harvard.iq.dataverse.persistence.DvObject;
-import edu.harvard.iq.dataverse.persistence.datafile.ingest.IngestReport;
-import edu.harvard.iq.dataverse.persistence.datafile.ingest.IngestRequest;
-import edu.harvard.iq.dataverse.persistence.dataset.Dataset;
-import edu.harvard.iq.dataverse.persistence.dataset.DatasetVersion.VersionState;
-import edu.harvard.iq.dataverse.persistence.guestbook.GuestbookResponse;
-import edu.harvard.iq.dataverse.persistence.user.AuthenticatedUser;
-import org.eclipse.persistence.annotations.BatchFetch;
-import org.eclipse.persistence.annotations.BatchFetchType;
-import org.hibernate.validator.constraints.NotBlank;
+import static edu.harvard.iq.dataverse.common.BundleUtil.getStringFromBundle;
+import static java.lang.Boolean.TRUE;
+import static java.util.stream.Collectors.toList;
+import static javax.persistence.CascadeType.MERGE;
+import static javax.persistence.CascadeType.PERSIST;
+import static javax.persistence.CascadeType.REMOVE;
+import static org.eclipse.persistence.annotations.BatchFetchType.JOIN;
 
-import javax.persistence.CascadeType;
+import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -35,12 +32,22 @@ import javax.persistence.OneToOne;
 import javax.persistence.Table;
 import javax.persistence.Transient;
 import javax.validation.constraints.Pattern;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Locale;
-import java.util.Objects;
+
+import org.eclipse.persistence.annotations.BatchFetch;
+import org.hibernate.validator.constraints.NotBlank;
+
+import com.google.gson.annotations.Expose;
+
+import edu.harvard.iq.dataverse.common.FileSizeUtil;
+import edu.harvard.iq.dataverse.common.FriendlyFileTypeUtil;
+import edu.harvard.iq.dataverse.common.files.mime.PackageMimeType;
+import edu.harvard.iq.dataverse.common.files.mime.ShapefileMimeType;
+import edu.harvard.iq.dataverse.persistence.DvObject;
+import edu.harvard.iq.dataverse.persistence.datafile.ingest.IngestReport;
+import edu.harvard.iq.dataverse.persistence.datafile.ingest.IngestRequest;
+import edu.harvard.iq.dataverse.persistence.dataset.Dataset;
+import edu.harvard.iq.dataverse.persistence.guestbook.GuestbookResponse;
+import edu.harvard.iq.dataverse.persistence.user.AuthenticatedUser;
 
 /**
  * @author gdurand
@@ -127,31 +134,28 @@ public class DataFile extends DvObject implements Comparable<DataFile> {
     //    Tabular (formerly "subsettable") data files have DataTable objects
     //    associated with them:
 
-    @OneToOne(mappedBy = "dataFile", cascade = {CascadeType.REMOVE, CascadeType.MERGE, CascadeType.PERSIST})
-    @BatchFetch(BatchFetchType.JOIN)
+    @OneToOne(mappedBy = "dataFile", cascade = {REMOVE, MERGE, PERSIST})
+    @BatchFetch(JOIN)
     private DataTable dataTable;
 
-    @OneToMany(mappedBy = "dataFile", cascade = {CascadeType.REMOVE, CascadeType.MERGE, CascadeType.PERSIST},
-            orphanRemoval = true)
+    @OneToMany(mappedBy = "dataFile", cascade = {REMOVE, MERGE, PERSIST}, orphanRemoval = true)
     private List<IngestReport> ingestReports;
 
-    @OneToOne(mappedBy = "dataFile", cascade = {CascadeType.REMOVE, CascadeType.MERGE, CascadeType.PERSIST})
-    @BatchFetch(BatchFetchType.JOIN)
+    @OneToOne(mappedBy = "dataFile", cascade = {REMOVE, MERGE, PERSIST})
+    @BatchFetch(JOIN)
     private IngestRequest ingestRequest;
 
-    @OneToMany(mappedBy = "dataFile", orphanRemoval = true,
-            cascade = {CascadeType.REMOVE, CascadeType.MERGE, CascadeType.PERSIST})
+    @OneToMany(mappedBy = "dataFile", cascade = {REMOVE, MERGE, PERSIST}, orphanRemoval = true)
     private List<DataFileTag> dataFileTags = new ArrayList<>();
 
-    @OneToMany(mappedBy = "dataFile", orphanRemoval = true,
-            cascade = {CascadeType.REMOVE, CascadeType.MERGE, CascadeType.PERSIST})
+    @OneToMany(mappedBy = "dataFile", cascade = {REMOVE, MERGE, PERSIST}, orphanRemoval = true)
     private List<FileMetadata> fileMetadatas;
 
-    @OneToMany(mappedBy = "dataFile", cascade = {CascadeType.REMOVE, CascadeType.MERGE, CascadeType.PERSIST})
+    @OneToMany(mappedBy = "dataFile", cascade = {REMOVE, MERGE, PERSIST})
     private List<GuestbookResponse> guestbookResponses;
 
     @OneToOne(mappedBy = "thumbnailFile")
-    @BatchFetch(BatchFetchType.JOIN)
+    @BatchFetch(JOIN)
     private Dataset thumbnailForDataset;
 
     @ManyToMany
@@ -168,7 +172,7 @@ public class DataFile extends DvObject implements Comparable<DataFile> {
      * the file from being ingested.
      */
     @Transient
-    private Boolean includedInIngest = Boolean.TRUE;
+    private Boolean includedInIngest = TRUE;
 
     private char ingestStatus = INGEST_STATUS_NONE;
 
@@ -275,19 +279,12 @@ public class DataFile extends DvObject implements Comparable<DataFile> {
     // -------------------- LOGIC --------------------
 
     public List<String> getTagLabels() {
-        List<DataFileTag> currentDataTags = this.getTags();
-        List<String> tagStrings = new ArrayList<>();
-
-        if (currentDataTags != null && !currentDataTags.isEmpty()) {
-            for (DataFileTag element : currentDataTags) {
-                tagStrings.add(element.getTypeLabel());
-            }
-        }
-        return tagStrings;
+        return this.dataFileTags.stream().map(DataFileTag::getTypeLabel)
+                .collect(toList());
     }
 
-    public void addTag(DataFileTag tag) {
-        dataFileTags.add(tag);
+    public void addTag(final DataFileTag tag) {
+        this.dataFileTags.add(tag);
     }
 
     public IngestReport getIngestReport() {
@@ -355,28 +352,21 @@ public class DataFile extends DvObject implements Comparable<DataFile> {
     }
 
     public FileMetadata getLatestFileMetadata() {
-        FileMetadata fmd = null;
-
-        // for newly added or harvested, just return the one fmd
-        if (fileMetadatas.size() == 1) {
-            return fileMetadatas.get(0);
-        }
-
-        for (FileMetadata fileMetadata : fileMetadatas) {
-            // if it finds a draft, return it
-            if (fileMetadata.getDatasetVersion().getVersionState().equals(VersionState.DRAFT)) {
-                return fileMetadata;
+        if (this.fileMetadatas.isEmpty()) {
+            return null;
+        } else if (this.fileMetadatas.size() == 1) { // for newly added or harvested
+            return this.fileMetadatas.get(0);
+        } else {
+            FileMetadata result = this.fileMetadatas.get(0);
+            for (final FileMetadata fileMetadata : this.fileMetadatas) {
+                if (fileMetadata.getDatasetVersion().isDraft()) {
+                    return fileMetadata;
+                } else if (fileMetadata.refersToNewerDatasetVersionThan(result)) {
+                    result = fileMetadata;
+                }
             }
-
-            // otherwise return the one with the latest version number
-            if (fmd == null
-                    || fileMetadata.getDatasetVersion().getVersionNumber().compareTo(fmd.getDatasetVersion().getVersionNumber()) > 0
-                    || (fileMetadata.getDatasetVersion().getVersionNumber().compareTo(fmd.getDatasetVersion().getVersionNumber()) == 0 &&
-                        fileMetadata.getDatasetVersion().getMinorVersionNumber().compareTo(fmd.getDatasetVersion().getMinorVersionNumber()) > 0)) {
-                fmd = fileMetadata;
-            }
+            return result;
         }
-        return fmd;
     }
 
     public long getFilesize() {
@@ -400,7 +390,7 @@ public class DataFile extends DvObject implements Comparable<DataFile> {
     }
 
     public String getOriginalChecksumType() {
-        return BundleUtil.getStringFromBundle("file.originalChecksumType", this.checksumType.toString());
+        return getStringFromBundle("file.originalChecksumType", this.checksumType.toString());
     }
 
     // Does the contentType indicate a shapefile?
@@ -473,14 +463,9 @@ public class DataFile extends DvObject implements Comparable<DataFile> {
     }
 
     public boolean isHarvested() {
-        // (storageIdentifier is not nullable - so no need to check for null
-        // pointers below):
-        if (getStorageIdentifier().startsWith("http://") || this.getStorageIdentifier().startsWith("https://")) {
-            return true;
-        }
-
-        Dataset ownerDataset = this.getOwner();
-        return ownerDataset != null && ownerDataset.isHarvested();
+        return getStorageIdentifier().startsWith("http://")
+                || this.getStorageIdentifier().startsWith("https://")
+                || getOwner().isHarvested();
     }
 
     public String getRemoteArchiveURL() {
@@ -489,8 +474,8 @@ public class DataFile extends DvObject implements Comparable<DataFile> {
 
     @Override
     protected String toStringExtras() {
-        FileMetadata fmd = getLatestFileMetadata();
-        return "label:" + (fmd != null ? fmd.getLabel() : "[no metadata]");
+        final FileMetadata fmd = getLatestFileMetadata();
+        return fmd != null ? "label:".concat(fmd.getLabel()) : "label:[no metadata]";
     }
 
     @Override
@@ -512,18 +497,19 @@ public class DataFile extends DvObject implements Comparable<DataFile> {
      * Check if the Geospatial Tag has been assigned to this file
      */
     public boolean hasGeospatialTag() {
-        return this.dataFileTags.stream()
-                .anyMatch(DataFileTag::isGeospatialTag);
+        return this.dataFileTags.stream().anyMatch(DataFileTag::isGeospatialTag);
     }
 
     public String getPublicationDateFormattedYYYYMMDD() {
-        return getPublicationDate() != null
-                ? new SimpleDateFormat("yyyy-MM-dd").format(getPublicationDate()) : null;
+        return getPublicationDate() != null ? format(getPublicationDate()) : null;
     }
 
     public String getCreateDateFormattedYYYYMMDD() {
-        return getCreateDate() != null
-                ? new SimpleDateFormat("yyyy-MM-dd").format(getCreateDate()) : null;
+        return getCreateDate() != null ? format(getCreateDate()) : null;
+    }
+    
+    private static String format(final Timestamp ts) {
+        return new SimpleDateFormat("yyyy-MM-dd").format(ts);
     }
 
     // -------------------- PRIVATE --------------------
@@ -555,8 +541,8 @@ public class DataFile extends DvObject implements Comparable<DataFile> {
         this.dataTable = dataTable;
     }
 
-    public void setTags(List<DataFileTag> dataFileTags) {
-        this.dataFileTags = dataFileTags;
+    public void setTags(final List<DataFileTag> dataFileTags) {
+        this.dataFileTags = dataFileTags != null ? dataFileTags : new ArrayList<>();
     }
 
     public void setFileMetadatas(List<FileMetadata> fileMetadatas) {
@@ -649,21 +635,19 @@ public class DataFile extends DvObject implements Comparable<DataFile> {
             this.text = text;
         }
 
-        public static ChecksumType fromString(String text) {
-            if (text != null) {
-                for (ChecksumType checksumType : ChecksumType.values()) {
-                    if (text.equals(checksumType.text)) {
-                        return checksumType;
-                    }
+        public static ChecksumType fromString(final String text) {
+            for (final ChecksumType checksumType : values()) {
+                if (checksumType.text.equals(text)) {
+                    return checksumType;
                 }
             }
-            throw new IllegalArgumentException("ChecksumType must be one of these values: "
-                    + Arrays.asList(ChecksumType.values()) + ".");
+            throw new IllegalArgumentException(
+                    "ChecksumType must be one of these values: " + values() + ".");
         }
 
         @Override
         public String toString() {
-            return text;
+            return this.text;
         }
     }
 }

--- a/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/datafile/DataFileTag.java
+++ b/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/datafile/DataFileTag.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * @author Leonid Andreev
@@ -93,14 +94,8 @@ public class DataFileTag implements JpaEntity<Long>, Serializable {
         TagLabelToTypes.put("Geospatial", TagType.Geospatial);
     }
 
-    public static List<String> listTags() {
-        List<String> retlist = new ArrayList<>();
-
-        for (TagType t : TagType.values()) {
-            retlist.add(TagTypeToLabels.get(t));
-        }
-
-        return retlist;
+    public static List<String> listTags() {     
+        return new ArrayList<>(TagLabelToTypes.keySet());
     }
 
     @Column(nullable = false)
@@ -147,17 +142,12 @@ public class DataFileTag implements JpaEntity<Long>, Serializable {
      * @return
      */
     public boolean isGeospatialTag() {
-        if (this.type == null) {
-            return false;
-        }
         return this.type == TagType.Geospatial;
     }
 
     @Override
     public int hashCode() {
-        int hash = 0;
-        hash += (id != null ? id.hashCode() : 0);
-        return hash;
+        return Objects.hashCode(this.id);
     }
 
     @Override

--- a/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/datafile/FileMetadata.java
+++ b/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/datafile/FileMetadata.java
@@ -1,22 +1,24 @@
 package edu.harvard.iq.dataverse.persistence.datafile;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.annotations.Expose;
-import edu.harvard.iq.dataverse.persistence.JpaEntity;
-import edu.harvard.iq.dataverse.persistence.datafile.license.FileTermsOfUse;
-import edu.harvard.iq.dataverse.persistence.datafile.license.TermsOfUseForm;
-import edu.harvard.iq.dataverse.persistence.dataset.DatasetVersion;
-import org.apache.commons.lang3.StringUtils;
-import org.eclipse.persistence.annotations.BatchFetch;
-import org.eclipse.persistence.annotations.BatchFetchType;
-import org.hibernate.validator.constraints.NotBlank;
+import static java.util.stream.Collectors.toList;
+import static javax.persistence.CascadeType.MERGE;
+import static javax.persistence.CascadeType.PERSIST;
+import static javax.persistence.CascadeType.REMOVE;
+import static org.eclipse.persistence.annotations.BatchFetchType.JOIN;
+
+import java.io.Serializable;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import javax.json.Json;
 import javax.json.JsonArrayBuilder;
-import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -33,16 +35,21 @@ import javax.persistence.Table;
 import javax.persistence.Transient;
 import javax.persistence.Version;
 import javax.validation.constraints.Pattern;
-import java.io.Serializable;
-import java.sql.Timestamp;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Comparator;
-import java.util.Date;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.persistence.annotations.BatchFetch;
+import org.hibernate.validator.constraints.NotBlank;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.annotations.Expose;
+
+import edu.harvard.iq.dataverse.persistence.JpaEntity;
+import edu.harvard.iq.dataverse.persistence.datafile.license.FileTermsOfUse;
+import edu.harvard.iq.dataverse.persistence.datafile.license.TermsOfUseForm;
+import edu.harvard.iq.dataverse.persistence.dataset.DatasetVersion;
 
 
 /**
@@ -76,7 +83,7 @@ public class FileMetadata implements JpaEntity<Long>, Serializable {
 
     @ManyToOne
     @JoinColumn(nullable = false)
-    @BatchFetch(BatchFetchType.JOIN)
+    @BatchFetch(JOIN)
     private DataFile dataFile;
 
     /**
@@ -89,9 +96,9 @@ public class FileMetadata implements JpaEntity<Long>, Serializable {
 
     private int displayOrder;
 
-    @OneToOne(cascade = {CascadeType.MERGE, CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true)
+    @OneToOne(cascade = {MERGE, PERSIST, REMOVE}, orphanRemoval = true)
     @JoinColumn(nullable = false, name = "termsofuse_id")
-    @BatchFetch(BatchFetchType.JOIN)
+    @BatchFetch(JOIN)
     private FileTermsOfUse termsOfUse;
 
     /**
@@ -181,37 +188,18 @@ public class FileMetadata implements JpaEntity<Long>, Serializable {
      * @return
      */
     public List<String> getCategoriesByName() {
-        ArrayList<String> ret = new ArrayList<>();
-
-        if (fileCategories.isEmpty()) {
-            return ret;
-        }
-
-        for (DataFileCategory fileCategory : fileCategories) {
-            ret.add(fileCategory.getName());
-        }
-
-        return ret;
+        return this.fileCategories.stream().map(DataFileCategory::getName)
+                .collect(toList());
     }
 
 
     public JsonArrayBuilder getCategoryNamesAsJsonArrayBuilder() {
-
-        JsonArrayBuilder builder = Json.createArrayBuilder();
-
-        if (fileCategories.isEmpty()) {
-            return builder;
-        }
-
-        for (DataFileCategory fileCategory : fileCategories) {
+        final JsonArrayBuilder builder = Json.createArrayBuilder();
+        
+        for (final DataFileCategory fileCategory : this.fileCategories) {
             builder.add(fileCategory.getName());
         }
-
-        //fileCategories.stream()
-        //              .map(x -> builder.add(x.getName()));
-
         return builder;
-
     }
 
 
@@ -242,38 +230,6 @@ public class FileMetadata implements JpaEntity<Long>, Serializable {
             }
         }
     }
-
-    /*
-        note that this version only *adds* new categories, but does not
-        remove the ones that has been unchecked!
-    public void setCategoriesByName(List<String> newCategoryNames) {
-        if (newCategoryNames != null) {
-            Collection<String> oldCategoryNames = getCategoriesByName();
-
-
-            for (int i = 0; i < newCategoryNames.size(); i++) {
-                if (!oldCategoryNames.contains(newCategoryNames.get(i))) {
-                    // Dataset.getCategoryByName() will check if such a category
-                    // already exists for the parent dataset; it will be created
-                    // if not. The method will return null if the supplied
-                    // category name is null or empty. -- L.A. 4.0 beta 10
-                    DataFileCategory fileCategory = null;
-                    try {
-                        // Using "try {}" to catch any null pointer exceptions,
-                        // just in case:
-                        fileCategory = this.getDatasetVersion().getDataset().getCategoryByName(newCategoryNames.get(i));
-                    } catch (Exception ex) {
-                        fileCategory = null;
-                    }
-                    if (fileCategory != null) {
-                        this.addCategory(fileCategory);
-                        fileCategory.addFileMetadata(this);
-                    }
-                }
-            }
-        }
-    }
-    */
 
     public void addCategoryByName(String newCategoryName) {
         if (newCategoryName != null && !newCategoryName.isEmpty()) {
@@ -398,6 +354,10 @@ public class FileMetadata implements JpaEntity<Long>, Serializable {
     public boolean isSelected() {
         return selected;
     }
+    
+    public boolean refersToNewerDatasetVersionThan(final FileMetadata other) {
+        return this.datasetVersion.isNewerThan(other.datasetVersion);
+    }
 
     public void setSelected(boolean selected) {
         this.selected = selected;
@@ -488,12 +448,8 @@ public class FileMetadata implements JpaEntity<Long>, Serializable {
         return "edu.harvard.iq.dvn.core.study.FileMetadata[id=" + id + "]";
     }
 
-    public static final Comparator<FileMetadata> compareByDisplayOrder = new Comparator<FileMetadata>() {
-        @Override
-        public int compare(FileMetadata o1, FileMetadata o2) {
-            return o1.getDisplayOrder() - o2.getDisplayOrder();
-        }
-    };
+    public static final Comparator<FileMetadata> compareByDisplayOrder = 
+            (o1, o2) -> o1.getDisplayOrder() - o2.getDisplayOrder();
 
 
     public String toPrettyJSON() {
@@ -510,12 +466,8 @@ public class FileMetadata implements JpaEntity<Long>, Serializable {
      * @param prettyPrint
      * @return
      */
-    private String serializeAsJSON(boolean prettyPrint) {
-
-        JsonObject jsonObj = asGsonObject(prettyPrint);
-
-        return jsonObj.toString();
-
+    private String serializeAsJSON(final boolean prettyPrint) {
+        return asGsonObject(prettyPrint).toString();
     }
 
 

--- a/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/datafile/ingest/IngestError.java
+++ b/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/datafile/ingest/IngestError.java
@@ -1,6 +1,6 @@
 package edu.harvard.iq.dataverse.persistence.datafile.ingest;
 
-import edu.harvard.iq.dataverse.common.BundleUtil;
+import static edu.harvard.iq.dataverse.common.BundleUtil.getStringFromBundle;
 
 import java.util.List;
 
@@ -38,12 +38,10 @@ public enum IngestError {
     GENERAL_TOO_MANY_VARIABLES,
     UNKNOWN_ERROR;
 
-    public static String ERROR_KEY_PREFIX = "ingest.error.";
-
     // -------------------- LOGIC --------------------
 
-    public String getErrorMessage(List<String> arguments) {
-        return BundleUtil.getStringFromBundle(ERROR_KEY_PREFIX + toString(), arguments.toArray());
+    public String getErrorMessage(final List<String> arguments) {
+        return getStringFromBundle("ingest.error.".concat(name()), arguments.toArray());
     }
 
 }

--- a/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/datafile/ingest/IngestReport.java
+++ b/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/datafile/ingest/IngestReport.java
@@ -6,15 +6,22 @@
 
 package edu.harvard.iq.dataverse.persistence.datafile.ingest;
 
-import edu.harvard.iq.dataverse.persistence.JpaEntity;
-import edu.harvard.iq.dataverse.persistence.datafile.DataFile;
+import static edu.harvard.iq.dataverse.persistence.datafile.ingest.IngestError.UNKNOWN_ERROR;
+import static java.util.Arrays.asList;
+import static javax.persistence.GenerationType.IDENTITY;
+import static javax.persistence.TemporalType.TIMESTAMP;
 
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import javax.persistence.Column;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Index;
 import javax.persistence.JoinColumn;
@@ -22,14 +29,9 @@ import javax.persistence.ManyToOne;
 import javax.persistence.OrderColumn;
 import javax.persistence.Table;
 import javax.persistence.Temporal;
-import javax.persistence.TemporalType;
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
-import java.util.Optional;
+
+import edu.harvard.iq.dataverse.persistence.JpaEntity;
+import edu.harvard.iq.dataverse.persistence.datafile.DataFile;
 
 /**
  * @author Leonid Andreev
@@ -39,7 +41,7 @@ import java.util.Optional;
 public class IngestReport implements JpaEntity<Long>, Serializable {
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue(strategy = IDENTITY)
     private Long id;
 
     public Long getId() {
@@ -61,8 +63,9 @@ public class IngestReport implements JpaEntity<Long>, Serializable {
     @JoinColumn(nullable = false)
     private DataFile dataFile;
 
+    @Column(nullable = false)
     @Enumerated(EnumType.STRING)
-    private IngestError errorKey;
+    private IngestError errorKey = UNKNOWN_ERROR;
 
     @ElementCollection
     @OrderColumn
@@ -72,10 +75,10 @@ public class IngestReport implements JpaEntity<Long>, Serializable {
 
     private int status;
 
-    @Temporal(value = TemporalType.TIMESTAMP)
+    @Temporal(value = TIMESTAMP)
     private Date startTime;
 
-    @Temporal(value = TemporalType.TIMESTAMP)
+    @Temporal(value = TIMESTAMP)
     private Date endTime;
 
     public int getType() {
@@ -106,8 +109,8 @@ public class IngestReport implements JpaEntity<Long>, Serializable {
         return errorKey;
     }
 
-    public void setErrorKey(IngestError errorKey) {
-        this.errorKey = errorKey;
+    public void setErrorKey(final IngestError errorKey) {
+        this.errorKey = errorKey != null ? errorKey : UNKNOWN_ERROR;
     }
 
     public DataFile getDataFile() {
@@ -141,28 +144,26 @@ public class IngestReport implements JpaEntity<Long>, Serializable {
     // -------------------- LOGIC --------------------
 
     public String getIngestReportMessage() {
-
-        return Optional.ofNullable(this.errorKey)
-                       .orElse(IngestError.UNKNOWN_ERROR)
-                       .getErrorMessage(errorArguments);
+        return this.errorKey.getErrorMessage(this.errorArguments);
     }
 
-    public static IngestReport createIngestFailureReport(DataFile dataFile, IngestException ingestException) {
+    public static IngestReport createIngestFailureReport(DataFile dataFile,
+            IngestException ingestException) {
         return createIngestFailureReport(dataFile,
-                                         ingestException.getErrorKey(),
-                                         ingestException.getErrorArguments().toArray(new String[0]));
+                ingestException.getErrorKey(),
+                ingestException.getErrorArguments());
 
     }
 
-    public static IngestReport createIngestFailureReport(DataFile dataFile, IngestError errorKey, String... errorArguments) {
-        List<String> args = Optional.ofNullable(errorArguments).map(Arrays::asList).orElseGet(Collections::emptyList);
-
-        return createIngestFailureReport(dataFile, errorKey, args);
+    public static IngestReport createIngestFailureReport(DataFile dataFile,
+            IngestError errorKey, String... errorArguments) {
+        return createIngestFailureReport(dataFile, errorKey, asList(errorArguments));
     }
 
-    public static IngestReport createIngestFailureReport(DataFile dataFile, IngestError errorKey, List<String> errorArguments) {
+    public static IngestReport createIngestFailureReport(DataFile dataFile,
+            IngestError errorKey, List<String> errorArguments) {
 
-        IngestReport errorReport = new IngestReport();
+        final IngestReport errorReport = new IngestReport();
         errorReport.setFailure();
         errorReport.setErrorKey(errorKey);
         errorReport.setDataFile(dataFile);
@@ -173,9 +174,7 @@ public class IngestReport implements JpaEntity<Long>, Serializable {
 
     @Override
     public int hashCode() {
-        int hash = 0;
-        hash += (id != null ? id.hashCode() : 0);
-        return hash;
+        return this.id != null ? this.id.hashCode() : 0;
     }
 
     @Override

--- a/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/datafile/ingest/IngestRequest.java
+++ b/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/datafile/ingest/IngestRequest.java
@@ -5,18 +5,21 @@
  */
 package edu.harvard.iq.dataverse.persistence.datafile.ingest;
 
-import edu.harvard.iq.dataverse.persistence.datafile.DataFile;
+import static javax.persistence.CascadeType.MERGE;
+import static javax.persistence.CascadeType.PERSIST;
+import static javax.persistence.GenerationType.IDENTITY;
 
-import javax.persistence.CascadeType;
+import java.io.Serializable;
+
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Index;
 import javax.persistence.JoinColumn;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
-import java.io.Serializable;
+
+import edu.harvard.iq.dataverse.persistence.datafile.DataFile;
 
 /**
  * @author Leonid Andreev
@@ -26,7 +29,7 @@ import java.io.Serializable;
 public class IngestRequest implements Serializable {
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue(strategy = IDENTITY)
     private Long id;
 
     public Long getId() {
@@ -37,7 +40,7 @@ public class IngestRequest implements Serializable {
         this.id = id;
     }
 
-    @OneToOne(cascade = {CascadeType.MERGE, CascadeType.PERSIST})
+    @OneToOne(cascade = {MERGE, PERSIST})
     @JoinColumn(name = "datafile_id")
     private DataFile dataFile;
 
@@ -93,17 +96,12 @@ public class IngestRequest implements Serializable {
     }
 
     public boolean isForceTypeCheck() {
-        if (forceTypeCheck != null) {
-            return forceTypeCheck;
-        }
-        return false;
+        return forceTypeCheck != null ? forceTypeCheck : false;
     }
 
     @Override
     public int hashCode() {
-        int hash = 0;
-        hash += (id != null ? id.hashCode() : 0);
-        return hash;
+        return this.id != null ? this.id.hashCode() : 0;
     }
 
     @Override

--- a/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/dataset/DatasetVersion.java
+++ b/dataverse-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/dataset/DatasetVersion.java
@@ -480,6 +480,12 @@ public class DatasetVersion implements Serializable, JpaEntity<Long>, DatasetVer
         return !fileMetadatas.isEmpty()
                 && !PackageMimeType.DATAVERSE_PACKAGE.getMimeValue().equals(fileMetadatas.get(0).getDataFile().getContentType());
     }
+    
+    public boolean isNewerThan(final DatasetVersion other) {
+        return this.versionNumber.compareTo(other.versionNumber) > 0
+            || (this.versionNumber.equals(other.versionNumber) &&
+                this.minorVersionNumber.compareTo(other.minorVersionNumber) > 0);
+    }
 
     public DatasetVersion cloneDatasetVersion() {
         DatasetVersion cloned = new DatasetVersion();

--- a/dataverse-persistence/src/main/resources/db/migration/V81__add_owner_id_not_null_for_files_and_datasets.sql
+++ b/dataverse-persistence/src/main/resources/db/migration/V81__add_owner_id_not_null_for_files_and_datasets.sql
@@ -1,0 +1,9 @@
+ALTER TABLE dvobject
+ADD CONSTRAINT owner_not_null_for_files_andDatasets CHECK 
+        (
+            (dtype = 'DataFile' and owner_id is not null)
+            or
+            (dtype = 'Dataset' and owner_id is not null)
+            or
+            (dtype = 'Dataverse')
+        );

--- a/dataverse-persistence/src/main/resources/db/migration/V82__add_not_null_with_default_value_to_ingestreport.sql
+++ b/dataverse-persistence/src/main/resources/db/migration/V82__add_not_null_with_default_value_to_ingestreport.sql
@@ -1,0 +1,9 @@
+ALTER TABLE ingestreport 
+ALTER COLUMN errorkey SET DEFAULT 'UNKNOWN_ERROR';
+
+UPDATE ingestreport
+SET errorkey = 'UNKNOWN_ERROR'
+WHERE errorkey IS NULL;
+
+ALTER TABLE ingestreport
+ALTER COLUMN errorkey SET NOT NULL;

--- a/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/datafile/DataFileTagTest.java
+++ b/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/datafile/DataFileTagTest.java
@@ -1,0 +1,15 @@
+package edu.harvard.iq.dataverse.persistence.datafile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class DataFileTagTest {
+
+    @Test
+    public void listTags_works() {
+
+        assertThat(DataFileTag.listTags()).containsExactlyInAnyOrder("Survey", "Time Series", "Panel",
+                "Event", "Genomics", "Network", "Geospatial");
+    }
+}

--- a/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/datafile/DataFileTest.java
+++ b/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/datafile/DataFileTest.java
@@ -1,0 +1,143 @@
+package edu.harvard.iq.dataverse.persistence.datafile;
+
+import static edu.harvard.iq.dataverse.persistence.datafile.DataFileTag.TagType.Survey;
+import static edu.harvard.iq.dataverse.persistence.datafile.DataFileTag.TagType.TimeSeries;
+import static edu.harvard.iq.dataverse.persistence.dataset.DatasetVersion.VersionState.DRAFT;
+import static edu.harvard.iq.dataverse.persistence.dataset.DatasetVersion.VersionState.RELEASED;
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static edu.harvard.iq.dataverse.persistence.datafile.DataFile.ChecksumType;
+import static edu.harvard.iq.dataverse.persistence.datafile.DataFile.ChecksumType.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import edu.harvard.iq.dataverse.persistence.dataset.Dataset;
+import edu.harvard.iq.dataverse.persistence.dataset.DatasetVersion;
+import edu.harvard.iq.dataverse.persistence.harvest.HarvestingClient;
+
+public class DataFileTest {
+
+    private final DataFileTag survey = new DataFileTag();
+    private final DataFileTag timeSeries = new DataFileTag();
+    private final FileMetadata olderVersionMetadata = new FileMetadata();
+    private final FileMetadata newerVersionMetadata = new FileMetadata();
+    private final FileMetadata draftMetadata = new FileMetadata();
+    
+    
+    @BeforeEach
+    public void setUp() {
+        this.survey.setType(Survey);
+        this.timeSeries.setType(TimeSeries);
+        
+        this.olderVersionMetadata.setDatasetVersion(new DatasetVersion());
+        this.olderVersionMetadata.getDatasetVersion().setVersionState(RELEASED);
+        this.olderVersionMetadata.getDatasetVersion().setVersionNumber(1L);
+        this.olderVersionMetadata.getDatasetVersion().setMinorVersionNumber(0L);
+        
+        this.newerVersionMetadata.setDatasetVersion(new DatasetVersion());
+        this.newerVersionMetadata.getDatasetVersion().setVersionState(RELEASED);
+        this.newerVersionMetadata.getDatasetVersion().setVersionNumber(2L);
+        this.newerVersionMetadata.getDatasetVersion().setMinorVersionNumber(0L);
+        
+        this.draftMetadata.setDatasetVersion(new DatasetVersion());
+        this.draftMetadata.getDatasetVersion().setVersionState(DRAFT);
+        this.draftMetadata.getDatasetVersion().setVersionNumber(2L);
+        this.draftMetadata.getDatasetVersion().setMinorVersionNumber(1L);
+        this.draftMetadata.setLabel("draft");
+    }
+    
+    @Test
+    public void settingTagLabels_works() {
+        
+        DataFile file = new DataFile();
+        
+        assertThat(file.getTagLabels()).isEmpty();
+        
+        file.addTag(this.survey);
+        file.addTag(this.timeSeries);
+        
+        assertThat(file.getTagLabels()).containsExactly("Survey", "Time Series");
+        
+        file.setTags(null);
+        
+        assertThat(file.getTagLabels()).isEmpty();
+    }
+    
+    @Test
+    public void gettingLatestFileMatadataWorks()  {
+        
+        DataFile file = new DataFile();
+        
+        assertThat(file.getLatestFileMetadata()).isNull();
+        
+        file.setFileMetadatas(asList(draftMetadata));
+        
+        assertThat(file.getLatestFileMetadata()).isSameAs(draftMetadata);
+        
+        file.setFileMetadatas(asList(olderVersionMetadata));
+        
+        assertThat(file.getLatestFileMetadata()).isSameAs(olderVersionMetadata);
+        
+        file.setFileMetadatas(asList(olderVersionMetadata, newerVersionMetadata));
+        
+        assertThat(file.getLatestFileMetadata()).isSameAs(newerVersionMetadata);
+        
+        file.setFileMetadatas(asList(olderVersionMetadata, newerVersionMetadata, draftMetadata));
+        
+        assertThat(file.getLatestFileMetadata()).isSameAs(draftMetadata);
+    }
+    
+    @Test
+    public void isHarvested_returnsTrue() {
+        DataFile file = new DataFile();  
+        file.setStorageIdentifier("http://google.com");
+        
+        assertThat(file.isHarvested()).isTrue();
+        
+        file.setStorageIdentifier("https://google.com");
+        
+        assertThat(file.isHarvested()).isTrue();
+  
+        file.setStorageIdentifier("ftp://google.com");
+        file.setOwner(new Dataset());
+        file.getOwner().setHarvestedFrom(new HarvestingClient());
+        assertThat(file.isHarvested()).isTrue();
+    }
+    
+    @Test
+    public void isHarvested_returnsFalse() {
+        DataFile file = new DataFile();
+        file.setStorageIdentifier("ftp://google.com");
+        file.setOwner(new Dataset());
+        file.getOwner().setHarvestedFrom(null);
+        
+        assertThat(file.isHarvested()).isFalse();
+    }
+    
+    @Test
+    public void toStringExtras_works() {
+        DataFile file = new DataFile();
+        
+        assertThat(file.toStringExtras()).isEqualTo("label:[no metadata]");
+        
+        file.setFileMetadatas(asList(draftMetadata));
+        assertThat(file.toStringExtras()).isEqualTo("label:draft");
+    }
+    
+    @Test
+    public void checsumType_fromString_returnsCheckSumType() {
+        assertThat(ChecksumType.fromString("MD5")).isSameAs(MD5);
+        assertThat(ChecksumType.fromString("SHA-1")).isSameAs(SHA1);
+        assertThat(ChecksumType.fromString("SHA-256")).isSameAs(SHA256);
+        assertThat(ChecksumType.fromString("SHA-512")).isSameAs(SHA512);
+    }
+    
+    @Test
+    public void checsumType_fromString_ThrowsException() {
+        assertThrows(IllegalArgumentException.class, () -> ChecksumType.fromString(null));
+        assertThrows(IllegalArgumentException.class, () -> ChecksumType.fromString(""));
+        assertThrows(IllegalArgumentException.class, () -> ChecksumType.fromString("abc"));
+    }
+}

--- a/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/datafile/FileMatadataTest.java
+++ b/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/datafile/FileMatadataTest.java
@@ -1,0 +1,36 @@
+package edu.harvard.iq.dataverse.persistence.datafile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class FileMatadataTest {
+
+    private final DataFileCategory category1 = new DataFileCategory();
+    private final DataFileCategory category2 = new DataFileCategory();
+
+    @BeforeEach
+    public void setUp() {
+        this.category1.setName("category1");
+        this.category2.setName("category2");
+    }
+
+    @Test
+    public void getCategoriesByName_works() {
+
+        FileMetadata meta = new FileMetadata();
+
+        assertThat(meta.getCategoriesByName()).isEmpty();
+
+        meta.addCategory(this.category1);
+
+        assertThat(meta.getCategoriesByName())
+                .containsExactly(this.category1.getName());
+
+        meta.addCategory(this.category2);
+
+        assertThat(meta.getCategoriesByName())
+                .containsExactly(this.category1.getName(), this.category2.getName());
+    }
+}

--- a/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/datafile/ingest/IngestReportTest.java
+++ b/dataverse-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/datafile/ingest/IngestReportTest.java
@@ -1,0 +1,43 @@
+package edu.harvard.iq.dataverse.persistence.datafile.ingest;
+
+import static edu.harvard.iq.dataverse.persistence.datafile.ingest.IngestError.UNZIP_FAIL;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import edu.harvard.iq.dataverse.persistence.datafile.DataFile;
+
+public class IngestReportTest {
+
+    @Test
+    public void getIngestErrorMessage_works() {
+        
+        IngestReport report = new IngestReport();
+        
+        assertThat(report.getIngestReportMessage()).isEqualTo("Unknown error occurred during ingest.");
+        
+        report.setErrorKey(UNZIP_FAIL);
+        assertThat(report.getIngestReportMessage()).isEqualTo("Failed to unzip the file.");
+    }
+    
+    @Test
+    public void createIngestFailureReport_works() {
+        
+        IngestReport report = IngestReport.createIngestFailureReport(new DataFile(), UNZIP_FAIL, "arg1");
+        
+        assertThat(report.getErrorArguments()).containsExactly("arg1");
+        
+        report = IngestReport.createIngestFailureReport(new DataFile(), UNZIP_FAIL);
+        
+        assertThat(report.getErrorArguments()).isEmpty();
+    }
+    
+    @Test
+    public void createIngestFailureReport_fromException_works() {
+        
+        IngestException exception = new IngestException(UNZIP_FAIL, "arg1");
+        IngestReport report = IngestReport.createIngestFailureReport(new DataFile(), exception);
+        
+        assertThat(report.getErrorArguments()).containsExactly("arg1");
+    }
+}

--- a/dataverse-webapp/src/test/java/edu/harvard/iq/dataverse/util/FileUtilTest.java
+++ b/dataverse-webapp/src/test/java/edu/harvard/iq/dataverse/util/FileUtilTest.java
@@ -161,9 +161,11 @@ public class FileUtilTest {
         assertFalse(FileUtil.isThumbnailSupported(null));
         // file with no content type:
         DataFile filewNoContentType = new DataFile("");
+        filewNoContentType.setOwner(new Dataset());
         filewNoContentType.setStorageIdentifier("");
         assertFalse(FileUtil.isThumbnailSupported(filewNoContentType));
         DataFile filewBogusContentType = new DataFile("");
+        filewBogusContentType.setOwner(new Dataset());
         filewBogusContentType.setStorageIdentifier("");
         assertFalse(FileUtil.isThumbnailSupported(filewBogusContentType));
     }


### PR DESCRIPTION
Did oportunistic refactoing of classes in edu.harvard.iq.dataverse.persistence.datafile package.
Introduced two new database contraints on tables dvobject and ingestreport which simplify application code.
Introduced tests to refactored methods to make sure behaviors didn't change.
