### PR TITLE
Closes #2834: Render map directly under geo coordinates field

### DIFF
--- a/fairchive-webapp/src/main/webapp/datasetFieldForEditFragment.xhtml
+++ b/fairchive-webapp/src/main/webapp/datasetFieldForEditFragment.xhtml
@@ -2,11 +2,15 @@
         xmlns:ui="http://java.sun.com/jsf/facelets"
         xmlns:p="http://primefaces.org/ui"
         xmlns:o="http://omnifaces.org/ui"
+        xmlns:c="http://java.sun.com/jsp/jstl/core"
+        xmlns:jsf="http://xmlns.jcp.org/jsf"
 >
 
     <o:importConstants
             type="edu.harvard.iq.dataverse.persistence.dataset.InputRendererType"
             var="inputRendererTypeEnum"/>
+
+    <c:set var="isGeoCoordinatesField" value="#{inputRenderer.getType() eq inputRendererTypeEnum.TEXTBOX and isGeospatial}" />
 
     <p:fragment rendered="#{inputRenderer.getType() eq inputRendererTypeEnum.TEXT}">
         <ui:include src="/WEB-INF/templates/dataset/inputRenderer/textInputField.xhtml" >
@@ -119,4 +123,11 @@
             <ui:param name="operation" value="#{operation}" />
         </ui:include>
     </p:fragment>
+
+
+    <!-- Map -->
+    <div id="#{mapId}" class="geo-map"
+         jsf:rendered="#{isGeoCoordinatesField}">
+    </div>
+
 </ui:composition>

--- a/fairchive-webapp/src/main/webapp/editMetadata.xhtml
+++ b/fairchive-webapp/src/main/webapp/editMetadata.xhtml
@@ -11,6 +11,10 @@
     <!--@elvariable id="metadataBlocks" type="java.util.Set< java.util.Map.Entry<edu.harvard.iq.dataverse.persistence.dataset.MetadataBlock, java.util.List<edu.harvard.iq.dataverse.persistence.dataset.DatasetField>>"-->
     <!-- Edit Mode -->
     <o:importConstants type="edu.harvard.iq.dataverse.persistence.dataset.FieldType"/>
+    <o:importConstants
+            type="edu.harvard.iq.dataverse.persistence.dataset.InputRendererType"
+            var="inputRendererTypeEnum"/>
+
     <p:fragment id="editMetadataFragement">
     <div class="panel-group">
         <ui:repeat id="metadataBlocks" value="#{metadataBlocks}" var="metadataBlockVal" varStatus="block">
@@ -81,6 +85,7 @@
                                                         aria-label="#{fieldsByType.datasetFieldType.allowMultiples ? datasetField.datasetFieldType.localeTitle.concat(' ').concat(valCount.index + 1) : ''}">
                                                 <ui:repeat id="subfields" value="#{datasetField.datasetFieldsChildren}" var="subdsf">
                                                     <ui:fragment rendered="#{inputRenderersByFieldType.get(subdsf.datasetFieldType).showOnCondition(datasetField.datasetFieldsChildren)}">
+
                                                         <div class="form-col-container
                                                             #{(inputRenderersByFieldType.get(subdsf.datasetFieldType).renderInTwoColumns()) ? 'col-sm-6' : 'col-sm-12'}
                                                             #{(inputRenderersByFieldType.get(subdsf.datasetFieldType).isHidden()) ? 'form-hidden-col-container' : ''}">
@@ -146,11 +151,6 @@
                                                     <span class="icon-text no-text">,</span>
                                                     <o:skipValidators/>
                                                 </p:commandLink>
-                                            </div>
-
-                                            <!-- Map -->
-                                            <div id="#{currentMap}" class="col-xs-9 form-col-container geo-map"
-                                                 jsf:rendered="#{isGeospatial}">
                                             </div>
                                         </div>
 

--- a/fairchive-webapp/src/main/webapp/resources/vecler/theme-base.scss
+++ b/fairchive-webapp/src/main/webapp/resources/vecler/theme-base.scss
@@ -592,6 +592,10 @@ a[id$=advsearchlink] {
 	max-height: calc(100vh - 160px);
 }
 
+.form-col-container .geo-map {
+    margin-top: .5em;
+}
+
 @media screen and (max-width: $screen-xs-max) {
 	.geo-map {
 		max-width: calc((100vw - 90px) * 0.75);

--- a/fairchive-webapp/src/main/webapp/viewMetadataField.xhtml
+++ b/fairchive-webapp/src/main/webapp/viewMetadataField.xhtml
@@ -27,11 +27,15 @@
                                 escape="false"/>
                 </ui:repeat>
                 <c:set var="isGeospatial" value="#{datasetField.isGeospatial()}"/>
-                <c:set var="currentGsIndex" value="map_#{mdBlockName}_#{fieldIndex}_#{fieldsLoop.index}"/>
-                <script jsf:rendered="#{isGeospatial}">
-                        DvJS.Geo.MetadataView.prepare('#{currentGsIndex}');
-                </script>
+
                 <ui:repeat var="childField" value="#{datasetField.datasetFieldsChildren}" varStatus="childLoop">
+                    <c:set var="isGeoCoordinatesField" value="#{isGeospatial and childField.datasetFieldType.fieldType.isTextbox()}"/>
+                    <c:set var="currentGeoCoordsIndex" value="map_#{mdBlockName}_#{fieldIndex}_#{fieldsLoop.index}_#{childLoop.index}"/>
+
+                    <script jsf:rendered="#{isGeoCoordinatesField}">
+                        DvJS.Geo.MetadataView.prepare('#{currentGeoCoordsIndex}');
+                    </script>
+
                     <div jsf:rendered="#{childField.parentDisplayFormatIsNewLine}">
                             <ui:repeat value="#{childField.values}" var="value" varStatus="valuesLoop">
                                 <c:set var="valueToDisplay" value="#{rendererFactory.getRendererFor(childField).render(value)}"/>
@@ -39,17 +43,18 @@
                                         escape="false"/>
                             </ui:repeat>
                     </div>
-                    <script jsf:rendered="#{isGeospatial}">
+                    <script jsf:rendered="#{isGeoCoordinatesField}">
                         var escapedCoordinates = "#{of:escapeJS(childField.value)}";
-                        DvJS.Geo.MetadataView.storeCoordinates('#{currentGsIndex}', escapedCoordinates);
+                        DvJS.Geo.MetadataView.storeCoordinates('#{currentGeoCoordsIndex}', escapedCoordinates);
                     </script>
                     <h:outputText value="#{childField.parentDisplayFormat} " rendered="#{!childLoop.first and !childField.parentDisplayFormatIsNewLine}" escape="false" />
                     <ui:repeat value="#{childField.values}" var="value" varStatus="valuesLoop">
                         <h:outputText value="#{valuesLoop.first?'':'; '}#{ value }" rendered="#{!childField.parentDisplayFormatIsNewLine}"
                                     escape="false"/>
                     </ui:repeat>
+
+                    <div id="#{currentGeoCoordsIndex}" class="geo-map" jsf:rendered="#{isGeoCoordinatesField}"></div>
                 </ui:repeat>
-                <div id="#{currentGsIndex}" class="geo-map" jsf:rendered="#{isGeospatial}"></div>
             </div>
         </ui:repeat>
     </div>


### PR DESCRIPTION
In our installation we have one field that we want to display below the map: geographicBoundingBox -> study_site_size

Currently the map renders under all fields from geographicBoundingBox. This means that our field study_site_size renders between coordinates field and the map.

This PR changes this. The map will always render directly under coordinates field