### PR TITLE
2819 fix issues with 3 d previewers

### DIFF
--- a/fairchive-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/datafile/DataFile.java
+++ b/fairchive-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/datafile/DataFile.java
@@ -2,6 +2,7 @@ package edu.harvard.iq.dataverse.persistence.datafile;
 
 import static edu.harvard.iq.dataverse.common.BundleUtil.getStringFromBundle;
 import static edu.harvard.iq.dataverse.common.files.mime.ShapefileMimeType.SHAPEFILE_FILE_TYPE;
+import static edu.harvard.iq.dataverse.common.files.mime.TextMimeType.TSV_ALT;
 import static edu.harvard.iq.dataverse.persistence.datafile.license.FileTermsOfUse.TermsOfUseType.RESTRICTED;
 import static java.lang.Boolean.TRUE;
 import static java.util.stream.Collectors.toList;
@@ -333,6 +334,13 @@ public class DataFile extends DvObject implements Comparable<DataFile> {
         } else {
             return false;
         }
+    }
+    
+    public boolean isNonPublicOrNotIngestedTsvFile(final DatasetVersion datasetVersion) {
+        final boolean isTsvAltContentType = TSV_ALT.getMimeValue()
+                .equals(isTabularData() ? TSV_ALT.getMimeValue() : getContentType());
+
+        return isTsvAltContentType && (!isPublicIn(datasetVersion) || !isTabularData());
     }
 
     /**

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/externaltools/ExternalToolServiceBean.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/externaltools/ExternalToolServiceBean.java
@@ -8,6 +8,7 @@ import java.io.StringReader;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.ejb.Stateless;
 import javax.inject.Inject;
@@ -35,15 +36,11 @@ public class ExternalToolServiceBean {
     }
 
     public List<ExternalTool> findBy(final Type type) {
-        return findAll().stream()
-                .filter(tool -> tool.getType().equals(type))
-                .collect(toList());
+        return streamBy(type).collect(toList());
     }
 
     private List<ExternalTool> findBy(final Type type, final String contentType) {
-        return findAll().stream()
-                .filter(tool -> tool.getType().equals(type))
-                .filter(tool -> tool.getContentType().equals(contentType))
+        return streamBy(type, contentType)
                 .filter(tool -> tool.getFileExtention() == null)
                 .collect(toList());
     }
@@ -72,7 +69,7 @@ public class ExternalToolServiceBean {
 
         return allExternalTools.stream()
                 .filter(t -> t.getContentType().equals(contentType))
-                .collect(Collectors.toList());
+                .collect(toList());
     }
 
     /**
@@ -157,9 +154,7 @@ public class ExternalToolServiceBean {
     
     private List<ExternalTool> findBy(final Type type,
             final String contentType, final String fileExtention) {
-        List<ExternalTool> result = findAll().stream()
-                .filter(tool -> tool.getType().equals(type))
-                .filter(tool -> tool.getContentType().equals(contentType))
+        List<ExternalTool> result = streamBy(type, contentType)
                 .filter(tool -> fileExtention
                         .equalsIgnoreCase(tool.getFileExtention()))
                 .collect(toList());
@@ -177,12 +172,19 @@ public class ExternalToolServiceBean {
 
     
     private List<ExternalTool> findByExtention(final Type type, final String fileExtention) {
-        return findAll().stream()
-                .filter(tool -> tool.getType().equals(type))
+        return streamBy(type)
                 .filter(tool -> fileExtention.equalsIgnoreCase(tool.getFileExtention()))
                 .collect(toList());
     }
-
+    
+    public Stream<ExternalTool> streamBy(final Type type) {
+        return findAll().stream().filter(tool -> tool.getType().equals(type));
+    }
+    
+    private Stream<ExternalTool> streamBy(final Type type, final String contentType) {
+        return streamBy(type).filter(tool -> tool.getContentType().equals(contentType));
+    }
+    
     private String getRequiredTopLevelField(JsonObject jsonObject, String key) {
         try {
             return jsonObject.getString(key);

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/externaltools/ExternalToolServiceBean.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/externaltools/ExternalToolServiceBean.java
@@ -5,7 +5,6 @@ import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
 
 import java.io.StringReader;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -47,20 +46,6 @@ public class ExternalToolServiceBean {
                 .filter(tool -> tool.getContentType().equals(contentType))
                 .filter(tool -> tool.getFileExtention() == null)
                 .collect(toList());
-    }
-    
-    public List<ExternalTool> findBy(final Type type,
-            final String contentType, final String fileExtention) {
-        final List<ExternalTool> result = findAll().stream()
-                    .filter(tool -> tool.getType().equals(type))
-                    .filter(tool -> tool.getContentType().equals(contentType))
-                    .filter(tool -> fileExtention.equalsIgnoreCase(tool.getFileExtention()))
-                    .collect(toList());
-        if(result.size() > 0) {
-            return result;
-        } else {
-            return findBy(type, contentType);
-        }
     }
     
     public boolean delete(final long id) {
@@ -115,9 +100,17 @@ public class ExternalToolServiceBean {
                     .collect(toList());
         }
     }
+    
+    public List<ExternalTool> findExternalTools(final Type type,
+            final String contentType, final DataFile file,
+            final DatasetVersion version) {
 
-    public List<ExternalTool> findExternalTools(Type type, String contentType, DataFile file, DatasetVersion version) {
-        return findExternalToolsByFileAndVersion(findBy(type, contentType, file.getFileMetadata().getFileNameExtention()), file, version);
+        if (file.isNonPublicOrNotIngestedTsvFile(version)) {
+            return emptyList();
+        } else {
+            return findBy(type, contentType,
+                    file.getFileMetadata().getFileNameExtention());
+        }
     }
 
     public ExternalTool parseAddExternalToolManifest(String manifest) {
@@ -161,7 +154,34 @@ public class ExternalToolServiceBean {
     }
 
     // -------------------- PRIVATE --------------------
+    
+    private List<ExternalTool> findBy(final Type type,
+            final String contentType, final String fileExtention) {
+        List<ExternalTool> result = findAll().stream()
+                .filter(tool -> tool.getType().equals(type))
+                .filter(tool -> tool.getContentType().equals(contentType))
+                .filter(tool -> fileExtention
+                        .equalsIgnoreCase(tool.getFileExtention()))
+                .collect(toList());
+        if (result.size() > 0) {
+            return result;
+        } else {
+            result = findByExtention(type, fileExtention);
+            if (result.size() > 0) {
+                return result;
+            } else {
+                return findBy(type, contentType);
+            }
+        }
+    }
 
+    
+    private List<ExternalTool> findByExtention(final Type type, final String fileExtention) {
+        return findAll().stream()
+                .filter(tool -> tool.getType().equals(type))
+                .filter(tool -> fileExtention.equalsIgnoreCase(tool.getFileExtention()))
+                .collect(toList());
+    }
 
     private String getRequiredTopLevelField(JsonObject jsonObject, String key) {
         try {

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/externaltools/ExternalToolServiceBean.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/externaltools/ExternalToolServiceBean.java
@@ -1,8 +1,11 @@
 package edu.harvard.iq.dataverse.externaltools;
 
+import static edu.harvard.iq.dataverse.common.files.mime.TextMimeType.TSV_ALT;
+import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
 
 import java.io.StringReader;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -93,16 +96,24 @@ public class ExternalToolServiceBean {
      * so it doesn't query the database each time
      */
     public List<ExternalTool> findExternalToolsByFileAndVersion(
-            List<ExternalTool> allExternalTools, DataFile file, DatasetVersion datasetVersion) {
+            final List<ExternalTool> allExternalTools, final DataFile file,
+            final DatasetVersion datasetVersion) {
 
-        // Map tabular data to it's mimetype (the isTabularData() check assures that this code works the same as before,
-        // but it may need to change if tabular data is split into subtypes with differing mimetypes)
-        final String contentType = file.isTabularData() ? TextMimeType.TSV_ALT.getMimeValue() : file.getContentType();
+        if (file.isNonPublicOrNotIngestedTsvFile(datasetVersion)) {
+            return emptyList();
+        } else {
+            // Map tabular data to it's mimetype (the isTabularData() check assures
+            // that this code works the same as before,
+            // but it may need to change if tabular data is split into subtypes with
+            // differing mimetypes)
+            final String contentType = file.isTabularData()
+                    ? TSV_ALT.getMimeValue()
+                    : file.getContentType();
 
-        return allExternalTools.stream()
-                .filter(t -> t.getContentType().equals(contentType))
-                .filter(t -> !file.isNonPublicOrNotIngestedTsvFile(datasetVersion))
-                .collect(Collectors.toList());
+            return allExternalTools.stream()
+                    .filter(t -> t.getContentType().equals(contentType))
+                    .collect(toList());
+        }
     }
 
     public List<ExternalTool> findExternalTools(Type type, String contentType, DataFile file, DatasetVersion version) {

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/externaltools/ExternalToolServiceBean.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/externaltools/ExternalToolServiceBean.java
@@ -14,8 +14,6 @@ import javax.json.JsonArray;
 import javax.json.JsonObject;
 import javax.json.JsonReader;
 
-import com.google.api.client.repackaged.com.google.common.base.Objects;
-
 import edu.harvard.iq.dataverse.common.files.mime.TextMimeType;
 import edu.harvard.iq.dataverse.persistence.datafile.DataFile;
 import edu.harvard.iq.dataverse.persistence.datafile.ExternalTool;
@@ -103,7 +101,7 @@ public class ExternalToolServiceBean {
 
         return allExternalTools.stream()
                 .filter(t -> t.getContentType().equals(contentType))
-                .filter(t -> !isNonPublicOrNotIngestedTsvFile(file, datasetVersion))
+                .filter(t -> !file.isNonPublicOrNotIngestedTsvFile(datasetVersion))
                 .collect(Collectors.toList());
     }
 
@@ -152,13 +150,6 @@ public class ExternalToolServiceBean {
     }
 
     // -------------------- PRIVATE --------------------
-
-    private boolean isNonPublicOrNotIngestedTsvFile(DataFile file, DatasetVersion datasetVersion) {
-        boolean isTsvAltContentType = TextMimeType.TSV_ALT.getMimeValue()
-                .equals(file.isTabularData() ? TextMimeType.TSV_ALT.getMimeValue() : file.getContentType());
-
-        return isTsvAltContentType && (!file.isPublicIn(datasetVersion) || !file.isTabularData());
-    }
 
 
     private String getRequiredTopLevelField(JsonObject jsonObject, String key) {

--- a/fairchive-webapp/src/test/java/edu/harvard/iq/dataverse/externaltools/ExternalToolServiceBeanTest.java
+++ b/fairchive-webapp/src/test/java/edu/harvard/iq/dataverse/externaltools/ExternalToolServiceBeanTest.java
@@ -59,10 +59,11 @@ public class ExternalToolServiceBeanTest {
     private final ExternalTool tool2 = new ExternalTool("tool2", "", PREVIEW, "", "{}", APPLICATION_PDF);
     private final ExternalTool tool3 = new ExternalTool("tool3", "", PREVIEW, "", "{}", TEXT_PLAIN);
     private final ExternalTool tool4 = new ExternalTool("tool4", "", PREVIEW, "", "{}", TEXT_PLAIN, "obj");
+    private final ExternalTool tool5 = new ExternalTool("tool5", "", PREVIEW, "", "{}", "application/x-nintendo-3ds-rom", "3ds");
     
     @BeforeEach
     public void setUp() {
-        when(repository.findAll()).thenReturn(asList(tool1, tool2, tool3, tool4));
+        when(repository.findAll()).thenReturn(asList(tool1, tool2, tool3, tool4, tool5));
     }
 
     // -------------------- TESTS --------------------
@@ -167,6 +168,33 @@ public class ExternalToolServiceBeanTest {
 
         assertThat(this.service.findExternalTools(PREVIEW, TEXT_PLAIN, dataFile,
                 datasetVersion)).containsExactly(tool4);
+    }
+    
+    @Test
+    public void findExternalTools_returnToolsBasedOnFileExtention_ifSearchingByContentTypeAndExtentionFails() {
+        // given
+        DataFile dataFile = new DataFile();
+        dataFile.setId(42l);
+        dataFile.setContentType(TEXT_PLAIN);
+        DatasetVersion datasetVersion = new DatasetVersion();
+        datasetVersion.setVersionState(RELEASED);
+        Dataset dataset = new Dataset();
+        datasetVersion.setDataset(dataset);
+
+        FileMetadata metadata = new FileMetadata();
+        metadata.setDatasetVersion(datasetVersion);
+        metadata.setLabel("abc.3ds");
+        List<FileMetadata> metadataList = new ArrayList<>();
+        metadataList.add(metadata);
+        dataFile.setOwner(dataset);
+
+        FileTermsOfUse termsOfUse = new FileTermsOfUse();
+        metadata.setTermsOfUse(termsOfUse);
+
+        dataFile.setFileMetadatas(metadataList);
+
+        assertThat(this.service.findExternalTools(PREVIEW, TEXT_PLAIN, dataFile,
+                datasetVersion)).containsExactly(tool5);
     }
 
     @Test
@@ -369,7 +397,7 @@ public class ExternalToolServiceBeanTest {
     @Test
     public void findAll_returnsproperResults() {
         
-        assertThat(this.service.findAll()).containsExactly(tool1, tool2, tool3, tool4);
+        assertThat(this.service.findAll()).containsExactly(tool1, tool2, tool3, tool4, tool5);
     }
     
     @Test
@@ -377,15 +405,6 @@ public class ExternalToolServiceBeanTest {
         
         assertThat(this.service.findBy(EXPLORE)).isEmpty();
         assertThat(this.service.findBy(CONFIGURE)).containsExactly(tool1);
-        assertThat(this.service.findBy(PREVIEW)).containsExactly(tool2, tool3, tool4);
-    }
-    
-    @Test
-    public void findBy_withTypeAndExtention_returnsproperResults() {
-        
-        assertThat(this.service.findBy(PREVIEW, TEXT_PLAIN, "obj")).containsExactly(tool4);
-        assertThat(this.service.findBy(PREVIEW, TEXT_PLAIN, "")).containsExactly(tool3);
-        assertThat(this.service.findBy(PREVIEW, APPLICATION_PDF, "obj")).containsExactly(tool2);
-        
+        assertThat(this.service.findBy(PREVIEW)).containsExactly(tool2, tool3, tool4, tool5);
     }
 }


### PR DESCRIPTION
File type detection mechanism is not consistent. This prevents 3d files from being previewable. 3D previewer is configurest through "externaltool" table in DB using exact file extenction and content type. To work arround added a fallback mode to tool searching algorithm.