### PR TITLE
Fix translating facet label (fallback to dataset field value when it is not defined in bundle translation files)

### DIFF
--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/mydata/MyDataSearchFragment.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/mydata/MyDataSearchFragment.java
@@ -29,6 +29,7 @@ import edu.harvard.iq.dataverse.search.SearchServiceBean.SortOrder;
 import edu.harvard.iq.dataverse.search.query.SearchForTypes;
 import edu.harvard.iq.dataverse.search.query.SearchObjectType;
 import edu.harvard.iq.dataverse.search.response.FacetCategory;
+import edu.harvard.iq.dataverse.search.response.FacetLocaleNameResolver;
 import edu.harvard.iq.dataverse.search.response.FacetLabel;
 import edu.harvard.iq.dataverse.search.response.FilterQuery;
 import edu.harvard.iq.dataverse.search.response.SolrQueryResponse;
@@ -667,8 +668,8 @@ public class MyDataSearchFragment implements java.io.Serializable {
                     results.getOrDefault(SearchObjectType.FILES, Collections.emptyList()));
 
             for (String publicationStatusFilter: publicationStatusFilters) {
-                String key = format(SearchServiceBean.FACETBUNDLE_MASK_VALUE, "publicationStatus");
-                String value = format(SearchServiceBean.FACETBUNDLE_MASK_GROUP_AND_VALUE, "publicationStatus", publicationStatusFilter.toLowerCase().replace(" ", "_"));
+                String key = format(FacetLocaleNameResolver.FACETBUNDLE_MASK_VALUE, "publicationStatus");
+                String value = format(FacetLocaleNameResolver.FACETBUNDLE_MASK_GROUP_AND_VALUE, "publicationStatus", publicationStatusFilter.toLowerCase().replace(" ", "_"));
 
                 selectedFilterQueries.add(
                         new FilterQuery(publicationStatusFilter,

--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/search/SearchServiceBean.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/search/SearchServiceBean.java
@@ -1,9 +1,7 @@
 package edu.harvard.iq.dataverse.search;
 
-import com.google.common.collect.Lists;
 import edu.harvard.iq.dataverse.DatasetFieldServiceBean;
 import edu.harvard.iq.dataverse.DataverseDao;
-import edu.harvard.iq.dataverse.DvObjectServiceBean;
 import edu.harvard.iq.dataverse.common.BundleUtil;
 import edu.harvard.iq.dataverse.common.DatasetFieldConstant;
 import edu.harvard.iq.dataverse.common.FriendlyFileTypeUtil;
@@ -15,7 +13,6 @@ import edu.harvard.iq.dataverse.persistence.dataset.DatasetVersion;
 import edu.harvard.iq.dataverse.persistence.dataverse.Dataverse;
 import edu.harvard.iq.dataverse.persistence.dataverse.DataverseFacet;
 import edu.harvard.iq.dataverse.search.index.IndexServiceBean;
-import edu.harvard.iq.dataverse.search.index.IndexedTermOfUse;
 import edu.harvard.iq.dataverse.search.query.PermissionFilterQueryBuilder;
 import edu.harvard.iq.dataverse.search.query.SearchForTypes;
 import edu.harvard.iq.dataverse.search.query.SearchObjectType;
@@ -23,6 +20,7 @@ import edu.harvard.iq.dataverse.search.query.SearchPublicationStatus;
 import edu.harvard.iq.dataverse.search.query.SolrQuerySanitizer;
 import edu.harvard.iq.dataverse.search.response.DvObjectCounts;
 import edu.harvard.iq.dataverse.search.response.FacetCategory;
+import edu.harvard.iq.dataverse.search.response.FacetLocaleNameResolver;
 import edu.harvard.iq.dataverse.search.response.FacetLabel;
 import edu.harvard.iq.dataverse.search.response.FilterQuery;
 import edu.harvard.iq.dataverse.search.response.Highlight;
@@ -35,7 +33,6 @@ import edu.harvard.iq.dataverse.search.response.GeoPoint;
 import edu.harvard.iq.dataverse.settings.SettingsServiceBean;
 import edu.harvard.iq.dataverse.util.SystemConfig;
 import io.vavr.control.Try;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.SolrQuery.ORDER;
@@ -74,16 +71,11 @@ import static java.util.stream.Collectors.joining;
 
 import static edu.harvard.iq.dataverse.search.SearchFields.RELEASE_OR_CREATE_DATE;
 import static edu.harvard.iq.dataverse.search.SearchFields.RELEVANCE;
-import static java.lang.String.format;
 
 @Stateless
 public class SearchServiceBean {
 
     private static final Logger logger = Logger.getLogger(SearchServiceBean.class.getCanonicalName());
-
-    public static final String FACETBUNDLE_MASK_GROUP_AND_VALUE = "facets.search.fieldtype.%s.%s.label";
-    public static final String FACETBUNDLE_MASK_VALUE = "facets.search.fieldtype.%s.label";
-    private static final String FACETBUNDLE_MASK_DVCATEGORY_VALUE = "dataverse.type.selectTab.%s";
 
     public enum SortOrder {
         
@@ -109,7 +101,6 @@ public class SearchServiceBean {
         }
     }
 
-    private DvObjectServiceBean dvObjectService;
     private DatasetFieldServiceBean datasetFieldService;
     private SettingsServiceBean settingsService;
     private SystemConfig systemConfig;
@@ -126,12 +117,11 @@ public class SearchServiceBean {
     public SearchServiceBean() { }
 
     @Inject
-    public SearchServiceBean(DvObjectServiceBean dvObjectService, DatasetFieldServiceBean datasetFieldService,
+    public SearchServiceBean(DatasetFieldServiceBean datasetFieldService,
                              SettingsServiceBean settingsService, SystemConfig systemConfig,
                              PermissionFilterQueryBuilder permissionQueryBuilder, SolrClient solrServer,
                              SolrQuerySanitizer querySanitizer, LicenseRepository licenseRepository,
                              DataverseDao dataverseDao) {
-        this.dvObjectService = dvObjectService;
         this.datasetFieldService = datasetFieldService;
         this.settingsService = settingsService;
         this.systemConfig = systemConfig;
@@ -327,6 +317,8 @@ public class SearchServiceBean {
 
         List<FacetCategory> facetCategoryList = new ArrayList<>();
 
+        FacetLocaleNameResolver facetCategoryNameResolver = new FacetLocaleNameResolver(licenseRepository, fieldIndex);
+
         for (FacetField facetField : queryResponse.getFacetFields()) {
             if (!shouldIncludeFacetInResults(facetField)) {
                 continue;
@@ -334,14 +326,14 @@ public class SearchServiceBean {
 
             FacetCategory facetCategory = new FacetCategory();
             facetCategory.setName(facetField.getName());
-            facetCategory.setFriendlyName(getLocaleFacetCategoryName(facetField.getName(), fieldIndex));
+            facetCategory.setFriendlyName(facetCategoryNameResolver.getLocaleFacetCategoryName(facetField.getName()));
 
             List<FacetLabel> facetLabelList = new ArrayList<>();
 
             for (FacetField.Count facetFieldCount : facetField.getValues()) {
                 // @todo we do want to show the count for each facet
                 FacetLabel facetLabel = new FacetLabel(facetFieldCount.getName(),
-                        getLocaleFacetLabelName(facetFieldCount.getName(), facetField.getName(), fieldIndex),
+                        facetCategoryNameResolver.getLocaleFacetLabelName(facetFieldCount.getName(), facetField.getName()),
                         facetFieldCount.getCount());
                 // quote field facets
                 facetLabel.setFilterQuery(facetField.getName() + ":\"" + facetFieldCount.getName() + "\"");
@@ -382,8 +374,8 @@ public class SearchServiceBean {
 
                 solrQueryResponse.addFilterQuery(new FilterQuery(
                         filterQuery,
-                        getLocaleFacetCategoryName(key, fieldIndex),
-                        getLocaleFacetLabelName(value, key, fieldIndex)));
+                        facetCategoryNameResolver.getLocaleFacetCategoryName(key),
+                        facetCategoryNameResolver.getLocaleFacetLabelName(value, key)));
             }
 
         }
@@ -657,87 +649,6 @@ public class SearchServiceBean {
         return rootDataverseId;
     }
 
-    private String getLocaleFacetCategoryName(String facetCategoryName, Map<String, DatasetFieldType> index) {
-        final String formattedFacetFieldName = removeSolrFieldSuffix(facetCategoryName);
-
-        if (index.containsKey(formattedFacetFieldName)) {
-            return getDatasetFieldFacetCategoryName(index.get(formattedFacetFieldName));
-        } else {
-            return getNonDatasetFieldFacetCategoryName(facetCategoryName);
-        }
-    }
-
-    private String getLocaleFacetLabelName(String facetLabelName, String facetCategoryName,
-                                          Map<String, DatasetFieldType> index) {
-        String formattedFacetCategoryName = removeSolrFieldSuffix(facetCategoryName);
-        String formattedFacetLabelName = toBundleNameFormat(facetLabelName);
-
-        if (index.containsKey(formattedFacetCategoryName)) {
-            return getDatasetFieldFacetLabelName(facetLabelName, formattedFacetLabelName, index.get(formattedFacetCategoryName));
-
-        } else {
-            return getNonDatasetFieldFacetLabelName(facetLabelName, formattedFacetCategoryName);
-        }
-    }
-
-    private String getDatasetFieldFacetCategoryName(DatasetFieldType matchedDatasetField) {
-        if (matchedDatasetField.isFacetable() && !matchedDatasetField.isHasParent()) {
-            String key = format(FACETBUNDLE_MASK_VALUE, matchedDatasetField.getName());
-            return Optional.ofNullable(BundleUtil.getStringFromBundle(key))
-                    .filter(name -> !name.isEmpty())
-                    .orElse(matchedDatasetField.getDisplayName());
-        }
-        return matchedDatasetField.getDisplayName();
-    }
-
-    private String getNonDatasetFieldFacetCategoryName(String facetCategoryName) {
-        if(facetCategoryName.equals(SearchFields.TYPE)) {
-            return facetCategoryName;
-        }
-        String key = format(FACETBUNDLE_MASK_VALUE, facetCategoryName);
-        return BundleUtil.getStringFromBundle(key);
-    }
-
-    private String getDatasetFieldFacetLabelName(String facetLabelName, String formattedFacetLabelName,
-                                                 DatasetFieldType matchedDatasetField) {
-        if (matchedDatasetField.isControlledVocabulary()) {
-            String key = "controlledvocabulary." + matchedDatasetField.getName() + "." + formattedFacetLabelName;
-            String bundleName = matchedDatasetField.getMetadataBlock().getName().toLowerCase();
-            return BundleUtil.getStringFromNonDefaultBundle(key, bundleName);
-        }
-        return facetLabelName;
-    }
-
-    private String getNonDatasetFieldFacetLabelName(String facetLabelName, String formattedFacetCategoryName) {
-        String formattedFacetLabelName = toBundleNameFormat(facetLabelName);
-        List<String> translatableNonDictionaryFacets = Lists.newArrayList(SearchFields.PUBLICATION_STATUS,
-                SearchFields.DATAVERSE_CATEGORY, SearchFields.FILE_TYPE, SearchFields.ACCESS);
-
-        if(translatableNonDictionaryFacets.contains(formattedFacetCategoryName)) {
-            if(formattedFacetCategoryName.equals(SearchFields.DATAVERSE_CATEGORY)) {
-                String key = format(FACETBUNDLE_MASK_DVCATEGORY_VALUE, formattedFacetLabelName);
-                return BundleUtil.getStringFromBundle(key);
-            }
-            String key = format(FACETBUNDLE_MASK_GROUP_AND_VALUE, formattedFacetCategoryName, formattedFacetLabelName);
-            return BundleUtil.getStringFromBundle(key);
-        }
-
-        if(formattedFacetCategoryName.equals(SearchFields.METADATA_SOURCE) && formattedFacetLabelName.equals("harvested")) {
-            return BundleUtil.getStringFromBundle(formattedFacetLabelName);
-        }
-
-        if(formattedFacetCategoryName.equals(SearchFields.LICENSE)) {
-            return licenseRepository.findLicenseByName(facetLabelName)
-                .map(l -> l.getLocalizedName(BundleUtil.getCurrentLocale()))
-                .orElseGet(() -> {
-                    String label = BundleUtil.getStringFromBundle(IndexedTermOfUse.getLabelFromName(facetLabelName));
-                    return StringUtils.isBlank(label)?facetLabelName:label;
-                });
-        }
-
-        return facetLabelName;
-    }
-
     private SolrQuery addHighlightFields(SolrQuery solrQuery, Map<String, String> solrFieldsToHightlightOnMap) {
         Set<String> dynamicDatasetFieldsPrefixes = new HashSet<>();
 
@@ -758,24 +669,6 @@ public class SearchServiceBean {
 
     private boolean isFieldDynamic(String field) {
         return field.length() > 8 && SearchDynamicFieldPrefix.contains(field.substring(0, 8));
-    }
-
-    private String removeSolrFieldSuffix(String name) {
-        if(name.endsWith("_ss")) {
-            name = name.substring(0, name.length() - 3);
-        } else if (name.endsWith("_s")) {
-            name = name.substring(0, name.length() - 2);
-        }
-        return name;
-    }
-
-    /**
-     * if exist, multi word bundle names are connected with underscores and formatted toLowerCase
-     * @param name text for which we want to create its bundle name
-     * @return text with replaced spaces with underscores, and leading/trailing whitespaces removed, toLowerCased
-     */
-    private String toBundleNameFormat(String name) {
-        return StringUtils.stripAccents(name.toLowerCase().replace(" ", "_"));
     }
 
     private DvObjectCounts convertFacetToDvObjectCounts(FacetField dvObjectFacetField) {

--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/search/response/FacetLocaleNameResolver.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/search/response/FacetLocaleNameResolver.java
@@ -1,0 +1,130 @@
+package edu.harvard.iq.dataverse.search.response;
+
+import static java.lang.String.format;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.google.common.collect.Lists;
+
+import edu.harvard.iq.dataverse.common.BundleUtil;
+import edu.harvard.iq.dataverse.persistence.datafile.license.LicenseRepository;
+import edu.harvard.iq.dataverse.persistence.dataset.DatasetFieldType;
+import edu.harvard.iq.dataverse.search.SearchFields;
+import edu.harvard.iq.dataverse.search.index.IndexedTermOfUse;
+
+public class FacetLocaleNameResolver {
+
+    public static final String FACETBUNDLE_MASK_GROUP_AND_VALUE = "facets.search.fieldtype.%s.%s.label";
+    public static final String FACETBUNDLE_MASK_VALUE = "facets.search.fieldtype.%s.label";
+    private static final String FACETBUNDLE_MASK_DVCATEGORY_VALUE = "dataverse.type.selectTab.%s";
+
+    private LicenseRepository licenseRepository;
+    private Map<String, DatasetFieldType> fieldIndex;
+
+    public FacetLocaleNameResolver(LicenseRepository licenseRepository, Map<String, DatasetFieldType> index) {
+        this.licenseRepository = licenseRepository;
+        this.fieldIndex = index;
+    }
+
+    public String getLocaleFacetCategoryName(String facetCategoryName) {
+        final String formattedFacetFieldName = removeSolrFieldSuffix(facetCategoryName);
+
+        if (fieldIndex.containsKey(formattedFacetFieldName)) {
+            return getDatasetFieldFacetCategoryName(fieldIndex.get(formattedFacetFieldName));
+        } else {
+            return getNonDatasetFieldFacetCategoryName(facetCategoryName);
+        }
+    }
+
+    public String getLocaleFacetLabelName(String facetLabelName, String facetCategoryName) {
+        String formattedFacetCategoryName = removeSolrFieldSuffix(facetCategoryName);
+        String formattedFacetLabelName = toBundleNameFormat(facetLabelName);
+
+        if (fieldIndex.containsKey(formattedFacetCategoryName)) {
+            return getDatasetFieldFacetLabelName(facetLabelName, formattedFacetLabelName, fieldIndex.get(formattedFacetCategoryName));
+
+        } else {
+            return getNonDatasetFieldFacetLabelName(facetLabelName, formattedFacetCategoryName);
+        }
+    }
+
+    private String getDatasetFieldFacetCategoryName(DatasetFieldType matchedDatasetField) {
+        if (matchedDatasetField.isFacetable() && !matchedDatasetField.isHasParent()) {
+            String key = format(FACETBUNDLE_MASK_VALUE, matchedDatasetField.getName());
+            return Optional.ofNullable(BundleUtil.getStringFromBundle(key))
+                    .filter(name -> !name.isEmpty())
+                    .orElse(matchedDatasetField.getDisplayName());
+        }
+        return matchedDatasetField.getDisplayName();
+    }
+
+    private String getNonDatasetFieldFacetCategoryName(String facetCategoryName) {
+        if(facetCategoryName.equals(SearchFields.TYPE)) {
+            return facetCategoryName;
+        }
+        String key = format(FACETBUNDLE_MASK_VALUE, facetCategoryName);
+        return BundleUtil.getStringFromBundle(key);
+    }
+
+    private String getDatasetFieldFacetLabelName(String facetLabelName, String formattedFacetLabelName,
+                                                 DatasetFieldType matchedDatasetField) {
+        if (matchedDatasetField.isControlledVocabulary()) {
+            String key = "controlledvocabulary." + matchedDatasetField.getName() + "." + formattedFacetLabelName;
+            String bundleName = matchedDatasetField.getMetadataBlock().getName().toLowerCase();
+            return BundleUtil.getStringFromNonDefaultBundle(key, bundleName);
+        }
+        return facetLabelName;
+    }
+
+    private String getNonDatasetFieldFacetLabelName(String facetLabelName, String formattedFacetCategoryName) {
+        String formattedFacetLabelName = toBundleNameFormat(facetLabelName);
+        List<String> translatableNonDictionaryFacets = Lists.newArrayList(SearchFields.PUBLICATION_STATUS,
+                SearchFields.DATAVERSE_CATEGORY, SearchFields.FILE_TYPE, SearchFields.ACCESS);
+
+        if(translatableNonDictionaryFacets.contains(formattedFacetCategoryName)) {
+            if(formattedFacetCategoryName.equals(SearchFields.DATAVERSE_CATEGORY)) {
+                String key = format(FACETBUNDLE_MASK_DVCATEGORY_VALUE, formattedFacetLabelName);
+                return BundleUtil.getStringFromBundle(key);
+            }
+            String key = format(FACETBUNDLE_MASK_GROUP_AND_VALUE, formattedFacetCategoryName, formattedFacetLabelName);
+            return BundleUtil.getStringFromBundle(key);
+        }
+
+        if(formattedFacetCategoryName.equals(SearchFields.METADATA_SOURCE) && formattedFacetLabelName.equals("harvested")) {
+            return BundleUtil.getStringFromBundle(formattedFacetLabelName);
+        }
+
+        if(formattedFacetCategoryName.equals(SearchFields.LICENSE)) {
+            return licenseRepository.findLicenseByName(facetLabelName)
+                .map(l -> l.getLocalizedName(BundleUtil.getCurrentLocale()))
+                .orElseGet(() -> {
+                    String label = BundleUtil.getStringFromBundle(IndexedTermOfUse.getLabelFromName(facetLabelName));
+                    return StringUtils.isBlank(label)?facetLabelName:label;
+                });
+        }
+
+        return facetLabelName;
+    }
+
+    private String removeSolrFieldSuffix(String name) {
+        if(name.endsWith("_ss")) {
+            name = name.substring(0, name.length() - 3);
+        } else if (name.endsWith("_s")) {
+            name = name.substring(0, name.length() - 2);
+        }
+        return name;
+    }
+
+    /**
+     * if exist, multi word bundle names are connected with underscores and formatted toLowerCase
+     * @param name text for which we want to create its bundle name
+     * @return text with replaced spaces with underscores, and leading/trailing whitespaces removed, toLowerCased
+     */
+    private String toBundleNameFormat(String name) {
+        return StringUtils.stripAccents(name.toLowerCase().replace(" ", "_"));
+    }
+}

--- a/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/search/response/FacetLocaleNameResolver.java
+++ b/dataverse-webapp/src/main/java/edu/harvard/iq/dataverse/search/response/FacetLocaleNameResolver.java
@@ -75,7 +75,11 @@ public class FacetLocaleNameResolver {
         if (matchedDatasetField.isControlledVocabulary()) {
             String key = "controlledvocabulary." + matchedDatasetField.getName() + "." + formattedFacetLabelName;
             String bundleName = matchedDatasetField.getMetadataBlock().getName().toLowerCase();
-            return BundleUtil.getStringFromNonDefaultBundle(key, bundleName);
+            
+            String facetLabelTranslation = BundleUtil.getStringFromNonDefaultBundle(key, bundleName);
+            if (StringUtils.isNotBlank(formattedFacetLabelName)) {
+                return facetLabelTranslation;
+            }
         }
         return facetLabelName;
     }


### PR DESCRIPTION
When some installation was not using any extra translation files for file metadata that it defines there was a problem in filters. Code assumed that when we were dealing with controlled vocab values then `BundleUtil.getStringFromNonDefaultBundle(key, bundleName);` would return proper translation of vocabulary value. This is not the case when installation does not use translation bundles for it's metadata at all.

 - First commit is just moving code related to translating facets to separate service (without the actual fix).
 - The second commit is the actual fix

#2711 