### PR TITLE
Closes #2861: Allow for default values in any dataset field type

### DIFF
--- a/fairchive-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/dataset/DatasetFieldType.java
+++ b/fairchive-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/dataset/DatasetFieldType.java
@@ -176,6 +176,16 @@ public class DatasetFieldType implements Serializable, Comparable<DatasetFieldTy
     private Map<String, Object> metadata = emptyMap();
     private boolean visibleThroughAnonymizedUrl;
 
+    /**
+     * When creating/editing dataset. Field value will be pre-populated with
+     * this value.
+     * If field type is a controlled vocabulary then it should be set to
+     * the value of {@link ControlledVocabularyValue#getStrValue()}.
+     * If controlled vocabulary is a multivalued it is possible to set
+     * default value to multiple values by seperating them by semicolon ';'.
+     */
+    private String defaultValue;
+
     // -------------------- CONSTRUCTORS --------------------
 
     public DatasetFieldType() { }
@@ -354,6 +364,10 @@ public class DatasetFieldType implements Serializable, Comparable<DatasetFieldTy
 
     public Map<String, Object> getMetadata() {
         return metadata;
+    }
+
+    public String getDefaultValue() {
+        return defaultValue;
     }
 
     // -------------------- LOGIC --------------------
@@ -696,6 +710,10 @@ public class DatasetFieldType implements Serializable, Comparable<DatasetFieldTy
 
     public void setMetadata(Map<String, Object> metadata) {
         this.metadata = metadata;
+    }
+
+    public void setDefaultValue(String defaultValue) {
+        this.defaultValue = defaultValue;
     }
 
     // -------------------- hashCode & equals --------------------

--- a/fairchive-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/dataset/DatasetFieldType.java
+++ b/fairchive-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/dataset/DatasetFieldType.java
@@ -177,7 +177,7 @@ public class DatasetFieldType implements Serializable, Comparable<DatasetFieldTy
     private boolean visibleThroughAnonymizedUrl;
 
     /**
-     * When creating/editing dataset. Field value will be pre-populated with
+     * When creating/editing dataset, field value will be pre-populated with
      * this value.
      * If field type is a controlled vocabulary then it should be set to
      * the value of {@link ControlledVocabularyValue#getStrValue()}.

--- a/fairchive-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/dataset/DatasetFieldsByType.java
+++ b/fairchive-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/dataset/DatasetFieldsByType.java
@@ -20,6 +20,8 @@ public class DatasetFieldsByType {
     // some kind of factory and collection of field actions.
     private FieldValueDivider divider;
 
+    private FieldDefaultValueApplier defaultValueApplier = new FieldDefaultValueApplier();
+
     private boolean include = true;
 
     // -------------------- CONSTRUCTORS --------------------
@@ -58,6 +60,7 @@ public class DatasetFieldsByType {
 
     public void addEmptyDatasetField(int position) {
         DatasetField newField = DatasetField.createNewEmptyDatasetField(datasetFieldType, null);
+        applyDefaultValues(newField);
         datasetFields.add(position, newField);
     }
 
@@ -89,6 +92,10 @@ public class DatasetFieldsByType {
             divider = FieldValueDivider.create(datasetFieldType);
         }
         return divider;
+    }
+
+    private void applyDefaultValues(DatasetField datasetField) {
+        defaultValueApplier.applyDefaultValue(datasetField);
     }
 
     // -------------------- SETTERS --------------------

--- a/fairchive-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/dataset/FieldDefaultValueApplier.java
+++ b/fairchive-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/dataset/FieldDefaultValueApplier.java
@@ -18,7 +18,6 @@ public class FieldDefaultValueApplier {
 
         if (StringUtils.isNotBlank(datasetFieldType.getDefaultValue())
                 && datasetField.isEmpty()) {
-            
             if (datasetFieldType.isControlledVocabulary()) {
                 datasetField.setControlledVocabularyValues(
                         getControlledVocabularyValues(datasetFieldType, datasetFieldType.getDefaultValue()));

--- a/fairchive-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/dataset/FieldDefaultValueApplier.java
+++ b/fairchive-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/dataset/FieldDefaultValueApplier.java
@@ -1,0 +1,40 @@
+package edu.harvard.iq.dataverse.persistence.dataset;
+
+import static java.util.stream.Collectors.toList;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+
+public class FieldDefaultValueApplier {
+
+    /**
+     * Fills up dataset field and its children with default values.
+     */
+    public void applyDefaultValue(DatasetField datasetField) {
+
+        DatasetFieldType datasetFieldType = datasetField.getDatasetFieldType();
+
+        if (StringUtils.isNotBlank(datasetFieldType.getDefaultValue())
+                && datasetField.isEmpty()) {
+            
+            if (datasetFieldType.isControlledVocabulary()) {
+                datasetField.setControlledVocabularyValues(
+                        getControlledVocabularyValues(datasetFieldType, datasetFieldType.getDefaultValue()));
+            } else {
+                datasetField.setValue(datasetFieldType.getDefaultValue());
+            }
+            
+        }
+
+        datasetField.getChildren().forEach(this::applyDefaultValue);
+    }
+
+    private List<ControlledVocabularyValue> getControlledVocabularyValues(DatasetFieldType datasetFieldType, String defaultValue) {
+        List<String> defaultValues = Arrays.asList(StringUtils.split(defaultValue, ';'));
+        return datasetFieldType.getControlledVocabularyValues().stream()
+                .filter(vocabValue -> defaultValues.contains(vocabValue.getStrValue()))
+                .collect(toList());
+    }
+}

--- a/fairchive-persistence/src/main/resources/db/migration/V89__add_field_default_value.sql
+++ b/fairchive-persistence/src/main/resources/db/migration/V89__add_field_default_value.sql
@@ -1,0 +1,2 @@
+
+alter table datasetfieldtype add column defaultvalue text;

--- a/fairchive-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/dataset/FieldDefaultValueApplierTest.java
+++ b/fairchive-persistence/src/test/java/edu/harvard/iq/dataverse/persistence/dataset/FieldDefaultValueApplierTest.java
@@ -1,0 +1,67 @@
+package edu.harvard.iq.dataverse.persistence.dataset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.ImmutableList;
+
+public class FieldDefaultValueApplierTest {
+
+    private FieldDefaultValueApplier applier = new FieldDefaultValueApplier();
+
+    @Test
+    void applyDefaultValue() {
+
+        // given
+        DatasetField df = new DatasetField();
+        DatasetFieldType dft = new DatasetFieldType();
+        dft.setDefaultValue("abc");
+        df.setDatasetFieldType(dft);
+
+        // when
+        applier.applyDefaultValue(df);
+
+        // then
+        assertThat(df.getValue()).isEqualTo("abc");
+    }
+
+    @Test
+    void applyDefaultValue__controlled_vocabulary() {
+
+        // given
+        DatasetField df = new DatasetField();
+        DatasetFieldType dft = new DatasetFieldType();
+        ControlledVocabularyValue cvv1 = new ControlledVocabularyValue(1L, "abc", dft);
+        ControlledVocabularyValue cvv2 = new ControlledVocabularyValue(1L, "cba", dft);
+        dft.setControlledVocabularyValues(ImmutableList.of(cvv1, cvv2));
+        dft.setDefaultValue("abc");
+        df.setDatasetFieldType(dft);
+
+        // when
+        applier.applyDefaultValue(df);
+
+        // then
+        assertThat(df.getControlledVocabularyValues()).containsExactly(cvv1);
+    }
+
+    @Test
+    void applyDefaultValue__for_children() {
+
+        // given
+        DatasetFieldType dft = new DatasetFieldType();
+        DatasetFieldType childDft1 = new DatasetFieldType();
+        DatasetFieldType childDft2 = new DatasetFieldType();
+        childDft2.setDefaultValue("abc");
+        dft.setChildDatasetFieldTypes(ImmutableList.of(childDft1, childDft2));
+
+        DatasetField df = DatasetField.createNewEmptyDatasetField(dft, null);
+
+        // when
+        applier.applyDefaultValue(df);
+
+        // then
+        assertThat(df.getChildren().get(0).getValue()).isNull();
+        assertThat(df.getChildren().get(1).getValue()).isEqualTo("abc");
+    }
+}

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/api/DatasetFieldServiceApi.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/api/DatasetFieldServiceApi.java
@@ -323,6 +323,9 @@ public class DatasetFieldServiceApi extends AbstractApiBean {
         setIfNotEmpty(dsf::setValidation, 19, values);
         setIfNotEmpty(v -> dsf.setMetadata(jsonMapConverter.convertToEntityAttribute(v)), 20, values);
         setIfNotEmpty(v -> dsf.setVisibleThroughAnonymizedUrl(parseBoolean(v)), 21, values);
+        if (values.length >= 22) {
+            dsf.setDefaultValue(values[22]);
+        }
 
         datasetFieldService.save(dsf);
         return dsf.getName();

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/api/DatasetFieldServiceApi.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/api/DatasetFieldServiceApi.java
@@ -323,7 +323,7 @@ public class DatasetFieldServiceApi extends AbstractApiBean {
         setIfNotEmpty(dsf::setValidation, 19, values);
         setIfNotEmpty(v -> dsf.setMetadata(jsonMapConverter.convertToEntityAttribute(v)), 20, values);
         setIfNotEmpty(v -> dsf.setVisibleThroughAnonymizedUrl(parseBoolean(v)), 21, values);
-        if (values.length >= 22) {
+        if (values.length > 22) {
             dsf.setDefaultValue(values[22]);
         }
 

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/dataset/DatasetFieldsInitializer.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/dataset/DatasetFieldsInitializer.java
@@ -6,6 +6,7 @@ import edu.harvard.iq.dataverse.persistence.dataset.DatasetField;
 import edu.harvard.iq.dataverse.persistence.dataset.DatasetFieldType;
 import edu.harvard.iq.dataverse.persistence.dataset.DatasetFieldUtil;
 import edu.harvard.iq.dataverse.persistence.dataset.DatasetFieldsByType;
+import edu.harvard.iq.dataverse.persistence.dataset.FieldDefaultValueApplier;
 import edu.harvard.iq.dataverse.persistence.dataset.MetadataBlock;
 import edu.harvard.iq.dataverse.persistence.dataverse.Dataverse;
 import org.apache.commons.collections4.SetUtils;
@@ -27,6 +28,7 @@ import java.util.stream.Collectors;
 public class DatasetFieldsInitializer {
 
     private DataverseFieldTypeInputLevelServiceBean dataverseFieldTypeInputLevelService;
+    private FieldDefaultValueApplier defaultValueApplier = new FieldDefaultValueApplier();
 
 
     // -------------------- CONSTRUCTORS --------------------
@@ -81,6 +83,8 @@ public class DatasetFieldsInitializer {
         newDatasetFields = filterEmptyFieldsFromUnknownBlocks(newDatasetFields, metadataBlocksDataverse);
 
         newDatasetFields = sortDatasetFieldsRecursively(newDatasetFields);
+
+        applyDefaultValues(newDatasetFields);
 
         return newDatasetFields;
     }
@@ -261,6 +265,10 @@ public class DatasetFieldsInitializer {
             }
         }
         return notEmptyFields;
+    }
+
+    private void applyDefaultValues(List<DatasetField> datasetFields) {
+        datasetFields.forEach(defaultValueApplier::applyDefaultValue);
     }
 
     private List<DatasetField> filterEmptyFieldsFromUnknownBlocks(List<DatasetField> datasetFields, Dataverse metadataBlocksDataverse) {

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/dataset/metadata/inputRenderer/HiddenVocabInputFieldRenderer.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/dataset/metadata/inputRenderer/HiddenVocabInputFieldRenderer.java
@@ -1,22 +1,12 @@
 package edu.harvard.iq.dataverse.dataset.metadata.inputRenderer;
 
-import edu.harvard.iq.dataverse.persistence.dataset.ControlledVocabularyValue;
 import edu.harvard.iq.dataverse.persistence.dataset.DatasetField;
 import edu.harvard.iq.dataverse.persistence.dataset.InputRendererType;
 
-import java.util.ArrayList;
 import java.util.List;
 
 public class HiddenVocabInputFieldRenderer implements InputFieldRenderer {
 
-    private List<ControlledVocabularyValue> defaultVocabValues = new ArrayList<>();
-    
-    // -------------------- CONSTRUCTORS --------------------
-    
-    public HiddenVocabInputFieldRenderer(List<ControlledVocabularyValue> defaultVocabValues) {
-        this.defaultVocabValues = defaultVocabValues;
-    }
-    
     // -------------------- GETTERS --------------------
     
     /**
@@ -47,14 +37,6 @@ public class HiddenVocabInputFieldRenderer implements InputFieldRenderer {
     @Override
     public boolean isHidden() {
         return true;
-    }
-
-    /**
-     * Returns {@link ControlledVocabularyValue}s that should
-     * be assigned to dataset field by default
-     */
-    public List<ControlledVocabularyValue> getDefaultVocabValues() {
-        return defaultVocabValues;
     }
 
     @Override

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/dataset/metadata/inputRenderer/HiddenVocabInputFieldRendererFactory.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/dataset/metadata/inputRenderer/HiddenVocabInputFieldRendererFactory.java
@@ -1,19 +1,11 @@
 package edu.harvard.iq.dataverse.dataset.metadata.inputRenderer;
 
-import com.google.gson.Gson;
 import com.google.gson.JsonObject;
-import edu.harvard.iq.dataverse.persistence.dataset.ControlledVocabularyValue;
 import edu.harvard.iq.dataverse.persistence.dataset.DatasetFieldType;
 import edu.harvard.iq.dataverse.persistence.dataset.InputRendererType;
-import io.vavr.control.Try;
 
 import javax.ejb.Stateless;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
-import static java.util.stream.Collectors.toList;
 
 @Stateless
 public class HiddenVocabInputFieldRendererFactory implements InputFieldRendererFactory<HiddenVocabInputFieldRenderer> {
@@ -35,35 +27,8 @@ public class HiddenVocabInputFieldRendererFactory implements InputFieldRendererF
      */
     @Override
     public HiddenVocabInputFieldRenderer createRenderer(DatasetFieldType fieldType, JsonObject jsonOptions) {
-        
-        HiddenVocabInputFieldRendererOptions rendererOptions = Try.of(() -> new Gson().fromJson(jsonOptions, HiddenVocabInputFieldRendererOptions.class))
-                .getOrElseThrow((e) -> new InputRendererInvalidConfigException("Invalid syntax of input renderer options " + jsonOptions + ")", e));
-        
-        List<ControlledVocabularyValue> defaultValues = fieldType.getControlledVocabularyValues().stream()
-            .filter(vocabValue -> rendererOptions.getDefaultValues().contains(vocabValue.getStrValue()))
-            .collect(toList());
-        
-        return new HiddenVocabInputFieldRenderer(defaultValues);
+
+        return new HiddenVocabInputFieldRenderer();
     }
-    
-    // -------------------- INNER CLASSES --------------------
 
-    /**
-     * Class representing allowed options for {@link HiddenVocabInputFieldRenderer}
-     */
-    public static class HiddenVocabInputFieldRendererOptions {
-        private Set<String> defaultValues = new HashSet<>();
-
-        // -------------------- GETTERS --------------------
-        
-        public Set<String> getDefaultValues() {
-            return defaultValues;
-        }
-
-        // -------------------- SETTERS --------------------
-        
-        public void setDefaultValues(Set<String> defaultValues) {
-            this.defaultValues = defaultValues;
-        }
-    }
 }

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/dataverse/MetadataBlockTsvCreator.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/dataverse/MetadataBlockTsvCreator.java
@@ -181,6 +181,7 @@ public class MetadataBlockTsvCreator {
         TERM_URI("termURI", DatasetFieldType::getUri),
         VALIDATION("validation", DatasetFieldType::getValidation),
         METADATA("metadata", DatasetFieldType::getMetadata, v -> (Object) jsonMapConverter.convertToDatabaseColumn((Map<String, Object>) v)),
+        VISIBLE_THROUGH_ANONYMIZED_URL("visibleThroughAnonymizedUrl", DatasetFieldType::isVisibleThroughAnonymizedUrl, Formatters.toUpperFormatter),
         DEFAULT_VALUE("defaultValue", DatasetFieldType::getDefaultValue);
 
         DatasetFieldTypeRecord(String columnName, Function<DatasetFieldType, Object> valueGetter, UnaryOperator<Object> formatter) {

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/dataverse/MetadataBlockTsvCreator.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/dataverse/MetadataBlockTsvCreator.java
@@ -180,7 +180,8 @@ public class MetadataBlockTsvCreator {
         METADATABLOCK_ID("metadatablock_id", t -> t.getMetadataBlock().getName()),
         TERM_URI("termURI", DatasetFieldType::getUri),
         VALIDATION("validation", DatasetFieldType::getValidation),
-        METADATA("metadata", DatasetFieldType::getMetadata, v -> (Object) jsonMapConverter.convertToDatabaseColumn((Map<String, Object>) v));
+        METADATA("metadata", DatasetFieldType::getMetadata, v -> (Object) jsonMapConverter.convertToDatabaseColumn((Map<String, Object>) v)),
+        DEFAULT_VALUE("defaultValue", DatasetFieldType::getDefaultValue);
 
         DatasetFieldTypeRecord(String columnName, Function<DatasetFieldType, Object> valueGetter, UnaryOperator<Object> formatter) {
             this.columnName = columnName;

--- a/fairchive-webapp/src/main/webapp/WEB-INF/templates/dataset/inputRenderer/hiddenControlledVocabInputField.xhtml
+++ b/fairchive-webapp/src/main/webapp/WEB-INF/templates/dataset/inputRenderer/hiddenControlledVocabInputField.xhtml
@@ -11,15 +11,7 @@
                 value="#{datasetField.controlledVocabularyValues}"
                 converter="controlledVocabularyValueConverter"
                 widgetVar="#{datasetField.datasetFieldType.name}_HiddenSelect">
-        <f:selectItems value="#{inputRenderer.defaultVocabValues}" />
+        <f:selectItems value="#{datasetField.datasetFieldType.getControlledVocabSelectItems(false)}" />
     </p:selectManyCheckbox>
-
-    <script>
-    $(document).ready(function (){
-        PF('#{datasetField.datasetFieldType.name}_HiddenSelect').inputs.each(function() {
-            $(this).prop('checked', true)
-        });
-    });
-    </script>
 
 </ui:composition>

--- a/fairchive-webapp/src/test/java/edu/harvard/iq/dataverse/dataset/DatasetFieldsInitializerTest.java
+++ b/fairchive-webapp/src/test/java/edu/harvard/iq/dataverse/dataset/DatasetFieldsInitializerTest.java
@@ -136,6 +136,7 @@ public class DatasetFieldsInitializerTest {
         keywordField.getDatasetFieldsChildren().add(makeDatasetField(keywordField, keywordValueType, "term3", 4));
 
         DatasetFieldType depositorFieldType = makeDepositorFieldType(citationBlock);
+        depositorFieldType.setDefaultValue("I am the depositor");
         DatasetFieldType dataOfDepositFieldType = makeDateOfDepositFieldType(citationBlock);
 
         DatasetField unitOfAnalysisField = DatasetField.createNewEmptyDatasetField(makeUnitOfAnalysisFieldType(socialScienceBlock), null);
@@ -158,7 +159,7 @@ public class DatasetFieldsInitializerTest {
         assertEquals("term1; vocabName; http://example.edu; term2; term3", retDatasetFields.get(2).getCompoundRawValue());
 
         assertEquals(depositorFieldType, retDatasetFields.get(3).getDatasetFieldType());
-        assertEquals("", retDatasetFields.get(3).getRawValue());
+        assertEquals("I am the depositor", retDatasetFields.get(3).getRawValue());
 
         assertEquals(dataOfDepositFieldType, retDatasetFields.get(4).getDatasetFieldType());
         assertEquals("", retDatasetFields.get(4).getRawValue());

--- a/fairchive-webapp/src/test/java/edu/harvard/iq/dataverse/dataset/metadata/inputRenderer/HiddenVocabInputFieldRendererFactoryTest.java
+++ b/fairchive-webapp/src/test/java/edu/harvard/iq/dataverse/dataset/metadata/inputRenderer/HiddenVocabInputFieldRendererFactoryTest.java
@@ -9,7 +9,6 @@ import edu.harvard.iq.dataverse.persistence.dataset.MetadataBlock;
 import edu.harvard.iq.dataverse.util.json.TestJsonCreator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.function.Executable;
 import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
@@ -19,11 +18,8 @@ import com.google.common.collect.Lists;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -35,7 +31,7 @@ public class HiddenVocabInputFieldRendererFactoryTest {
     // -------------------- TESTS --------------------
     
     @Test
-    public void createRenderer__withEmptyOptions() {
+    public void createRenderer() {
         // given
         DatasetFieldType fieldType = new DatasetFieldType();
         fieldType.setControlledVocabularyValues(Lists.newArrayList());
@@ -45,41 +41,6 @@ public class HiddenVocabInputFieldRendererFactoryTest {
         HiddenVocabInputFieldRenderer renderer = inputFieldRendererFactory.createRenderer(fieldType, rendererOptions);
         // then
         assertEquals(inputFieldRendererFactory.isFactoryForType(), renderer.getType());
-        assertEquals(0, renderer.getDefaultVocabValues().size());
-    }
-    
-    @Test
-    public void createRenderer__withDefaultValues() {
-        // given
-        DatasetFieldType fieldType = new DatasetFieldType();
-        ControlledVocabularyValue vocabValue1 = new ControlledVocabularyValue(1L, "val1", null);
-        ControlledVocabularyValue vocabValue2 = new ControlledVocabularyValue(2L, "val2", null);
-        ControlledVocabularyValue vocabValue3 = new ControlledVocabularyValue(2L, "val3", null);
-        fieldType.setControlledVocabularyValues(Lists.newArrayList(vocabValue1, vocabValue2, vocabValue3));
-        
-        JsonObject rendererOptions = TestJsonCreator.stringAsJsonElement("{'defaultValues': ['val1', 'val2']}").getAsJsonObject();
-        
-        // when
-        HiddenVocabInputFieldRenderer renderer = inputFieldRendererFactory.createRenderer(fieldType, rendererOptions);
-        // then
-        assertEquals(inputFieldRendererFactory.isFactoryForType(), renderer.getType());
-        assertThat(renderer.getDefaultVocabValues(), contains(vocabValue1, vocabValue2));
-    }
-    
-    @Test
-    public void createRenderer__invalidOptions() {
-        // given
-        DatasetFieldType fieldType = new DatasetFieldType();
-        fieldType.setControlledVocabularyValues(Lists.newArrayList());
-        
-        JsonObject rendererOptions = TestJsonCreator.stringAsJsonElement(
-                "{'defaultValues':'notAnArray'}").getAsJsonObject();
-        
-        // when
-        Executable createRendererOperation = () -> inputFieldRendererFactory.createRenderer(fieldType, rendererOptions);
-        
-        // then
-        assertThrows(InputRendererInvalidConfigException.class, createRendererOperation);
     }
 
     @Test

--- a/fairchive-webapp/src/test/java/edu/harvard/iq/dataverse/dataverse/MetadataBlockTsvCreatorTest.java
+++ b/fairchive-webapp/src/test/java/edu/harvard/iq/dataverse/dataverse/MetadataBlockTsvCreatorTest.java
@@ -20,8 +20,8 @@ class MetadataBlockTsvCreatorTest {
 
     private static String EXPECTED = "#metadataBlock\tname\tdataverseAlias\tdisplayName\tblockURI\tdisplayOrder\n" +
             "\tMetadataBlock 1\t\tMetadata Block 1\thttp:\\\\metadatablock.uri\t15\n" +
-            "#datasetField\tname\ttitle\tdescription\twatermark\tfieldType\tdisplayOrder\tdisplayFormat\tadvancedSearchField\tallowControlledVocabulary\tallowmultiples\tfacetable\tdisplayoncreate\trequired\tparent\tinputRendererType\tinputRendererOptions\tmetadatablock_id\ttermURI\tvalidation\tmetadata\tdefaultValue\n" +
-            "\tType 1\tDatasetFieldType 1\tLorem ipsum dolor sit amet\tEnter value…\ttext\t7\t#NAME: #VALUE\tFALSE\tTRUE\tFALSE\tTRUE\tTRUE\tFALSE\t\tVOCABULARY_SELECT\t{\"sortByLocalisedStringsOrder\" : \"true\"}\tMetadataBlock 1\thttp:\\\\test.test\t[{\"name\":\"standard_input\",\"parameters\":[\"format:https://ror.org/0[a-hjkmnp-z0-9]{6}[0-9]{2}\"]}]\t{}\t\n" +
+            "#datasetField\tname\ttitle\tdescription\twatermark\tfieldType\tdisplayOrder\tdisplayFormat\tadvancedSearchField\tallowControlledVocabulary\tallowmultiples\tfacetable\tdisplayoncreate\trequired\tparent\tinputRendererType\tinputRendererOptions\tmetadatablock_id\ttermURI\tvalidation\tmetadata\tvisibleThroughAnonymizedUrl\tdefaultValue\n" +
+            "\tType 1\tDatasetFieldType 1\tLorem ipsum dolor sit amet\tEnter value…\ttext\t7\t#NAME: #VALUE\tFALSE\tTRUE\tFALSE\tTRUE\tTRUE\tFALSE\t\tVOCABULARY_SELECT\t{\"sortByLocalisedStringsOrder\" : \"true\"}\tMetadataBlock 1\thttp:\\\\test.test\t[{\"name\":\"standard_input\",\"parameters\":[\"format:https://ror.org/0[a-hjkmnp-z0-9]{6}[0-9]{2}\"]}]\t{}\tFALSE\t\n" +
             "#controlledVocabulary\tDatasetField\tValue\tidentifier\tdisplayOrder\n" +
             "\tType 1\tValue 1\tV1\t0\n" +
             "\tType 1\tValue 2\tV2\t1\tVALUE2\n";

--- a/fairchive-webapp/src/test/java/edu/harvard/iq/dataverse/dataverse/MetadataBlockTsvCreatorTest.java
+++ b/fairchive-webapp/src/test/java/edu/harvard/iq/dataverse/dataverse/MetadataBlockTsvCreatorTest.java
@@ -20,8 +20,8 @@ class MetadataBlockTsvCreatorTest {
 
     private static String EXPECTED = "#metadataBlock\tname\tdataverseAlias\tdisplayName\tblockURI\tdisplayOrder\n" +
             "\tMetadataBlock 1\t\tMetadata Block 1\thttp:\\\\metadatablock.uri\t15\n" +
-            "#datasetField\tname\ttitle\tdescription\twatermark\tfieldType\tdisplayOrder\tdisplayFormat\tadvancedSearchField\tallowControlledVocabulary\tallowmultiples\tfacetable\tdisplayoncreate\trequired\tparent\tinputRendererType\tinputRendererOptions\tmetadatablock_id\ttermURI\tvalidation\tmetadata\n" +
-            "\tType 1\tDatasetFieldType 1\tLorem ipsum dolor sit amet\tEnter value…\ttext\t7\t#NAME: #VALUE\tFALSE\tTRUE\tFALSE\tTRUE\tTRUE\tFALSE\t\tVOCABULARY_SELECT\t{\"sortByLocalisedStringsOrder\" : \"true\"}\tMetadataBlock 1\thttp:\\\\test.test\t[{\"name\":\"standard_input\",\"parameters\":[\"format:https://ror.org/0[a-hjkmnp-z0-9]{6}[0-9]{2}\"]}]\t{}\n" +
+            "#datasetField\tname\ttitle\tdescription\twatermark\tfieldType\tdisplayOrder\tdisplayFormat\tadvancedSearchField\tallowControlledVocabulary\tallowmultiples\tfacetable\tdisplayoncreate\trequired\tparent\tinputRendererType\tinputRendererOptions\tmetadatablock_id\ttermURI\tvalidation\tmetadata\tdefaultValue\n" +
+            "\tType 1\tDatasetFieldType 1\tLorem ipsum dolor sit amet\tEnter value…\ttext\t7\t#NAME: #VALUE\tFALSE\tTRUE\tFALSE\tTRUE\tTRUE\tFALSE\t\tVOCABULARY_SELECT\t{\"sortByLocalisedStringsOrder\" : \"true\"}\tMetadataBlock 1\thttp:\\\\test.test\t[{\"name\":\"standard_input\",\"parameters\":[\"format:https://ror.org/0[a-hjkmnp-z0-9]{6}[0-9]{2}\"]}]\t{}\t\n" +
             "#controlledVocabulary\tDatasetField\tValue\tidentifier\tdisplayOrder\n" +
             "\tType 1\tValue 1\tV1\t0\n" +
             "\tType 1\tValue 2\tV2\t1\tVALUE2\n";


### PR DESCRIPTION
Added new column in tsv:
 - defaultValue
 - hidden vocabulary now will use the default value instead of option in input renderer
 - added `visibleThroughAnonymizedUrl` to output of `MetadataBlockTsvCreator` to be consistent with the api in DatasetFieldServiceApi