### PR TITLE
Closes #2804: Allow to append extra javascript code via extension

### DIFF
--- a/fairchive-webapp/src/main/webapp/WEB-INF/templates/dataset/inputRenderer/controlledVocabInputField.xhtml
+++ b/fairchive-webapp/src/main/webapp/WEB-INF/templates/dataset/inputRenderer/controlledVocabInputField.xhtml
@@ -31,6 +31,7 @@
                      rendered="#{!datasetField.datasetFieldType.allowMultiples}"
                      filter="true"
                      filterMatchMode="contains"
+                     pt:data-field-type="#{datasetField.datasetFieldType.name}"
     >
         <f:selectItem itemLabel="#{bundle.select}" itemValue="" noSelectionOption="true"/>
         <f:selectItems value="#{datasetField.datasetFieldType.getControlledVocabSelectItems(inputRenderer.isSortByLocalisedStringsOrder())}" />
@@ -47,7 +48,8 @@
                 style="width: 100%" panelStyleClass="without-select-all"
                 multiple="true" label="#{bundle.select}" updateLabel="true"
                 filter="true" filterMatchMode="contains"
-                pt:aria-label="#{datasetField.datasetFieldType.localeTitle.concat(datasetField.datasetFieldType.requiredInDataverse ? ' *': '')}">
+                pt:aria-label="#{datasetField.datasetFieldType.localeTitle.concat(datasetField.datasetFieldType.requiredInDataverse ? ' *': '')}"
+                pt:data-field-type="#{datasetField.datasetFieldType.name}">
         
         <f:selectItems value="#{datasetField.datasetFieldType.getControlledVocabSelectItems(inputRenderer.isSortByLocalisedStringsOrder())}" />
     </p:selectCheckboxMenu>

--- a/fairchive-webapp/src/main/webapp/WEB-INF/templates/dataset/inputRenderer/geoboxTextAreaField.xhtml
+++ b/fairchive-webapp/src/main/webapp/WEB-INF/templates/dataset/inputRenderer/geoboxTextAreaField.xhtml
@@ -35,6 +35,7 @@
                  widgetVar="#{widgetVar}"
                  rows="5"
                  pt:data-handler="#{widgetVar}"
+                 pt:data-field-type="#{datasetField.datasetFieldType.name}"
                  styleClass="form-control"/>
 
     <script>

--- a/fairchive-webapp/src/main/webapp/WEB-INF/templates/dataset/inputRenderer/suggestionInputField.xhtml
+++ b/fairchive-webapp/src/main/webapp/WEB-INF/templates/dataset/inputRenderer/suggestionInputField.xhtml
@@ -2,7 +2,8 @@
         xmlns:h="http://java.sun.com/jsf/html"
         xmlns:ui="http://java.sun.com/jsf/facelets"
         xmlns:p="http://primefaces.org/ui"
-        xmlns:jsf="http://xmlns.jcp.org/jsf">
+        xmlns:jsf="http://xmlns.jcp.org/jsf"
+        xmlns:pt="http://xmlns.jcp.org/jsf/passthrough">
 
     <!--@elvariable id="datasetField" type="edu.harvard.iq.dataverse.persistence.dataset.DatasetField"-->
     <!--@elvariable id="inputRenderer" type="edu.harvard.iq.dataverse.dataset.metadata.inputRenderer.SuggestionInputFieldRenderer"-->
@@ -36,6 +37,7 @@
             var="suggestion" itemLabel="#{suggestion}" itemValue="#{suggestion.value}"
             autoSelection="false"
             autoHighlight="false"
+            pt:data-field-type="#{datasetField.datasetFieldType.name}"
             rendered="#{inputRenderer.suggestionDisplayType eq 'SIMPLE'}"
     >
         <p:ajax process="@form:@id(fieldsByTypeFragment)" event="focus" />
@@ -53,6 +55,7 @@
             var="suggestion" itemLabel="#{suggestion}" itemValue="#{suggestion.value}"
             autoSelection="false"
             autoHighlight="false"
+            pt:data-field-type="#{datasetField.datasetFieldType.name}"
             rendered="#{inputRenderer.suggestionDisplayType eq 'TWO_COLUMNS'}"
     >
         <p:ajax process="@form:@id(fieldsByTypeFragment)" event="focus" />

--- a/fairchive-webapp/src/main/webapp/WEB-INF/templates/dataset/inputRenderer/textInputField.xhtml
+++ b/fairchive-webapp/src/main/webapp/WEB-INF/templates/dataset/inputRenderer/textInputField.xhtml
@@ -26,7 +26,8 @@
     <span id="pre-input-#{datasetField.datasetFieldType.name}" class="pre-input-tag"/>
 
     <p:inputText value="#{datasetField.value}" id="inputText"
-                 styleClass="form-control"/>
+                 styleClass="form-control"
+                 pt:data-field-type="#{datasetField.datasetFieldType.name}" />
 
 
     <p:watermark for="inputText" value="#{datasetField.datasetFieldType.localeWatermark}"></p:watermark>

--- a/fairchive-webapp/src/main/webapp/WEB-INF/templates/dataset/inputRenderer/textboxInputField.xhtml
+++ b/fairchive-webapp/src/main/webapp/WEB-INF/templates/dataset/inputRenderer/textboxInputField.xhtml
@@ -6,6 +6,7 @@
                 xmlns:p="http://primefaces.org/ui"
                 xmlns:o="http://omnifaces.org/ui"
                 xmlns:jsf="http://xmlns.jcp.org/jsf"
+                xmlns:pt="http://xmlns.jcp.org/jsf/passthrough"
                 >
 
     <div class="control-label-with-tooltip">
@@ -22,8 +23,9 @@
     </div>
 
     <p:inputTextarea value="#{datasetField.value}" id="textbox"
-                     rows="5" cols="60" styleClass="form-control" />
-                     
+                     rows="5" cols="60" styleClass="form-control"
+                     pt:data-field-type="#{datasetField.datasetFieldType.name}" />
+
 
     <p:watermark for="textbox" value="#{datasetField.datasetFieldType.localeWatermark}"></p:watermark>
 

--- a/fairchive-webapp/src/main/webapp/dataverse_template.xhtml
+++ b/fairchive-webapp/src/main/webapp/dataverse_template.xhtml
@@ -57,6 +57,7 @@
         <script src="#{resource['leaflet-markercluster/leaflet.markercluster.js']}?version=#{systemConfig.getVersionWithBuild()}"></script>
         <script src="#{resource['leaflet-editable/Leaflet.Editable.min.js']}?version=#{systemConfig.getVersionWithBuild()}"></script>
         <script src="#{resource['js/dvjs.js']}?version=#{systemConfig.getVersionWithBuild()}"></script>
+        <script src="#{resource['js/extra_scripts.js']}?version=#{systemConfig.getVersionWithBuild()}"></script>
         <script>
             window.DvJS = window.DvJS || initDvJS()
         </script>
@@ -77,7 +78,7 @@
                 <ui:param name="widgetView" value="#{widgetWrapper.widgetView}"/>
                 <ui:param name="loginRedirectPage" value="#{loginRedirectPage != null ? '?redirectPage='.concat(loginRedirectPage) : navigationWrapper.redirectPage}"/>
             </ui:include>
-            <p:ajaxStatus id="ajaxStatusPanel">
+            <p:ajaxStatus id="ajaxStatusPanel" widgetVar="ajaxStatusPanel">
                 <f:facet name="start">
                     <h:graphicImage value="/resources/images/ajax-loading.gif" alt="Loading" />
                 </f:facet>

--- a/fairchive-webapp/src/main/webapp/resources/js/extra_scripts.js
+++ b/fairchive-webapp/src/main/webapp/resources/js/extra_scripts.js
@@ -1,0 +1,2 @@
+
+// This javascript file is intended to be overridden by Dataverse extensions


### PR DESCRIPTION
This PR introduces the possibility to add some javascript code using extension.

In our case we want to be able to modify dataset create form. We want to be able to append a button next to one of the field. After clicking this button javascript code will calculate area that is selected on the map with polygon:

![obraz](https://github.com/user-attachments/assets/95a9ec4c-7cfe-4af4-ad09-e12d749bc597)

Changes in inputs for dataset fields (for example in `textInputField.xhtml`) are for easier selecting fields that are interesting for us using javascript (possibly we could live  without this change but it would be quite hard to write a selector for those fields).
