### PR TITLE
Closes #2842: Extend field validation mechanism to support overriding messages for each dataset field type

### DIFF
--- a/fairchive-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/config/EMailValidator.java
+++ b/fairchive-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/config/EMailValidator.java
@@ -24,8 +24,7 @@ public class EMailValidator implements ConstraintValidator<ValidateEmail, String
     public static boolean isEmailValid(String value, ConstraintValidatorContext context) {
         boolean isValid = EmailValidator.getInstance().isValid(value);
         if (!isValid && context != null) {
-            context.buildConstraintViolationWithTemplate(value + "  "
-                    + BundleUtil.getStringFromBundle("email.invalid"))
+            context.buildConstraintViolationWithTemplate(BundleUtil.getStringFromBundle("email.invalid", value))
                     .addConstraintViolation();
         }
         return isValid;

--- a/fairchive-persistence/src/main/resources/Bundle_en.properties
+++ b/fairchive-persistence/src/main/resources/Bundle_en.properties
@@ -2529,7 +2529,7 @@ dataset.file.zip.unzip.failure=Failed to unzip the file. Saving the file as is.
 dataset.file.zip.uploadFileSizeLimit.exceeded=One of the unzipped files exceeds the size limit resorting to saving the file as is, zipped.
 
 #EmailValidator.java
-email.invalid=is not a valid email address.
+email.invalid={0} is not a valid email address.
 
 #URLValidator.java
 url.invalid=is not a valid URL.

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
@@ -1340,7 +1340,7 @@ public class DatasetPage implements Serializable {
         boolean valid = org.apache.commons.validator.routines.EmailValidator.getInstance().isValid(email);
         if (!valid) {
             throw new ValidatorException(new FacesMessage(FacesMessage.SEVERITY_ERROR,
-                    email + " " + BundleUtil.getStringFromBundle("email.invalid"), ""));
+                    BundleUtil.getStringFromBundle("email.invalid", email), ""));
         }
     }
 

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/api/datadeposit/MediaResourceManagerImpl.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/api/datadeposit/MediaResourceManagerImpl.java
@@ -327,7 +327,7 @@ public class MediaResourceManagerImpl implements MediaResourceManager {
                 if (!fieldValidationResults.isEmpty()) {
                     FieldValidationResult firstError = fieldValidationResults.get(0);
                     throw new SwordError(UriRegistry.ERROR_BAD_REQUEST,
-                            String.format("Unable to add file(s) to dataset: %s The invalid value was \"%s\".", firstError.getMessage(), firstError.getField().getSingleValue()));
+                            String.format("Unable to add file(s) to dataset: %s The invalid value was \"%s\".", firstError.getField().getValidationMessage(), firstError.getField().getSingleValue()));
                 } else if (!constraintViolations.isEmpty()) {
                     ConstraintViolation<FileMetadata> violation = constraintViolations.iterator().next();
                     throw new SwordError(UriRegistry.ERROR_BAD_REQUEST,

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/api/datadeposit/MediaResourceManagerImpl.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/api/datadeposit/MediaResourceManagerImpl.java
@@ -327,11 +327,13 @@ public class MediaResourceManagerImpl implements MediaResourceManager {
                 if (!fieldValidationResults.isEmpty()) {
                     FieldValidationResult firstError = fieldValidationResults.get(0);
                     throw new SwordError(UriRegistry.ERROR_BAD_REQUEST,
-                            String.format("Unable to add file(s) to dataset: %s The invalid value was \"%s\".", firstError.getField().getValidationMessage(), firstError.getField().getSingleValue()));
+                            String.format("Unable to add file(s) to dataset: %s The invalid value was \"%s\".",
+                                    firstError.getField().getValidationMessage(), firstError.getField().getSingleValue()));
                 } else if (!constraintViolations.isEmpty()) {
                     ConstraintViolation<FileMetadata> violation = constraintViolations.iterator().next();
                     throw new SwordError(UriRegistry.ERROR_BAD_REQUEST,
-                            String.format("Unable to add file(s) to dataset: %s The invalid value was \"%s\".", violation.getMessage(), violation.getInvalidValue()));
+                            String.format("Unable to add file(s) to dataset: %s The invalid value was \"%s\".",
+                                    violation.getMessage(), violation.getInvalidValue()));
                 } else {
                     ingestService.saveAndAddFilesToDataset(editVersion, dataFiles);
                 }

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/datafile/FileService.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/datafile/FileService.java
@@ -79,7 +79,7 @@ public class FileService {
         Set<ConstraintViolation<FileMetadata>> constraintViolations = versionToValidate.validateFileMetadata();
 
         if (!fieldValidationResults.isEmpty() || !constraintViolations.isEmpty()) {
-            fieldValidationResults.forEach(r -> logger.warn(r.getMessage()));
+            fieldValidationResults.forEach(r -> logger.warn(r.getField().getValidationMessage()));
             constraintViolations.forEach(constraintViolation -> logger.warn(constraintViolation.getMessage()));
             throw new ValidationException("There was validation error during deletion attempt with the dataFile id: " + fileToDelete.getDataFile().getId());
 
@@ -116,7 +116,7 @@ public class FileService {
         Set<ConstraintViolation<FileMetadata>> constraintViolations = versionToValidate.validateFileMetadata();
 
         if (!fieldValidationResults.isEmpty() || !constraintViolations.isEmpty()) {
-            fieldValidationResults.forEach(r -> logger.warn(r.getMessage()));
+            fieldValidationResults.forEach(r -> logger.warn(r.getField().getValidationMessage()));
             constraintViolations.forEach(constraintViolation -> logger.warn(constraintViolation.getMessage()));
             throw new ValidationException("There was validation error during deletion attempt with the dataFile id: " + editedFile.getDataFile().getId());
         }

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/dataset/datasetversion/DatasetVersionServiceBean.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/dataset/datasetversion/DatasetVersionServiceBean.java
@@ -1084,7 +1084,7 @@ w
         List<FieldValidationResult> fieldValidationResults = fieldValidationService.validateFieldsOfDatasetVersion(editVersion);
         Set<ConstraintViolation<FileMetadata>> constraintViolations = editVersion.validateFileMetadata();
         if (!fieldValidationResults.isEmpty() || !constraintViolations.isEmpty()) {
-            fieldValidationResults.forEach(r -> log.warn(r.getMessage()));
+            fieldValidationResults.forEach(r -> log.warn(r.getField().getValidationMessage()));
             constraintViolations.forEach(constraintViolation -> log.warn(constraintViolation.getMessage()));
             throw new ValidationException("There was validation error during updating dataset attempt with id: " + editVersion.getDataset().getId());
         }

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/datasetutility/AddReplaceFileHelper.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/datasetutility/AddReplaceFileHelper.java
@@ -1021,7 +1021,7 @@ public class AddReplaceFileHelper {
         // violations found: gather all error messages
         // -----------------------------------------------------------
         Stream.concat(
-                fieldValidationResults.stream().map(FieldValidationResult::getMessage),
+                fieldValidationResults.stream().map(fvr -> fvr.getField().getValidationMessage()),
                 constraintViolations.stream().map(ConstraintViolation::getMessage))
                 .forEach(this::addError);
         return this.hasError();

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/AbstractDatasetCommand.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/AbstractDatasetCommand.java
@@ -120,7 +120,7 @@ public abstract class AbstractDatasetCommand<T> extends AbstractCommand<T> {
             } else {
                 // explode with a helpful message
                 String validationMessage = fieldValidationResults.stream()
-                        .map(r -> String.format("%s (Invalid value:%s)", r.getMessage(), r.getField().getSingleValue()))
+                        .map(r -> String.format("%s (Invalid value:%s)", r.getField().getValidationMessage(), r.getField().getSingleValue()))
                         .collect(joining(", ", "Validation Failed: ", "."));
                 throw new IllegalCommandException(validationMessage, this);
             }

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/validation/DatasetFieldValidationService.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/validation/DatasetFieldValidationService.java
@@ -7,20 +7,24 @@ import edu.harvard.iq.dataverse.validation.field.FieldValidationResult;
 
 import javax.ejb.Stateless;
 import javax.inject.Inject;
+
 import java.util.List;
 
 @Stateless
 public class DatasetFieldValidationService {
 
     private DatasetFieldValidationDispatcherFactory dispatcherFactory;
+    private ValidationMessageResolver validationMessageResolver;
 
     // -------------------- CONSTRUCTORS --------------------
 
     public DatasetFieldValidationService() { }
 
     @Inject
-    public DatasetFieldValidationService(DatasetFieldValidationDispatcherFactory dispatcherFactory) {
+    public DatasetFieldValidationService(DatasetFieldValidationDispatcherFactory dispatcherFactory,
+            ValidationMessageResolver validationMessageResolver) {
         this.dispatcherFactory = dispatcherFactory;
+        this.validationMessageResolver = validationMessageResolver;
     }
 
 // -------------------- LOGIC --------------------
@@ -32,7 +36,7 @@ public class DatasetFieldValidationService {
                 .executeValidations();
         fieldValidationResults.forEach(r -> {
                     ValidatableField field = r.getField();
-                    field.setValidationMessage(r.getMessage());
+                    field.setValidationMessage(validationMessageResolver.resolveValidationMessage(r));
                 });
         return fieldValidationResults;
     }

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/validation/SearchFormValidationService.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/validation/SearchFormValidationService.java
@@ -1,6 +1,5 @@
 package edu.harvard.iq.dataverse.validation;
 
-import edu.harvard.iq.dataverse.common.BundleUtil;
 import edu.harvard.iq.dataverse.persistence.dataset.ValidatableField;
 import edu.harvard.iq.dataverse.search.advanced.field.SearchField;
 import edu.harvard.iq.dataverse.validation.field.SearchFormValidationDispatcherFactory;
@@ -9,24 +8,24 @@ import edu.harvard.iq.dataverse.validation.field.FieldValidationResult;
 import javax.ejb.Stateless;
 import javax.inject.Inject;
 
-import org.apache.commons.lang3.StringUtils;
-
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 @Stateless
 public class SearchFormValidationService {
 
     private SearchFormValidationDispatcherFactory dispatcherFactory;
+    private ValidationMessageResolver validationMessageResolver;
 
     // -------------------- CONSTRUCTORS --------------------
 
     public SearchFormValidationService() { }
 
     @Inject
-    public SearchFormValidationService(SearchFormValidationDispatcherFactory dispatcherFactory) {
+    public SearchFormValidationService(SearchFormValidationDispatcherFactory dispatcherFactory,
+            ValidationMessageResolver validationMessageResolver) {
         this.dispatcherFactory = dispatcherFactory;
+        this.validationMessageResolver = validationMessageResolver;
     }
 
     // -------------------- LOGIC --------------------
@@ -38,20 +37,9 @@ public class SearchFormValidationService {
                 .executeValidations();
         fieldValidationResults.forEach(r -> {
             ValidatableField field = r.getField();
-            field.setValidationMessage(resolveValidationMessage(r));
+            field.setValidationMessage(validationMessageResolver.resolveValidationMessage(r));
         });
         return fieldValidationResults;
     }
 
-    private String resolveValidationMessage(FieldValidationResult result) {
-        String fieldTypeName = result.getField().getDatasetFieldType().getName();
-        String metadataBlockName = result.getField().getDatasetFieldType().getMetadataBlock().getName();
-
-        String key = "datasetfieldtype." + fieldTypeName + "." + result.getErrorCode();
-
-        return Optional.of(BundleUtil.getStringFromNonDefaultBundle(key, metadataBlockName, result.getErrorArgs()))
-            .filter(StringUtils::isNotBlank)
-            .orElse(BundleUtil.getStringFromBundle(key, result.getErrorArgs()));
-
-    }
 }

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/validation/SearchFormValidationService.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/validation/SearchFormValidationService.java
@@ -1,5 +1,6 @@
 package edu.harvard.iq.dataverse.validation;
 
+import edu.harvard.iq.dataverse.common.BundleUtil;
 import edu.harvard.iq.dataverse.persistence.dataset.ValidatableField;
 import edu.harvard.iq.dataverse.search.advanced.field.SearchField;
 import edu.harvard.iq.dataverse.validation.field.SearchFormValidationDispatcherFactory;
@@ -7,8 +8,12 @@ import edu.harvard.iq.dataverse.validation.field.FieldValidationResult;
 
 import javax.ejb.Stateless;
 import javax.inject.Inject;
+
+import org.apache.commons.lang3.StringUtils;
+
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 @Stateless
 public class SearchFormValidationService {
@@ -33,8 +38,20 @@ public class SearchFormValidationService {
                 .executeValidations();
         fieldValidationResults.forEach(r -> {
             ValidatableField field = r.getField();
-            field.setValidationMessage(r.getMessage());
+            field.setValidationMessage(resolveValidationMessage(r));
         });
         return fieldValidationResults;
+    }
+
+    private String resolveValidationMessage(FieldValidationResult result) {
+        String fieldTypeName = result.getField().getDatasetFieldType().getName();
+        String metadataBlockName = result.getField().getDatasetFieldType().getMetadataBlock().getName();
+
+        String key = "datasetfieldtype." + fieldTypeName + "." + result.getErrorCode();
+
+        return Optional.of(BundleUtil.getStringFromNonDefaultBundle(key, metadataBlockName, result.getErrorArgs()))
+            .filter(StringUtils::isNotBlank)
+            .orElse(BundleUtil.getStringFromBundle(key, result.getErrorArgs()));
+
     }
 }

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/validation/ValidationMessageResolver.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/validation/ValidationMessageResolver.java
@@ -1,0 +1,32 @@
+package edu.harvard.iq.dataverse.validation;
+
+import java.util.Optional;
+
+import javax.ejb.Stateless;
+
+import org.apache.commons.lang3.StringUtils;
+
+import edu.harvard.iq.dataverse.common.BundleUtil;
+import edu.harvard.iq.dataverse.validation.field.FieldValidationResult;
+
+/**
+ * Service responsible for resolving validation errors messages
+ */
+@Stateless
+public class ValidationMessageResolver {
+
+    /**
+     * Returns validation message for the given {@link FieldValidationResult}.
+     */
+    public String resolveValidationMessage(FieldValidationResult result) {
+        String fieldTypeName = result.getField().getDatasetFieldType().getName();
+        String metadataBlockName = result.getField().getDatasetFieldType().getMetadataBlock().getName();
+
+        String key = "datasetfieldtype." + fieldTypeName + "." + result.getErrorCode();
+
+        return Optional.of(BundleUtil.getStringFromNonDefaultBundle(key, metadataBlockName, result.getErrorArgs()))
+            .filter(StringUtils::isNotBlank)
+            .orElse(BundleUtil.getStringFromBundle(result.getErrorCode(), result.getErrorArgs()));
+
+    }
+}

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/DatasetFieldValidationDispatcher.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/DatasetFieldValidationDispatcher.java
@@ -1,7 +1,6 @@
 package edu.harvard.iq.dataverse.validation.field;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import edu.harvard.iq.dataverse.common.BundleUtil;
 import edu.harvard.iq.dataverse.persistence.dataset.DatasetField;
 import edu.harvard.iq.dataverse.persistence.dataset.DatasetFieldType;
 import edu.harvard.iq.dataverse.persistence.dataverse.Dataverse;
@@ -55,8 +54,7 @@ public class DatasetFieldValidationDispatcher {
     private FieldValidationResult validateField(DatasetField field) {
         DatasetFieldType fieldType = field.getDatasetFieldType();
         if (StringUtils.isBlank(field.getValue()) && fieldType.isPrimitive() && isRequiredInDataverse(field)) {
-            return FieldValidationResult.invalid(field,
-                    BundleUtil.getStringFromBundle("isrequired", fieldType.getDisplayName()));
+            return FieldValidationResult.invalid(field, "isrequired", fieldType.getDisplayName());
         }
         boolean effectivelyEmptyValue = StringUtils.isBlank(field.getValue())
                 || DatasetField.NA_VALUE.equals(field.getValue());

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/FieldValidationResult.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/FieldValidationResult.java
@@ -2,21 +2,20 @@ package edu.harvard.iq.dataverse.validation.field;
 
 import edu.harvard.iq.dataverse.persistence.dataset.ValidatableField;
 import edu.harvard.iq.dataverse.validation.ValidationResult;
-import org.apache.commons.lang3.StringUtils;
 
 public class FieldValidationResult extends ValidationResult {
 
-    public static FieldValidationResult OK = new FieldValidationResult(true, null, null, StringUtils.EMPTY);
+    public static FieldValidationResult OK = new FieldValidationResult(true, null, null);
 
     private final ValidatableField field;
-    private final String message;
+    private final Object[] errorArgs;
 
     // -------------------- CONSTRUCTORS --------------------
 
-    private FieldValidationResult(boolean ok, String errorCode, ValidatableField field, String validationMessage) {
+    private FieldValidationResult(boolean ok, String errorCode, ValidatableField field, Object...errorArgs) {
         super(ok, errorCode);
         this.field = field;
-        this.message = validationMessage;
+        this.errorArgs = errorArgs;
     }
 
     // -------------------- GETTERS --------------------
@@ -25,8 +24,8 @@ public class FieldValidationResult extends ValidationResult {
         return field;
     }
 
-    public String getMessage() {
-        return message;
+    public Object[] getErrorArgs() {
+        return errorArgs;
     }
 
     // -------------------- LOGIC --------------------
@@ -35,7 +34,8 @@ public class FieldValidationResult extends ValidationResult {
         return OK;
     }
 
-    public static FieldValidationResult invalid(ValidatableField field, String message) {
-        return new FieldValidationResult(false, null, field, message);
+    public static FieldValidationResult invalid(ValidatableField field, String errorCode, Object... errorArgs) {
+        return new FieldValidationResult(false, errorCode, field, errorArgs);
     }
+
 }

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/validators/ControlledVocabularyValidator.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/validators/ControlledVocabularyValidator.java
@@ -1,7 +1,6 @@
 package edu.harvard.iq.dataverse.validation.field.validators;
 
 import edu.harvard.iq.dataverse.ControlledVocabularyValueServiceBean;
-import edu.harvard.iq.dataverse.common.BundleUtil;
 import edu.harvard.iq.dataverse.persistence.dataset.ControlledVocabularyValue;
 import edu.harvard.iq.dataverse.persistence.dataset.ValidatableField;
 import edu.harvard.iq.dataverse.validation.field.FieldValidationResult;
@@ -45,9 +44,7 @@ public class ControlledVocabularyValidator extends MultiValueValidatorBase {
             return FieldValidationResult.ok();
         } else {
             return FieldValidationResult.invalid(
-                    field,
-                    BundleUtil.getStringFromBundle("validation.value.not.allowed.in.controlled.vocabulary", value)
-            );
+                    field, "validation.value.not.allowed.in.controlled.vocabulary", value);
         }
     }
 }

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/validators/DateRangeValidator.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/validators/DateRangeValidator.java
@@ -1,6 +1,5 @@
 package edu.harvard.iq.dataverse.validation.field.validators;
 
-import edu.harvard.iq.dataverse.common.BundleUtil;
 import edu.harvard.iq.dataverse.persistence.dataset.ValidatableField;
 import edu.harvard.iq.dataverse.validation.field.FieldValidationResult;
 import io.vavr.Tuple;
@@ -44,14 +43,14 @@ public class DateRangeValidator extends FieldValidatorBase {
 
         Tuple2<LocalDate, Boolean> dateFrom = validateAndParse(dateFromValue);
         if (!dateFrom._2()) {
-            return FieldValidationResult.invalid(field, BundleUtil.getStringFromBundle("advanced.search.wrong.daterange.format", dateFromValue));
+            return FieldValidationResult.invalid(field, "advanced.search.wrong.daterange.format", dateFromValue);
         }
         Tuple2<LocalDate, Boolean> dateTo = validateAndParse(dateToValue);
         if (!dateTo._2()) {
-            return FieldValidationResult.invalid(field, BundleUtil.getStringFromBundle("advanced.search.wrong.daterange.format", dateToValue));
+            return FieldValidationResult.invalid(field, "advanced.search.wrong.daterange.format", dateToValue);
         }
         if (!isValidDateRange(dateFrom._1(), dateTo._1(), dateToValue)) {
-            return FieldValidationResult.invalid(field, BundleUtil.getStringFromBundle("advanced.search.wrong.daterange.badRange"));
+            return FieldValidationResult.invalid(field, "advanced.search.wrong.daterange.badRange");
         }
         return FieldValidationResult.ok();
     }

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/validators/NotGreaterThanValidator.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/validators/NotGreaterThanValidator.java
@@ -8,7 +8,6 @@ import javax.enterprise.context.ApplicationScoped;
 import org.apache.commons.lang3.StringUtils;
 import org.omnifaces.cdi.Eager;
 
-import edu.harvard.iq.dataverse.common.BundleUtil;
 import edu.harvard.iq.dataverse.persistence.dataset.ValidatableField;
 import edu.harvard.iq.dataverse.validation.field.FieldValidationResult;
 
@@ -41,9 +40,9 @@ public class NotGreaterThanValidator extends DependantFieldValidator {
         long compareToValueLong = Long.parseLong(compareToValue);
 
         if (valueLong > compareToValueLong) {
-            return FieldValidationResult.invalid(field, BundleUtil.getStringFromBundle("isGreaterThanField",
+            return FieldValidationResult.invalid(field, "isGreaterThanField",
                     field.getDatasetFieldType().getDisplayName(),
-                    dependantField.getDatasetFieldType().getDisplayName()));
+                    dependantField.getDatasetFieldType().getDisplayName());
         }
 
         return FieldValidationResult.ok();

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/validators/NotGreaterThanValueValidator.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/validators/NotGreaterThanValueValidator.java
@@ -9,7 +9,6 @@ import javax.enterprise.context.ApplicationScoped;
 
 import org.omnifaces.cdi.Eager;
 
-import edu.harvard.iq.dataverse.common.BundleUtil;
 import edu.harvard.iq.dataverse.persistence.dataset.ValidatableField;
 import edu.harvard.iq.dataverse.validation.field.FieldValidationResult;
 
@@ -54,9 +53,9 @@ public class NotGreaterThanValueValidator extends FieldValidatorBase {
         long compareToValueLong = parseValue((String) compareToValue);
 
         if (valueLong > compareToValueLong) {
-            return FieldValidationResult.invalid(field, BundleUtil.getStringFromBundle("isGreaterThanValue",
+            return FieldValidationResult.invalid(field, "isGreaterThanValue",
                     field.getDatasetFieldType().getDisplayName(),
-                    String.valueOf(compareToValueLong)));
+                    String.valueOf(compareToValueLong));
         }
 
         return FieldValidationResult.ok();

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/validators/OrcidFieldValidator.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/validators/OrcidFieldValidator.java
@@ -1,6 +1,5 @@
 package edu.harvard.iq.dataverse.validation.field.validators;
 
-import edu.harvard.iq.dataverse.common.BundleUtil;
 import edu.harvard.iq.dataverse.persistence.dataset.ValidatableField;
 import edu.harvard.iq.dataverse.validation.OrcidValidator;
 import edu.harvard.iq.dataverse.validation.field.FieldValidationResult;
@@ -33,7 +32,7 @@ public class OrcidFieldValidator extends AuthorIdentifierValidator {
         if (result.isOk()) {
             return FieldValidationResult.ok();
         } else {
-            return FieldValidationResult.invalid(field, BundleUtil.getStringFromBundle(result.getErrorCode(), fieldName));
+            return FieldValidationResult.invalid(field, result.getErrorCode(), fieldName);
         }
     }
 }

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/validators/PeriodoFieldValidator.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/validators/PeriodoFieldValidator.java
@@ -1,6 +1,5 @@
 package edu.harvard.iq.dataverse.validation.field.validators;
 
-import static edu.harvard.iq.dataverse.common.BundleUtil.getStringFromBundle;
 import static edu.harvard.iq.dataverse.validation.field.FieldValidationResult.invalid;
 import static edu.harvard.iq.dataverse.validation.field.FieldValidationResult.ok;
 
@@ -38,6 +37,6 @@ public class PeriodoFieldValidator extends MultiValueValidatorBase {
         final ValidationResult result = this.validator.validate(periodoUrl);
         return result.isOk()
                 ? ok()
-                : invalid(field, getStringFromBundle(result.getErrorCode(), fieldName));
+                : invalid(field, result.getErrorCode(), fieldName);
     }
 }

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/validators/RequiredByValueDependantFieldValidator.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/validators/RequiredByValueDependantFieldValidator.java
@@ -49,8 +49,8 @@ public class RequiredByValueDependantFieldValidator extends DependantFieldValida
         if (dependantField.getValidatableValues().stream().anyMatch(actualValue ->
                 StringUtils.equalsIgnoreCase(actualValue, (String) params.get(DEPENDANT_FIELD_VALUE_PARAM)))) {
             if (field.getValidatableValues().stream().noneMatch(StringUtils::isNotBlank)) {
-                return FieldValidationResult.invalid(field, BundleUtil.getStringFromBundle("isrequired",
-                        field.getDatasetFieldType().getDisplayName()));
+                return FieldValidationResult.invalid(field, "isrequired",
+                        field.getDatasetFieldType().getDisplayName());
             }
             return FieldValidationResult.ok();
         }

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/validators/RequiredDependantFieldValidator.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/validators/RequiredDependantFieldValidator.java
@@ -48,8 +48,8 @@ public class RequiredDependantFieldValidator extends DependantFieldValidator {
             Map<String, ? extends List<? extends ValidatableField>> fieldIndex) {
 
         if (dependantField.getValidatableValues().stream().noneMatch(StringUtils::isNotBlank)) {
-            return FieldValidationResult.invalid(dependantField, BundleUtil.getStringFromBundle("isrequired",
-                    dependantField.getDatasetFieldType().getDisplayName()));
+            return FieldValidationResult.invalid(dependantField, "isrequired",
+                    dependantField.getDatasetFieldType().getDisplayName());
         }
         return FieldValidationResult.ok();
     }

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/validators/RorFieldValidator.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/validators/RorFieldValidator.java
@@ -1,6 +1,5 @@
 package edu.harvard.iq.dataverse.validation.field.validators;
 
-import edu.harvard.iq.dataverse.common.BundleUtil;
 import edu.harvard.iq.dataverse.persistence.dataset.ValidatableField;
 import edu.harvard.iq.dataverse.validation.RorValidator;
 import edu.harvard.iq.dataverse.validation.ValidationResult;
@@ -34,7 +33,7 @@ public class RorFieldValidator extends MultiValueValidatorBase {
         if (result.isOk()) {
             return FieldValidationResult.ok();
         } else {
-            return FieldValidationResult.invalid(field, BundleUtil.getStringFromBundle(result.getErrorCode(), fieldName));
+            return FieldValidationResult.invalid(field, result.getErrorCode(), fieldName);
         }
     }
 }

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/validators/StandardBooleanValidator.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/validators/StandardBooleanValidator.java
@@ -1,6 +1,5 @@
 package edu.harvard.iq.dataverse.validation.field.validators;
 
-import edu.harvard.iq.dataverse.common.BundleUtil;
 import edu.harvard.iq.dataverse.persistence.dataset.ValidatableField;
 import edu.harvard.iq.dataverse.validation.field.FieldValidationResult;
 import org.omnifaces.cdi.Eager;
@@ -33,7 +32,7 @@ public class StandardBooleanValidator extends MultiValueValidatorBase {
         if (valueToValidateParsed == acceptableValueParsed) {
             return FieldValidationResult.ok();
         } else {
-            return FieldValidationResult.invalid(field, BundleUtil.getStringFromBundle("isNotAcceptable", value));
+            return FieldValidationResult.invalid(field, "isNotAcceptable", value);
         }
     }
 

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/validators/StandardDateValidator.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/validators/StandardDateValidator.java
@@ -1,6 +1,5 @@
 package edu.harvard.iq.dataverse.validation.field.validators;
 
-import edu.harvard.iq.dataverse.common.BundleUtil;
 import edu.harvard.iq.dataverse.persistence.dataset.ValidatableField;
 import edu.harvard.iq.dataverse.validation.field.FieldValidationResult;
 import org.omnifaces.cdi.Eager;
@@ -55,16 +54,16 @@ public class StandardDateValidator extends MultiValueValidatorBase {
                 return FieldValidationResult.ok();
             }
         }
-        return FieldValidationResult.invalid(field, BundleUtil.getStringFromBundle("isNotValidDate",
-                field.getDatasetFieldType().getDisplayName(), YYYY_MM_DD_FORMAT, YYYY_MM_FORMAT, YYYY_FORMAT));
+        return FieldValidationResult.invalid(field, "isNotValidDate",
+                field.getDatasetFieldType().getDisplayName(), YYYY_MM_DD_FORMAT, YYYY_MM_FORMAT, YYYY_FORMAT);
     }
 
     private FieldValidationResult validateOnlyYear(String value, ValidatableField field) {
         if (isValidDate(value, YEAR_ONLY_PARSER)) {
             return FieldValidationResult.ok();
         }
-        return FieldValidationResult.invalid(field, BundleUtil.getStringFromBundle("isNotValidYear",
-                field.getDatasetFieldType().getDisplayName(), YYYY_FORMAT));
+        return FieldValidationResult.invalid(field, "isNotValidYear",
+                field.getDatasetFieldType().getDisplayName(), YYYY_FORMAT);
     }
 
     // -------------------- LOGIC --------------------

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/validators/StandardEmailValidator.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/validators/StandardEmailValidator.java
@@ -23,7 +23,6 @@ public class StandardEmailValidator extends MultiValueValidatorBase {
                                                Map<String, ? extends List<? extends ValidatableField>> fieldIndex) {
         return EmailValidator.getInstance().isValid(value)
                 ? FieldValidationResult.ok()
-                : FieldValidationResult.invalid(field,
-                        "email.invalid", value);
+                : FieldValidationResult.invalid(field, "email.invalid", value);
     }
 }

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/validators/StandardEmailValidator.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/validators/StandardEmailValidator.java
@@ -1,6 +1,5 @@
 package edu.harvard.iq.dataverse.validation.field.validators;
 
-import edu.harvard.iq.dataverse.common.BundleUtil;
 import edu.harvard.iq.dataverse.persistence.dataset.ValidatableField;
 import edu.harvard.iq.dataverse.validation.field.FieldValidationResult;
 import org.apache.commons.validator.routines.EmailValidator;
@@ -25,6 +24,6 @@ public class StandardEmailValidator extends MultiValueValidatorBase {
         return EmailValidator.getInstance().isValid(value)
                 ? FieldValidationResult.ok()
                 : FieldValidationResult.invalid(field,
-                String.format("%s %s", value, BundleUtil.getStringFromBundle("email.invalid")));
+                        "email.invalid", value);
     }
 }

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/validators/StandardInputValidator.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/validators/StandardInputValidator.java
@@ -1,6 +1,5 @@
 package edu.harvard.iq.dataverse.validation.field.validators;
 
-import edu.harvard.iq.dataverse.common.BundleUtil;
 import edu.harvard.iq.dataverse.persistence.dataset.ValidatableField;
 import edu.harvard.iq.dataverse.validation.field.FieldValidationResult;
 import org.apache.commons.lang.StringUtils;
@@ -26,8 +25,8 @@ public class StandardInputValidator extends MultiValueValidatorBase {
         if (StringUtils.isNotBlank(validationFormat)) {
             return value.matches(validationFormat)
                     ? FieldValidationResult.ok()
-                    : FieldValidationResult.invalid(field, BundleUtil.getStringFromBundle("isNotValidEntry",
-                    field.getDatasetFieldType().getDisplayName()));
+                    : FieldValidationResult.invalid(field, "isNotValidEntry",
+                    field.getDatasetFieldType().getDisplayName());
         }
         return FieldValidationResult.ok();
     }

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/validators/StandardIntegerValidator.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/validators/StandardIntegerValidator.java
@@ -1,6 +1,5 @@
 package edu.harvard.iq.dataverse.validation.field.validators;
 
-import edu.harvard.iq.dataverse.common.BundleUtil;
 import edu.harvard.iq.dataverse.persistence.dataset.ValidatableField;
 import edu.harvard.iq.dataverse.validation.field.FieldValidationResult;
 import org.omnifaces.cdi.Eager;
@@ -25,8 +24,8 @@ public class StandardIntegerValidator extends MultiValueValidatorBase {
             Integer.parseInt(value);
             return FieldValidationResult.ok();
         } catch (NumberFormatException nfe) {
-            return FieldValidationResult.invalid(field, BundleUtil.getStringFromBundle("isNotValidInteger",
-                    field.getDatasetFieldType().getDisplayName()));
+            return FieldValidationResult.invalid(field, "isNotValidInteger",
+                    field.getDatasetFieldType().getDisplayName());
         }
     }
 }

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/validators/StandardNumberValidator.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/validators/StandardNumberValidator.java
@@ -1,6 +1,5 @@
 package edu.harvard.iq.dataverse.validation.field.validators;
 
-import edu.harvard.iq.dataverse.common.BundleUtil;
 import edu.harvard.iq.dataverse.persistence.dataset.ValidatableField;
 import edu.harvard.iq.dataverse.validation.field.FieldValidationResult;
 import org.omnifaces.cdi.Eager;
@@ -25,8 +24,8 @@ public class StandardNumberValidator extends MultiValueValidatorBase {
             Double.parseDouble(value);
             return FieldValidationResult.ok();
         } catch (NumberFormatException nfe) {
-            return FieldValidationResult.invalid(field, BundleUtil.getStringFromBundle("isNotValidNumber",
-                    field.getDatasetFieldType().getDisplayName()));
+            return FieldValidationResult.invalid(field, "isNotValidNumber",
+                    field.getDatasetFieldType().getDisplayName());
         }
     }
 }

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/validators/StandardUrlValidator.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/validators/StandardUrlValidator.java
@@ -1,6 +1,5 @@
 package edu.harvard.iq.dataverse.validation.field.validators;
 
-import edu.harvard.iq.dataverse.common.BundleUtil;
 import edu.harvard.iq.dataverse.persistence.dataset.ValidatableField;
 import edu.harvard.iq.dataverse.validation.field.FieldValidationResult;
 import org.omnifaces.cdi.Eager;
@@ -27,8 +26,8 @@ public class StandardUrlValidator extends MultiValueValidatorBase {
             new URL(value);
             return FieldValidationResult.ok();
         } catch (MalformedURLException e) {
-            return FieldValidationResult.invalid(field, BundleUtil.getStringFromBundle("isNotValidUrl",
-                    field.getDatasetFieldType().getDisplayName(), value));
+            return FieldValidationResult.invalid(field, "isNotValidUrl",
+                    field.getDatasetFieldType().getDisplayName(), value);
         }
     }
 }

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/validators/geobox/GeoboxFillValidator.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/validators/geobox/GeoboxFillValidator.java
@@ -1,12 +1,10 @@
 package edu.harvard.iq.dataverse.validation.field.validators.geobox;
 
-import edu.harvard.iq.dataverse.common.BundleUtil;
 import edu.harvard.iq.dataverse.validation.field.FieldValidator;
 import edu.harvard.iq.dataverse.validation.field.FieldValidationResult;
 import edu.harvard.iq.dataverse.persistence.dataset.ValidatableField;
 import org.apache.commons.lang3.StringUtils;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -20,7 +18,7 @@ class GeoboxFillValidator implements FieldValidator {
     @Override
     public FieldValidationResult validate(ValidatableField field, Map<String, Object> params, Map<String, ? extends List<? extends ValidatableField>> fieldIndex) {
         if (field.hasNonUniqueValue()) {
-            return FieldValidationResult.invalid(field, BundleUtil.getStringFromBundle("validation.nonunique"));
+            return FieldValidationResult.invalid(field, "validation.nonunique");
         }
 
         return FieldValidationResult.ok();

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/validators/geobox/GeoboxPolygonValueValidator.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/validators/geobox/GeoboxPolygonValueValidator.java
@@ -37,13 +37,11 @@ class GeoboxPolygonValueValidator implements FieldValidator {
             }
 
             if (!NumberUtils.isParsable(coords[0])) {
-                return FieldValidationResult.invalid(field, "isNotValidNumber",
-                        coords[0]);
+                return FieldValidationResult.invalid(field, "isNotValidNumber", coords[0]);
             }
 
             if (!NumberUtils.isParsable(coords[1])) {
-                return FieldValidationResult.invalid(field, "isNotValidNumber",
-                        coords[1]);
+                return FieldValidationResult.invalid(field, "isNotValidNumber", coords[1]);
             }
 
             BigDecimal longitude = new BigDecimal(coords[0]);

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/validators/geobox/GeoboxPolygonValueValidator.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/validators/geobox/GeoboxPolygonValueValidator.java
@@ -1,6 +1,5 @@
 package edu.harvard.iq.dataverse.validation.field.validators.geobox;
 
-import edu.harvard.iq.dataverse.common.BundleUtil;
 import edu.harvard.iq.dataverse.persistence.dataset.ValidatableField;
 import edu.harvard.iq.dataverse.validation.field.FieldValidationResult;
 import edu.harvard.iq.dataverse.validation.field.FieldValidator;
@@ -33,18 +32,18 @@ class GeoboxPolygonValueValidator implements FieldValidator {
         for (String line : value.split("\n")) {
             String[] coords = line.trim().split("\\s+");
             if (coords.length != 2) {
-                return FieldValidationResult.invalid(field, BundleUtil.getStringFromBundle("geobox.polygon.invalid.geo.point",
-                        field.getDatasetFieldType().getDisplayName()));
+                return FieldValidationResult.invalid(field, "geobox.polygon.invalid.geo.point",
+                        field.getDatasetFieldType().getDisplayName());
             }
 
             if (!NumberUtils.isParsable(coords[0])) {
-                return FieldValidationResult.invalid(field, BundleUtil.getStringFromBundle("isNotValidNumber",
-                        coords[0]));
+                return FieldValidationResult.invalid(field, "isNotValidNumber",
+                        coords[0]);
             }
 
             if (!NumberUtils.isParsable(coords[1])) {
-                return FieldValidationResult.invalid(field, BundleUtil.getStringFromBundle("isNotValidNumber",
-                        coords[1]));
+                return FieldValidationResult.invalid(field, "isNotValidNumber",
+                        coords[1]);
             }
 
             BigDecimal longitude = new BigDecimal(coords[0]);
@@ -52,17 +51,17 @@ class GeoboxPolygonValueValidator implements FieldValidator {
             minLongitude = minLongitude.compareTo(longitude) > 0 ? longitude : minLongitude;
             BigDecimal latitude = new BigDecimal(coords[1]);
             if (longitude.abs().compareTo(MAX_LONGITUDE) > 0) {
-                return FieldValidationResult.invalid(field, BundleUtil.getStringFromBundle("geobox.invalid.longitude"));
+                return FieldValidationResult.invalid(field, "geobox.invalid.longitude");
             }
 
             if (latitude.abs().compareTo(MAX_LATITUDE) > 0) {
-                return FieldValidationResult.invalid(field, BundleUtil.getStringFromBundle("geobox.invalid.latitude"));
+                return FieldValidationResult.invalid(field, "geobox.invalid.latitude");
             }
         }
 
         BigDecimal span = maxLongitude.subtract(minLongitude).abs();
         if (span.compareTo(MAX_LONGITUDE) > 0) {
-            return FieldValidationResult.invalid(field, BundleUtil.getStringFromBundle("geobox.invalid.longitude.span"));
+            return FieldValidationResult.invalid(field, "geobox.invalid.longitude.span");
         }
 
         return FieldValidationResult.ok();

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/validators/geobox/GeoboxRectangleValueValidator.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/validators/geobox/GeoboxRectangleValueValidator.java
@@ -1,6 +1,5 @@
 package edu.harvard.iq.dataverse.validation.field.validators.geobox;
 
-import edu.harvard.iq.dataverse.common.BundleUtil;
 import edu.harvard.iq.dataverse.persistence.dataset.ValidatableField;
 import edu.harvard.iq.dataverse.search.advanced.field.GeoboxCoordSearchField;
 import edu.harvard.iq.dataverse.search.response.GeoPoint;
@@ -42,7 +41,7 @@ class GeoboxRectangleValueValidator implements FieldValidator {
                 .collect(Collectors.toList());
 
         if (coordinates.size() != 4) {
-            return FieldValidationResult.invalid(field, BundleUtil.getStringFromBundle("geobox.polygon.invalid.coordiantes.length"));
+            return FieldValidationResult.invalid(field, "geobox.polygon.invalid.coordiantes.length");
         }
 
         // Sort to match: Top-left, Top-right, Bottom-left, Bottom-right
@@ -64,7 +63,7 @@ class GeoboxRectangleValueValidator implements FieldValidator {
         if (topSide && bottomSide && leftSide && rightSide) {
             return FieldValidationResult.ok();
         } else {
-            return FieldValidationResult.invalid(field, BundleUtil.getStringFromBundle("geobox.polygon.invalid.coordiantes.rectangle"));
+            return FieldValidationResult.invalid(field, "geobox.polygon.invalid.coordiantes.rectangle");
         }
     }
 }

--- a/fairchive-webapp/src/test/java/edu/harvard/iq/dataverse/validation/ValidationMessageResolverTest.java
+++ b/fairchive-webapp/src/test/java/edu/harvard/iq/dataverse/validation/ValidationMessageResolverTest.java
@@ -1,0 +1,55 @@
+package edu.harvard.iq.dataverse.validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import edu.harvard.iq.dataverse.persistence.dataset.DatasetField;
+import edu.harvard.iq.dataverse.persistence.dataset.DatasetFieldType;
+import edu.harvard.iq.dataverse.persistence.dataset.MetadataBlock;
+import edu.harvard.iq.dataverse.validation.field.FieldValidationResult;
+
+public class ValidationMessageResolverTest {
+
+    private ValidationMessageResolver validationMessageResolver = new ValidationMessageResolver();
+    
+    @Test
+    void resolveValidationMessage__message_from_metadatablock_translations_file() {
+        // given
+        DatasetField field = new DatasetField();
+        DatasetFieldType fieldType = new DatasetFieldType();
+        fieldType.setName("somefieldtype");
+        MetadataBlock metadataBlock = new MetadataBlock();
+        metadataBlock.setName("custommetadata");
+        fieldType.setMetadataBlock(metadataBlock);
+        field.setDatasetFieldType(fieldType);
+        
+        FieldValidationResult result = FieldValidationResult.invalid(field, "customValidationError");
+        
+        // when
+        String message = validationMessageResolver.resolveValidationMessage(result);
+        
+        // then
+        assertThat(message).isEqualTo("Custom validation message");
+    }
+    
+    @Test
+    void resolveValidationMessage__message_from_bundle() {
+        // given
+        DatasetField field = new DatasetField();
+        DatasetFieldType fieldType = new DatasetFieldType();
+        fieldType.setName("somefieldtype");
+        MetadataBlock metadataBlock = new MetadataBlock();
+        metadataBlock.setName("custommetadata");
+        fieldType.setMetadataBlock(metadataBlock);
+        field.setDatasetFieldType(fieldType);
+        
+        FieldValidationResult result = FieldValidationResult.invalid(field, "isrequired", "Some field");
+        
+        // when
+        String message = validationMessageResolver.resolveValidationMessage(result);
+        
+        // then
+        assertThat(message).isEqualTo("Some field is required.");
+    }
+}

--- a/fairchive-webapp/src/test/java/edu/harvard/iq/dataverse/validation/field/DatasetFieldValidationDispatcherTest.java
+++ b/fairchive-webapp/src/test/java/edu/harvard/iq/dataverse/validation/field/DatasetFieldValidationDispatcherTest.java
@@ -43,7 +43,7 @@ class DatasetFieldValidationDispatcherTest {
         @Override
         public FieldValidationResult validate(ValidatableField field, Map<String, Object> params,
                                               Map<String, ? extends List<? extends ValidatableField>> fieldIndex) {
-            return FieldValidationResult.invalid(field, "message");
+            return FieldValidationResult.invalid(field, "message.code");
         }
     };
 
@@ -110,8 +110,8 @@ class DatasetFieldValidationDispatcherTest {
 
         // then
         assertThat(results)
-                .extracting(FieldValidationResult::getMessage, FieldValidationResult::isOk)
-                .containsExactly(tuple("testField is not a valid entry.", false));
+                .extracting(FieldValidationResult::getErrorCode, FieldValidationResult::isOk)
+                .containsExactly(tuple("isNotValidEntry", false));
     }
 
     @Test
@@ -128,8 +128,8 @@ class DatasetFieldValidationDispatcherTest {
 
         // then
         assertThat(results)
-                .extracting(FieldValidationResult::getMessage, FieldValidationResult::isOk)
-                .containsExactly(tuple("testField is not a valid entry.", false));
+                .extracting(FieldValidationResult::getErrorCode, FieldValidationResult::isOk)
+                .containsExactly(tuple("isNotValidEntry", false));
     }
 
     @Test
@@ -142,8 +142,8 @@ class DatasetFieldValidationDispatcherTest {
 
         // then
         assertThat(results)
-                .extracting(FieldValidationResult::getMessage, FieldValidationResult::isOk)
-                .containsExactly(tuple("testField is required.", false));
+                .extracting(FieldValidationResult::getErrorCode, FieldValidationResult::isOk)
+                .containsExactly(tuple("isrequired", false));
     }
 
     @Test

--- a/fairchive-webapp/src/test/java/edu/harvard/iq/dataverse/validation/field/SearchFormValidationDispatcherTest.java
+++ b/fairchive-webapp/src/test/java/edu/harvard/iq/dataverse/validation/field/SearchFormValidationDispatcherTest.java
@@ -43,7 +43,7 @@ class SearchFormValidationDispatcherTest {
         @Override
         public FieldValidationResult validate(ValidatableField field, Map<String, Object> params,
                                               Map<String, ? extends List<? extends ValidatableField>> fieldIndex) {
-            return FieldValidationResult.invalid(field, "message");
+            return FieldValidationResult.invalid(field, "message.code");
         }
     };
 
@@ -102,8 +102,8 @@ class SearchFormValidationDispatcherTest {
 
         // then
         assertThat(results)
-                .extracting(FieldValidationResult::getMessage, FieldValidationResult::isOk)
-                .containsExactly(tuple("testField is not a valid entry.", false));
+                .extracting(FieldValidationResult::getErrorCode, FieldValidationResult::isOk)
+                .containsExactly(tuple("isNotValidEntry", false));
     }
 
     @Test
@@ -120,8 +120,8 @@ class SearchFormValidationDispatcherTest {
 
         // then
         assertThat(results)
-                .extracting(FieldValidationResult::getMessage, FieldValidationResult::isOk)
-                .containsExactly(tuple("testField is not a valid entry.", false));
+                .extracting(FieldValidationResult::getErrorCode, FieldValidationResult::isOk)
+                .containsExactly(tuple("isNotValidEntry", false));
     }
 
     @ParameterizedTest

--- a/fairchive-webapp/src/test/java/edu/harvard/iq/dataverse/validation/field/validators/ControlledVocabularyValidatorTest.java
+++ b/fairchive-webapp/src/test/java/edu/harvard/iq/dataverse/validation/field/validators/ControlledVocabularyValidatorTest.java
@@ -5,19 +5,20 @@ import edu.harvard.iq.dataverse.persistence.dataset.ControlledVocabularyValue;
 import edu.harvard.iq.dataverse.persistence.dataset.DatasetFieldType;
 import edu.harvard.iq.dataverse.persistence.dataset.ValidatableField;
 import edu.harvard.iq.dataverse.validation.field.FieldValidationResult;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Collections;
 import java.util.HashMap;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 class ControlledVocabularyValidatorTest {
 
     @Mock
@@ -26,10 +27,6 @@ class ControlledVocabularyValidatorTest {
     @InjectMocks
     private ControlledVocabularyValidator validator;
 
-    @BeforeEach
-    public void setUp() {
-        MockitoAnnotations.initMocks(this);
-    }
 
     @Test
     void testValidateValue_success() {
@@ -49,7 +46,7 @@ class ControlledVocabularyValidatorTest {
         FieldValidationResult result = validator.validateValue(
                 testValue, testField, new HashMap<>(), new HashMap<>());
 
-        assertTrue(result.isOk());
+        assertThat(result.isOk()).isTrue();
     }
 
     @Test
@@ -67,7 +64,8 @@ class ControlledVocabularyValidatorTest {
         FieldValidationResult result = validator.validateValue(
                 testValue, testField, new HashMap<>(), new HashMap<>());
 
-        assertFalse(result.isOk());
-        assertEquals("Value \"InvalidValue\" is not allowed. Please select one from the list.", result.getMessage());
+        assertThat(result.isOk()).isFalse();
+        assertThat(result.getErrorCode()).isEqualTo("validation.value.not.allowed.in.controlled.vocabulary");
+        assertThat(result.getErrorArgs()).containsExactly("InvalidValue");
     }
 }

--- a/fairchive-webapp/src/test/java/edu/harvard/iq/dataverse/validation/field/validators/NotGreaterThanValueValidatorTest.java
+++ b/fairchive-webapp/src/test/java/edu/harvard/iq/dataverse/validation/field/validators/NotGreaterThanValueValidatorTest.java
@@ -66,8 +66,8 @@ public class NotGreaterThanValueValidatorTest {
 
         // then
         assertThat(result.isOk()).isFalse();
-        assertThat(result.getMessage()).contains("FROM");
-        assertThat(result.getMessage()).contains("1998");
+        assertThat(result.getErrorCode()).isEqualTo("isGreaterThanValue");
+        assertThat(result.getErrorArgs()).containsExactly("FROM", "1998");
     }
 
     @Test
@@ -113,8 +113,8 @@ public class NotGreaterThanValueValidatorTest {
 
         // then
         assertThat(result.isOk()).isFalse();
-        assertThat(result.getMessage()).contains("FROM");
-        assertThat(result.getMessage()).contains(Year.now(Clock.systemUTC()).toString());
+        assertThat(result.getErrorCode()).isEqualTo("isGreaterThanValue");
+        assertThat(result.getErrorArgs()).contains("FROM", Year.now(Clock.systemUTC()).toString());
     }
 
     private DatasetField buildSimpleField(String typeName, String value) {

--- a/fairchive-webapp/src/test/java/edu/harvard/iq/dataverse/validation/field/validators/OrcidFieldValidatorTest.java
+++ b/fairchive-webapp/src/test/java/edu/harvard/iq/dataverse/validation/field/validators/OrcidFieldValidatorTest.java
@@ -44,7 +44,7 @@ public class OrcidFieldValidatorTest {
         // then
         assertThat(result.isOk()).isTrue();
         assertThat(result.getField()).isNull();
-        assertThat(result.getMessage()).isEmpty();
+        assertThat(result.getErrorCode()).isNull();
     }
 
     @Test
@@ -77,7 +77,7 @@ public class OrcidFieldValidatorTest {
         // then
         assertThat(result.isOk()).isTrue();
         assertThat(result.getField()).isNull();
-        assertThat(result.getMessage()).isEmpty();
+        assertThat(result.getErrorCode()).isNull();
         verify(orcidValidator, never()).validate(isni);
     }
 

--- a/fairchive-webapp/src/test/java/edu/harvard/iq/dataverse/validation/field/validators/RequiredDependantFieldValidatorTest.java
+++ b/fairchive-webapp/src/test/java/edu/harvard/iq/dataverse/validation/field/validators/RequiredDependantFieldValidatorTest.java
@@ -28,7 +28,7 @@ public class RequiredDependantFieldValidatorTest {
         // then
         assertThat(result.isOk()).isTrue();
         assertThat(result.getField()).isNull();
-        assertThat(result.getMessage()).isEmpty();
+        assertThat(result.getErrorCode()).isNull();
     }
 
     @Test
@@ -57,7 +57,7 @@ public class RequiredDependantFieldValidatorTest {
         // then
         assertThat(result.isOk()).isTrue();
         assertThat(result.getField()).isNull();
-        assertThat(result.getMessage()).isEmpty();
+        assertThat(result.getErrorCode()).isNull();
     }
 
     // -------------------- PRIVATE ---------------------

--- a/fairchive-webapp/src/test/java/edu/harvard/iq/dataverse/validation/field/validators/RorFieldValidatorTest.java
+++ b/fairchive-webapp/src/test/java/edu/harvard/iq/dataverse/validation/field/validators/RorFieldValidatorTest.java
@@ -41,7 +41,7 @@ public class RorFieldValidatorTest {
         // then
         assertThat(result.isOk()).isTrue();
         assertThat(result.getField()).isNull();
-        assertThat(result.getMessage()).isEmpty();
+        assertThat(result.getErrorCode()).isNull();
     }
 
     @Test

--- a/fairchive-webapp/src/test/java/edu/harvard/iq/dataverse/validation/field/validators/geobox/GeoboxPolygonValueValidatorTest.java
+++ b/fairchive-webapp/src/test/java/edu/harvard/iq/dataverse/validation/field/validators/geobox/GeoboxPolygonValueValidatorTest.java
@@ -39,7 +39,7 @@ class GeoboxPolygonValueValidatorTest {
         FieldValidationResult result = validator.validate(datasetField, Collections.emptyMap(), Collections.emptyMap());
 
         // then
-        assertThat(result.getMessage()).isEqualTo("Each line should have only two numbers");
+        assertThat(result.getErrorCode()).isEqualTo("geobox.polygon.invalid.geo.point");
     }
 
     @Test
@@ -52,7 +52,8 @@ class GeoboxPolygonValueValidatorTest {
         FieldValidationResult result = validator.validate(datasetField, Collections.emptyMap(), Collections.emptyMap());
 
         // then
-        assertThat(result.getMessage()).isEqualTo("abc is not a valid number.");
+        assertThat(result.getErrorCode()).isEqualTo("isNotValidNumber");
+        assertThat(result.getErrorArgs()).containsExactly("abc");
     }
 
     @Test
@@ -65,7 +66,8 @@ class GeoboxPolygonValueValidatorTest {
         FieldValidationResult result = validator.validate(datasetField, Collections.emptyMap(), Collections.emptyMap());
 
         // then
-        assertThat(result.getMessage()).isEqualTo("xyz is not a valid number.");
+        assertThat(result.getErrorCode()).isEqualTo("isNotValidNumber");
+        assertThat(result.getErrorArgs()).containsExactly("xyz");
     }
 
     @Test
@@ -78,7 +80,7 @@ class GeoboxPolygonValueValidatorTest {
         FieldValidationResult result = validator.validate(datasetField, Collections.emptyMap(), Collections.emptyMap());
 
         // then
-        assertThat(result.getMessage()).isEqualTo("The longitude must be a number between -180 and 180.");
+        assertThat(result.getErrorCode()).isEqualTo("geobox.invalid.longitude");
     }
 
     @Test
@@ -91,7 +93,7 @@ class GeoboxPolygonValueValidatorTest {
         FieldValidationResult result = validator.validate(datasetField, Collections.emptyMap(), Collections.emptyMap());
 
         // then
-        assertThat(result.getMessage()).isEqualTo("The longitude cannot span more than 180 degrees.");
+        assertThat(result.getErrorCode()).isEqualTo("geobox.invalid.longitude.span");
     }
 
     @Test
@@ -104,7 +106,7 @@ class GeoboxPolygonValueValidatorTest {
         FieldValidationResult result = validator.validate(datasetField, Collections.emptyMap(), Collections.emptyMap());
 
         // then
-        assertThat(result.getMessage()).isEqualTo("The latitude must be a number between -90 and 90.");
+        assertThat(result.getErrorCode()).isEqualTo("geobox.invalid.latitude");
     }
 
     private DatasetField createField(String value) {

--- a/fairchive-webapp/src/test/java/edu/harvard/iq/dataverse/validation/field/validators/geobox/GeoboxRectangleValueValidatorTest.java
+++ b/fairchive-webapp/src/test/java/edu/harvard/iq/dataverse/validation/field/validators/geobox/GeoboxRectangleValueValidatorTest.java
@@ -53,7 +53,7 @@ class GeoboxRectangleValueValidatorTest {
         FieldValidationResult result = validator.validate(datasetField, Collections.emptyMap(), Collections.emptyMap());
 
         // then
-        assertThat(result.getMessage()).isEqualTo("Coordinates should have 4 different points");
+        assertThat(result.getErrorCode()).isEqualTo("geobox.polygon.invalid.coordiantes.length");
     }
 
     @Test
@@ -66,7 +66,7 @@ class GeoboxRectangleValueValidatorTest {
         FieldValidationResult result = validator.validate(datasetField, Collections.emptyMap(), Collections.emptyMap());
 
         // then
-        assertThat(result.getMessage()).isEqualTo("Coordinates should have 4 different points");
+        assertThat(result.getErrorCode()).isEqualTo("geobox.polygon.invalid.coordiantes.length");
     }
 
     @Test
@@ -79,7 +79,7 @@ class GeoboxRectangleValueValidatorTest {
         FieldValidationResult result = validator.validate(datasetField, Collections.emptyMap(), Collections.emptyMap());
 
         // then
-        assertThat(result.getMessage()).isEqualTo("Coordinates should create axis-aligned rectangle");
+        assertThat(result.getErrorCode()).isEqualTo("geobox.polygon.invalid.coordiantes.rectangle");
     }
 
     private DatasetField createField(String value) {

--- a/fairchive-webapp/src/test/resources/custommetadata_en.properties
+++ b/fairchive-webapp/src/test/resources/custommetadata_en.properties
@@ -1,3 +1,4 @@
 datasetfieldtype.fieldWithSuggestions.title=Field with suggestions
 datasetfieldtype.fieldWithSuggestions.suggestionDisplay.valueHeader=Suggestion Value Header
 datasetfieldtype.fieldWithSuggestions.suggestionDisplay.detailsHeader=Suggestion Details Header
+datasetfieldtype.somefieldtype.customValidationError=Custom validation message


### PR DESCRIPTION
Unfortunetly I didn't have any solid and easy idea for merging of `SearchFormValidationService` and `SearchFormValidationService` without some major changes.

I'm not a fan of logging translated messages like:
```
fieldValidationResults.forEach(r -> logger.warn(r.getField().getValidationMessage()))
```
but I didn't do anything with it. It works as it worked before (maybe we could change it / get rid of it?). Not sure if it has some big value.
