### PR TITLE
Closes #2823: Do not show empty search block when there are no advanced searchable field types in metadata block

### DIFF
--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/AdvancedSearchBlocksBuilder.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/AdvancedSearchBlocksBuilder.java
@@ -1,0 +1,169 @@
+package edu.harvard.iq.dataverse;
+
+import static java.util.stream.Collectors.toList;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import javax.ejb.Stateless;
+import javax.faces.model.SelectItem;
+import javax.inject.Inject;
+
+import edu.harvard.iq.dataverse.common.BundleUtil;
+import edu.harvard.iq.dataverse.common.DatasetFieldConstant;
+import edu.harvard.iq.dataverse.license.TermsOfUseSelectItemsFactory;
+import edu.harvard.iq.dataverse.persistence.datafile.license.License;
+import edu.harvard.iq.dataverse.persistence.datafile.license.LicenseRepository;
+import edu.harvard.iq.dataverse.persistence.dataset.DatasetFieldType;
+import edu.harvard.iq.dataverse.persistence.dataset.MetadataBlock;
+import edu.harvard.iq.dataverse.persistence.dataverse.Dataverse;
+import edu.harvard.iq.dataverse.search.SearchFields;
+import edu.harvard.iq.dataverse.search.advanced.SearchBlock;
+import edu.harvard.iq.dataverse.search.advanced.SearchFieldFactory;
+import edu.harvard.iq.dataverse.search.advanced.field.CheckboxSearchField;
+import edu.harvard.iq.dataverse.search.advanced.field.DateSearchField;
+import edu.harvard.iq.dataverse.search.advanced.field.LicenseCheckboxSearchField;
+import edu.harvard.iq.dataverse.search.advanced.field.SearchField;
+import edu.harvard.iq.dataverse.search.advanced.field.TextSearchField;
+import edu.harvard.iq.dataverse.validation.ValidationEnhancer;
+import edu.harvard.iq.dataverse.validation.field.ValidationDescriptor;
+import edu.harvard.iq.dataverse.validation.field.validators.DateRangeValidator;
+import io.vavr.Tuple;
+
+/**
+ * Builder of {@link SearchBlock}s for advanced search page
+ */
+@Stateless
+public class AdvancedSearchBlocksBuilder {
+
+    private SearchFieldFactory searchFieldFactory;
+    private DatasetFieldServiceBean datasetFieldService;
+    private LicenseRepository licenseRepository;
+    private TermsOfUseSelectItemsFactory termsOfUseSelectItemsFactory;
+
+    AdvancedSearchBlocksBuilder() { }
+
+    @Inject
+    public AdvancedSearchBlocksBuilder(SearchFieldFactory searchFieldFactory,
+            DatasetFieldServiceBean datasetFieldService, LicenseRepository licenseRepository,
+            TermsOfUseSelectItemsFactory termsOfUseSelectItemsFactory) {
+        this.searchFieldFactory = searchFieldFactory;
+        this.datasetFieldService = datasetFieldService;
+        this.licenseRepository = licenseRepository;
+        this.termsOfUseSelectItemsFactory = termsOfUseSelectItemsFactory;
+    }
+
+
+    /**
+     * Returns list of {@link SearchBlock}s. Each of returned {@link SearchBlock}
+     * contains possible {@link SearchField}s for single metadata block that is
+     * turned on in the given dataverse.
+     */
+    public List<SearchBlock> createDatasetMetadataBlocks(Dataverse dataverse) {
+        List<SearchBlock> metadataSearchBlocks = new ArrayList<>();
+
+        List<MetadataBlock> metadataBlocks = dataverse.getRootMetadataBlocks();
+        List<Long> metadataBlockIds = metadataBlocks.stream()
+                .map(MetadataBlock::getId)
+                .collect(toList());
+        Map<Long, List<DatasetFieldType>> metadataFieldListByBlock
+                = datasetFieldService.findAllAdvancedSearchFieldTypesByMetadataBlockIds(metadataBlockIds).stream()
+                .collect(Collectors.groupingBy(f -> f.getMetadataBlock().getId()));
+        for (MetadataBlock block : metadataBlocks) {
+            List<SearchField> searchFields
+                    = metadataFieldListByBlock.getOrDefault(block.getId(), Collections.emptyList()).stream()
+                    .map(searchFieldFactory::create)
+                    .filter(f -> !SearchField.EMPTY.equals(f))
+                    .collect(toList());
+            metadataSearchBlocks.add(new SearchBlock(block.getName(), block.getLocaleDisplayName(), searchFields));
+        }
+        addExtraFieldsToCitationMetadataBlock(metadataSearchBlocks);
+        return metadataSearchBlocks;
+    }
+
+    /**
+     * Returns {@link SearchBlock} with {@link SearchField}s related to
+     * searching for dataverses.
+     */
+    public SearchBlock createDataversesBlock() {
+        return new SearchBlock("dataverses",
+                BundleUtil.getStringFromBundle("advanced.search.header.dataverses"), constructDataversesSearchFields());
+    }
+
+    /**
+     * Returns {@link SearchBlock} with {@link SearchField}s related to
+     * searching for files.
+     */
+    public SearchBlock createFilesBlock() {
+        return new SearchBlock("files",
+                BundleUtil.getStringFromBundle("advanced.search.header.files"), constructFilesSearchFields());
+    }
+
+    private void addExtraFieldsToCitationMetadataBlock(List<SearchBlock> metadataSearchBlocks) {
+        for (SearchBlock b : metadataSearchBlocks) {
+            if (SearchFields.DATASET_CITATION.equals(b.getBlockName())) {
+                ValidationEnhancer enhancer = new ValidationEnhancer();
+                TextSearchField persistentIdField = textFieldFromBundle(SearchFields.DATASET_PERSISTENT_ID, "dataset.metadata.persistentId", "dataset.metadata.persistentId.tip");
+                DatasetFieldType publicationDateType = enhancer.createDatasetFieldType(SearchFields.DATASET_PUBLICATION_DATE,
+                        BundleUtil.getStringFromBundle("dataset.metadata.publicationYear"),
+                        BundleUtil.getStringFromBundle("dataset.metadata.publicationYear.tip"),
+                        enhancer.createValidation(new DateRangeValidator(),
+                                Collections.singletonMap(ValidationDescriptor.CONTEXT_PARAM, Collections.singletonList(ValidationDescriptor.SEARCH_CONTEXT))));
+                DateSearchField publicationDateField = new DateSearchField(publicationDateType);
+                b.addSearchField(persistentIdField);
+                b.addSearchField(publicationDateField);
+                break;
+            }
+        }
+    }
+
+    private List<SearchField> constructDataversesSearchFields() {
+        List<SearchField> fields = new ArrayList<>();
+
+        fields.add(textFieldFromBundle(SearchFields.DATAVERSE_NAME, "name", "advanced.search.dataverses.name.tip"));
+        fields.add(textFieldFromBundle(SearchFields.DATAVERSE_ALIAS, "identifier","dataverse.identifier.title"));
+        fields.add(textFieldFromBundle(SearchFields.DATAVERSE_AFFILIATION, "affiliation", "advanced.search.dataverses.affiliation.tip"));
+        fields.add(textFieldFromBundle(SearchFields.DATAVERSE_DESCRIPTION, "description", "advanced.search.dataverses.description.tip"));
+
+        CheckboxSearchField checkboxSearchField = new CheckboxSearchField(SearchFields.DATAVERSE_SUBJECT,
+                BundleUtil.getStringFromBundle("subject"),
+                BundleUtil.getStringFromBundle("advanced.search.dataverses.subject.tip"));
+        datasetFieldService.findByName(DatasetFieldConstant.subject)
+                .getControlledVocabularyValues()
+                .forEach(v -> checkboxSearchField.getCheckboxLabelAndValue()
+                        .add(Tuple.of(v.getLocaleStrValue(), v.getStrValue())));
+        fields.add(checkboxSearchField);
+
+        return fields;
+    }
+
+    private List<SearchField> constructFilesSearchFields() {
+        List<SearchField> fields = new ArrayList<>();
+
+        fields.add(textFieldFromBundle(SearchFields.FILE_NAME, "name", "advanced.search.files.name.tip"));
+        fields.add(textFieldFromBundle(SearchFields.FILE_DESCRIPTION, "description", "advanced.search.files.description.tip"));
+        fields.add(textFieldFromBundle(SearchFields.FILE_EXTENSION, "advanced.search.files.fileExtension", "advanced.search.files.fileExtension.tip"));
+        fields.add(textFieldFromBundle(SearchFields.FILE_PERSISTENT_ID, "advanced.search.files.persistentId", "advanced.search.files.persistentId.tip"));
+        fields.add(textFieldFromBundle(SearchFields.VARIABLE_NAME, "advanced.search.files.variableName", "advanced.search.files.variableName.tip"));
+        fields.add(textFieldFromBundle(SearchFields.VARIABLE_LABEL, "advanced.search.files.variableLabel", "advanced.search.files.variableLabel.tip"));
+
+        Map<Long, String> licenseNames = licenseRepository.findAll().stream()
+                .collect(Collectors.toMap(License::getId, License::getName, (prev, next) -> next));
+        CheckboxSearchField licenseSearchField = new LicenseCheckboxSearchField(SearchFields.LICENSE,
+                BundleUtil.getStringFromBundle("advanced.search.files.license"),
+                BundleUtil.getStringFromBundle("advanced.search.files.license.tip"), licenseNames);
+
+        for (SelectItem selectItem : termsOfUseSelectItemsFactory.buildLicenseSelectItems()) {
+            licenseSearchField.getCheckboxLabelAndValue().add(Tuple.of(selectItem.getLabel(), selectItem.getValue().toString()));
+        }
+        fields.add(licenseSearchField);
+        return fields;
+    }
+
+    private TextSearchField textFieldFromBundle(String name, String displayNameKey, String descriptionKey) {
+        return new TextSearchField(name, BundleUtil.getStringFromBundle(displayNameKey), BundleUtil.getStringFromBundle(descriptionKey));
+    }
+}

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/AdvancedSearchBlocksBuilder.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/AdvancedSearchBlocksBuilder.java
@@ -78,9 +78,12 @@ public class AdvancedSearchBlocksBuilder {
                     .map(searchFieldFactory::create)
                     .filter(f -> !SearchField.EMPTY.equals(f))
                     .collect(toList());
+
             metadataSearchBlocks.add(new SearchBlock(block.getName(), block.getLocaleDisplayName(), searchFields));
         }
         addExtraFieldsToCitationMetadataBlock(metadataSearchBlocks);
+
+        metadataSearchBlocks.removeIf(sBlock -> sBlock.getSearchFields().isEmpty());
         return metadataSearchBlocks;
     }
 

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/search/AdvancedSearchPage.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/search/AdvancedSearchPage.java
@@ -1,38 +1,23 @@
 package edu.harvard.iq.dataverse.search;
 
-import edu.harvard.iq.dataverse.DatasetFieldServiceBean;
+import edu.harvard.iq.dataverse.AdvancedSearchBlocksBuilder;
 import edu.harvard.iq.dataverse.DataverseDao;
 import edu.harvard.iq.dataverse.WidgetWrapper;
 import edu.harvard.iq.dataverse.common.BundleUtil;
-import edu.harvard.iq.dataverse.common.DatasetFieldConstant;
-import edu.harvard.iq.dataverse.license.TermsOfUseSelectItemsFactory;
-import edu.harvard.iq.dataverse.persistence.datafile.license.License;
-import edu.harvard.iq.dataverse.persistence.datafile.license.LicenseRepository;
 import edu.harvard.iq.dataverse.persistence.dataset.DatasetFieldType;
-import edu.harvard.iq.dataverse.persistence.dataset.MetadataBlock;
 import edu.harvard.iq.dataverse.persistence.dataverse.Dataverse;
 import edu.harvard.iq.dataverse.search.advanced.QueryWrapperCreator;
 import edu.harvard.iq.dataverse.search.advanced.SearchBlock;
-import edu.harvard.iq.dataverse.search.advanced.SearchFieldFactory;
-import edu.harvard.iq.dataverse.search.advanced.field.CheckboxSearchField;
-import edu.harvard.iq.dataverse.search.advanced.field.DateSearchField;
 import edu.harvard.iq.dataverse.search.advanced.field.GroupingSearchField;
-import edu.harvard.iq.dataverse.search.advanced.field.LicenseCheckboxSearchField;
 import edu.harvard.iq.dataverse.search.advanced.field.SearchField;
-import edu.harvard.iq.dataverse.search.advanced.field.TextSearchField;
 import edu.harvard.iq.dataverse.search.advanced.query.QueryWrapper;
 import edu.harvard.iq.dataverse.util.JsfHelper;
 import edu.harvard.iq.dataverse.validation.SearchFormValidationService;
-import edu.harvard.iq.dataverse.validation.ValidationEnhancer;
-import edu.harvard.iq.dataverse.validation.field.ValidationDescriptor;
 import edu.harvard.iq.dataverse.validation.field.FieldValidationResult;
-import edu.harvard.iq.dataverse.validation.field.validators.DateRangeValidator;
-import io.vavr.Tuple;
 import org.apache.commons.lang3.StringUtils;
 import org.omnifaces.cdi.ViewScoped;
 
 import javax.annotation.PostConstruct;
-import javax.faces.model.SelectItem;
 import javax.inject.Inject;
 import javax.inject.Named;
 import java.io.IOException;
@@ -40,7 +25,6 @@ import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -48,8 +32,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-
-import static java.util.stream.Collectors.toList;
 
 /**
  * Page class responsible for showing search fields for Metadata blocks, files/dataverses blocks
@@ -62,13 +44,10 @@ public class AdvancedSearchPage implements Serializable {
     private static final Logger logger = Logger.getLogger(AdvancedSearchPage.class.getCanonicalName());
 
     private DataverseDao dataverseDao;
-    private DatasetFieldServiceBean datasetFieldService;
     private WidgetWrapper widgetWrapper;
     private QueryWrapperCreator queryWrapperCreator;
-    private TermsOfUseSelectItemsFactory termsOfUseSelectItemsFactory;
     private SearchFormValidationService validationService;
-    private SearchFieldFactory searchFieldFactory;
-    private LicenseRepository licenseRepository;
+    private AdvancedSearchBlocksBuilder advancedSearchBlocksBuilder;
 
     private Dataverse dataverse;
     private String dataverseIdentifier;
@@ -85,18 +64,15 @@ public class AdvancedSearchPage implements Serializable {
     public AdvancedSearchPage() { }
 
     @Inject
-    public AdvancedSearchPage(DataverseDao dataverseDao, DatasetFieldServiceBean datasetFieldService,
+    public AdvancedSearchPage(DataverseDao dataverseDao,
                               WidgetWrapper widgetWrapper, QueryWrapperCreator queryWrapperCreator,
-                              TermsOfUseSelectItemsFactory termsOfUseSelectItemsFactory, SearchFormValidationService validationService,
-                              SearchFieldFactory searchFieldFactory, LicenseRepository licenseRepository) {
+                              SearchFormValidationService validationService,
+                              AdvancedSearchBlocksBuilder advancedSearchBlocksBuilder) {
         this.dataverseDao = dataverseDao;
-        this.datasetFieldService = datasetFieldService;
         this.widgetWrapper = widgetWrapper;
         this.queryWrapperCreator = queryWrapperCreator;
-        this.termsOfUseSelectItemsFactory = termsOfUseSelectItemsFactory;
         this.validationService = validationService;
-        this.searchFieldFactory = searchFieldFactory;
-        this.licenseRepository = licenseRepository;
+        this.advancedSearchBlocksBuilder = advancedSearchBlocksBuilder;
     }
 
     // -------------------- LOGIC --------------------
@@ -109,7 +85,12 @@ public class AdvancedSearchPage implements Serializable {
         if (dataverse == null) {
             dataverse = dataverseDao.findRootDataverse();
         }
-        buildFieldStructure();
+        dataversesSearchBlock = advancedSearchBlocksBuilder.createDataversesBlock();
+        filesSearchBlock = advancedSearchBlocksBuilder.createFilesBlock();
+
+        metadataSearchBlocks = advancedSearchBlocksBuilder.createDatasetMetadataBlocks(dataverse);
+        searchFieldIndex = buildSearchFieldIndex(metadataSearchBlocks);
+        nonSearchFieldIndex = createParentFieldsForSearchFields(nonSearchFieldIndex);
     }
 
     /** Composes query and redirects to the page with results. */
@@ -132,31 +113,10 @@ public class AdvancedSearchPage implements Serializable {
 
     // -------------------- PRIVATE --------------------
 
-    private void buildFieldStructure() {
-        extractSearchableFieldsForMetadataBlocks();
-        createParentFieldsForSearchFields();
-        createDataversesAndFilesBlocks();
-    }
-
-    private void extractSearchableFieldsForMetadataBlocks() {
-        List<MetadataBlock> metadataBlocks = dataverse.getRootMetadataBlocks();
-        List<Long> metadataBlockIds = metadataBlocks.stream()
-                .map(MetadataBlock::getId)
-                .collect(toList());
-        Map<Long, List<DatasetFieldType>> metadataFieldListByBlock
-                = datasetFieldService.findAllAdvancedSearchFieldTypesByMetadataBlockIds(metadataBlockIds).stream()
-                .collect(Collectors.groupingBy(f -> f.getMetadataBlock().getId()));
-        for (MetadataBlock block : metadataBlocks) {
-            List<SearchField> searchFields
-                    = metadataFieldListByBlock.getOrDefault(block.getId(), Collections.emptyList()).stream()
-                    .map(searchFieldFactory::create)
-                    .filter(f -> !SearchField.EMPTY.equals(f))
-                    .collect(toList());
-            searchFieldIndex.putAll(searchFields.stream()
-                    .collect(Collectors.toMap(SearchField::getName, f -> f, (prev, next) -> next)));
-            metadataSearchBlocks.add(new SearchBlock(block.getName(), block.getLocaleDisplayName(), searchFields));
-        }
-        addExtraFieldsToCitationMetadataBlock();
+    private Map<String, SearchField> buildSearchFieldIndex(List<SearchBlock> searchBlocks) {
+        return searchBlocks.stream()
+            .flatMap(block -> block.getSearchFields().stream())
+            .collect(Collectors.toMap(SearchField::getName, f -> f, (prev, next) -> next));
     }
 
     /**
@@ -165,7 +125,8 @@ public class AdvancedSearchPage implements Serializable {
      * accessing {@link DatasetFieldType} and creating new or retrieving
      * existing parent fields in order to connect them with search fields.
      */
-    private void createParentFieldsForSearchFields() {
+    private Map<String, SearchField> createParentFieldsForSearchFields(Map<String, SearchField> searchFieldIndex) {
+        Map<String, SearchField> nonSearchFieldIndex = new HashMap<>();
         int i = 0;
         for (SearchField field : searchFieldIndex.values()) {
             DatasetFieldType fieldType = field.getDatasetFieldType();
@@ -185,80 +146,7 @@ public class AdvancedSearchPage implements Serializable {
             parentField.getChildren().add(field);
             field.setParent(parentField);
         }
-    }
-
-    private void createDataversesAndFilesBlocks() {
-        dataversesSearchBlock = new SearchBlock("dataverses",
-                BundleUtil.getStringFromBundle("advanced.search.header.dataverses"), constructDataversesSearchFields());
-        filesSearchBlock = new SearchBlock("files",
-                BundleUtil.getStringFromBundle("advanced.search.header.files"), constructFilesSearchFields());
-    }
-
-    private void addExtraFieldsToCitationMetadataBlock() {
-        for (SearchBlock b : metadataSearchBlocks) {
-            if (SearchFields.DATASET_CITATION.equals(b.getBlockName())) {
-                ValidationEnhancer enhancer = new ValidationEnhancer();
-                TextSearchField persistentIdField = textFieldFromBundle(SearchFields.DATASET_PERSISTENT_ID, "dataset.metadata.persistentId", "dataset.metadata.persistentId.tip");
-                DatasetFieldType publicationDateType = enhancer.createDatasetFieldType(SearchFields.DATASET_PUBLICATION_DATE,
-                        BundleUtil.getStringFromBundle("dataset.metadata.publicationYear"),
-                        BundleUtil.getStringFromBundle("dataset.metadata.publicationYear.tip"),
-                        enhancer.createValidation(new DateRangeValidator(),
-                                Collections.singletonMap(ValidationDescriptor.CONTEXT_PARAM, Collections.singletonList(ValidationDescriptor.SEARCH_CONTEXT))));
-                DateSearchField publicationDateField = new DateSearchField(publicationDateType);
-                b.addSearchField(persistentIdField);
-                b.addSearchField(publicationDateField);
-                searchFieldIndex.put(persistentIdField.getName(), persistentIdField);
-                searchFieldIndex.put(publicationDateField.getName(), publicationDateField);
-                break;
-            }
-        }
-    }
-
-    private List<SearchField> constructFilesSearchFields() {
-        List<SearchField> fields = new ArrayList<>();
-
-        fields.add(textFieldFromBundle(SearchFields.FILE_NAME, "name", "advanced.search.files.name.tip"));
-        fields.add(textFieldFromBundle(SearchFields.FILE_DESCRIPTION, "description", "advanced.search.files.description.tip"));
-        fields.add(textFieldFromBundle(SearchFields.FILE_EXTENSION, "advanced.search.files.fileExtension", "advanced.search.files.fileExtension.tip"));
-        fields.add(textFieldFromBundle(SearchFields.FILE_PERSISTENT_ID, "advanced.search.files.persistentId", "advanced.search.files.persistentId.tip"));
-        fields.add(textFieldFromBundle(SearchFields.VARIABLE_NAME, "advanced.search.files.variableName", "advanced.search.files.variableName.tip"));
-        fields.add(textFieldFromBundle(SearchFields.VARIABLE_LABEL, "advanced.search.files.variableLabel", "advanced.search.files.variableLabel.tip"));
-
-        Map<Long, String> licenseNames = licenseRepository.findAll().stream()
-                .collect(Collectors.toMap(License::getId, License::getName, (prev, next) -> next));
-        CheckboxSearchField licenseSearchField = new LicenseCheckboxSearchField(SearchFields.LICENSE,
-                BundleUtil.getStringFromBundle("advanced.search.files.license"),
-                BundleUtil.getStringFromBundle("advanced.search.files.license.tip"), licenseNames);
-
-        for (SelectItem selectItem : termsOfUseSelectItemsFactory.buildLicenseSelectItems()) {
-            licenseSearchField.getCheckboxLabelAndValue().add(Tuple.of(selectItem.getLabel(), selectItem.getValue().toString()));
-        }
-        fields.add(licenseSearchField);
-        return fields;
-    }
-
-    private List<SearchField> constructDataversesSearchFields() {
-        List<SearchField> fields = new ArrayList<>();
-
-        fields.add(textFieldFromBundle(SearchFields.DATAVERSE_NAME, "name", "advanced.search.dataverses.name.tip"));
-        fields.add(textFieldFromBundle(SearchFields.DATAVERSE_ALIAS, "identifier","dataverse.identifier.title"));
-        fields.add(textFieldFromBundle(SearchFields.DATAVERSE_AFFILIATION, "affiliation", "advanced.search.dataverses.affiliation.tip"));
-        fields.add(textFieldFromBundle(SearchFields.DATAVERSE_DESCRIPTION, "description", "advanced.search.dataverses.description.tip"));
-
-        CheckboxSearchField checkboxSearchField = new CheckboxSearchField(SearchFields.DATAVERSE_SUBJECT,
-                BundleUtil.getStringFromBundle("subject"),
-                BundleUtil.getStringFromBundle("advanced.search.dataverses.subject.tip"));
-        datasetFieldService.findByName(DatasetFieldConstant.subject)
-                .getControlledVocabularyValues()
-                .forEach(v -> checkboxSearchField.getCheckboxLabelAndValue()
-                        .add(Tuple.of(v.getLocaleStrValue(), v.getStrValue())));
-        fields.add(checkboxSearchField);
-
-        return fields;
-    }
-
-    private TextSearchField textFieldFromBundle(String name, String displayNameKey, String descriptionKey) {
-        return new TextSearchField(name, BundleUtil.getStringFromBundle(displayNameKey), BundleUtil.getStringFromBundle(descriptionKey));
+        return nonSearchFieldIndex;
     }
 
     private String buildSearchUrl(QueryWrapper queryWrapper) {

--- a/fairchive-webapp/src/test/java/edu/harvard/iq/dataverse/AdvancedSearchBlocksBuilderTest.java
+++ b/fairchive-webapp/src/test/java/edu/harvard/iq/dataverse/AdvancedSearchBlocksBuilderTest.java
@@ -1,0 +1,197 @@
+package edu.harvard.iq.dataverse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import javax.faces.model.SelectItem;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.google.common.collect.ImmutableList;
+
+import edu.harvard.iq.dataverse.common.DatasetFieldConstant;
+import edu.harvard.iq.dataverse.license.TermsOfUseSelectItemsFactory;
+import edu.harvard.iq.dataverse.persistence.MocksFactory;
+import edu.harvard.iq.dataverse.persistence.datafile.license.LicenseRepository;
+import edu.harvard.iq.dataverse.persistence.dataset.DatasetFieldType;
+import edu.harvard.iq.dataverse.persistence.dataset.FieldType;
+import edu.harvard.iq.dataverse.persistence.dataset.MetadataBlock;
+import edu.harvard.iq.dataverse.persistence.dataverse.Dataverse;
+import edu.harvard.iq.dataverse.search.advanced.SearchBlock;
+import edu.harvard.iq.dataverse.search.advanced.SearchFieldFactory;
+import edu.harvard.iq.dataverse.search.advanced.SearchFieldType;
+import edu.harvard.iq.dataverse.search.advanced.field.CheckboxSearchField;
+import edu.harvard.iq.dataverse.search.advanced.field.SearchField;
+import edu.harvard.iq.dataverse.search.advanced.field.TextSearchField;
+
+@ExtendWith(MockitoExtension.class)
+public class AdvancedSearchBlocksBuilderTest {
+
+    @InjectMocks
+    private AdvancedSearchBlocksBuilder advancedSearchBlocksBuilder;
+
+    @Mock
+    private SearchFieldFactory searchFieldFactory;
+    @Mock
+    private DatasetFieldServiceBean datasetFieldService;
+    @Mock
+    private LicenseRepository licenseRepository;
+    @Mock
+    private TermsOfUseSelectItemsFactory termsOfUseSelectItemsFactory;
+    
+    @Test
+    void createDatasetMetadataBlocks() {
+        // given
+        Dataverse dataverse = new Dataverse();
+        MetadataBlock block1 = MocksFactory.makeMetadataBlock("citation", "Citation Metadata", 0);
+        MetadataBlock block2 = MocksFactory.makeMetadataBlock("block2", "Block Name2", 1);
+        MetadataBlock block3 = MocksFactory.makeMetadataBlock("block3", "Block Name3", 2);
+        dataverse.setMetadataBlocks(ImmutableList.of(block1, block2, block3));
+
+        List<Long> blockIds = ImmutableList.of(block1.getId(), block2.getId(), block3.getId());
+
+        DatasetFieldType field1 = MocksFactory.makeDatasetFieldType("field1", FieldType.TEXT, false, block1);
+        DatasetFieldType field2 = MocksFactory.makeDatasetFieldType("field2", FieldType.TEXT, false, block1);
+        DatasetFieldType field3 = MocksFactory.makeDatasetFieldType("field3", FieldType.TEXT, false, block2);
+        DatasetFieldType field4 = MocksFactory.makeDatasetFieldType("field4", FieldType.TEXT, false, block2);
+
+        when(datasetFieldService.findAllAdvancedSearchFieldTypesByMetadataBlockIds(eq(blockIds))).thenReturn(
+                ImmutableList.of(field1, field2, field3, field4));
+        when(searchFieldFactory.create(any())).thenAnswer(invocation -> new TextSearchField(invocation.getArgument(0)));
+            
+        
+        // when
+        List<SearchBlock> searchBlocks = advancedSearchBlocksBuilder.createDatasetMetadataBlocks(dataverse);
+        // then
+        assertThat(searchBlocks).hasSize(3);
+        assertThat(searchBlocks).extracting(SearchBlock::getBlockName).containsExactly("citation", "block2", "block3");
+        assertThat(searchBlocks.get(0).getSearchFields())
+            .extracting(SearchField::getName, SearchField::getSearchFieldType)
+            .containsExactly(
+                    tuple("field1", SearchFieldType.TEXT),
+                    tuple("field2", SearchFieldType.TEXT),
+                    tuple("dsPersistentId", SearchFieldType.TEXT),
+                    tuple("dsPublicationDate", SearchFieldType.DATE));
+        assertThat(searchBlocks.get(1).getSearchFields())
+            .extracting(SearchField::getName, SearchField::getSearchFieldType)
+            .containsExactly(
+                    tuple("field3", SearchFieldType.TEXT),
+                    tuple("field4", SearchFieldType.TEXT));
+        assertThat(searchBlocks.get(2).getSearchFields()).isEmpty();
+    }
+    
+    @Test
+    void createDatasetMetadataBlocks__dataverse_is_not_metadata_block_root() {
+        // given
+        Dataverse rootDataverse = new Dataverse();
+        MetadataBlock block1 = MocksFactory.makeMetadataBlock("citation", "Citation Metadata", 0);
+        rootDataverse.setMetadataBlocks(ImmutableList.of(block1));
+        rootDataverse.setMetadataBlockRoot(true);
+        Dataverse dataverse = new Dataverse();
+        dataverse.setOwner(rootDataverse);
+        dataverse.setMetadataBlockRoot(false);
+
+        List<Long> blockIds = ImmutableList.of(block1.getId());
+
+        DatasetFieldType field1 = MocksFactory.makeDatasetFieldType("field1", FieldType.TEXT, false, block1);
+        DatasetFieldType field2 = MocksFactory.makeDatasetFieldType("field2", FieldType.TEXT, false, block1);
+
+        when(datasetFieldService.findAllAdvancedSearchFieldTypesByMetadataBlockIds(eq(blockIds))).thenReturn(
+                ImmutableList.of(field1, field2));
+        when(searchFieldFactory.create(any())).thenAnswer(invocation -> new TextSearchField(invocation.getArgument(0)));
+            
+        
+        // when
+        List<SearchBlock> searchBlocks = advancedSearchBlocksBuilder.createDatasetMetadataBlocks(rootDataverse);
+        // then
+        assertThat(searchBlocks).hasSize(1);
+        assertThat(searchBlocks).extracting(SearchBlock::getBlockName).containsExactly("citation");
+        assertThat(searchBlocks.get(0).getSearchFields())
+            .extracting(SearchField::getName, SearchField::getSearchFieldType)
+            .containsExactly(
+                    tuple("field1", SearchFieldType.TEXT),
+                    tuple("field2", SearchFieldType.TEXT),
+                    tuple("dsPersistentId", SearchFieldType.TEXT),
+                    tuple("dsPublicationDate", SearchFieldType.DATE));
+    }
+
+    @Test
+    void createDataversesBlock() {
+        // given
+        MetadataBlock citationBlock = MocksFactory.makeMetadataBlock("citation", "Citation Metadata", 0);
+        DatasetFieldType subjectField = MocksFactory.makeControlledVocabDatasetFieldType(
+                DatasetFieldConstant.subject, true, citationBlock, "Chemistry", "Astronomy");
+        when(datasetFieldService.findByName(DatasetFieldConstant.subject)).thenReturn(subjectField);
+
+        // when
+        SearchBlock dataversesBlock = advancedSearchBlocksBuilder.createDataversesBlock();
+
+        // then
+        assertThat(dataversesBlock).extracting(SearchBlock::getBlockName).isEqualTo("dataverses");
+        assertThat(dataversesBlock.getSearchFields())
+            .extracting(SearchField::getName, SearchField::getSearchFieldType)
+            .containsExactly(
+                    tuple("dvName", SearchFieldType.TEXT),
+                    tuple("dvAlias", SearchFieldType.TEXT),
+                    tuple("dvAffiliation", SearchFieldType.TEXT),
+                    tuple("dvDescription", SearchFieldType.TEXT),
+                    tuple("dvSubject", SearchFieldType.CHECKBOX));
+
+        CheckboxSearchField subjectSearchField = dataversesBlock.getSearchFields().stream()
+                .filter(sfield -> "dvSubject".equals(sfield.getName()))
+                .map(sfield -> (CheckboxSearchField)sfield)
+                .findFirst()
+                .orElseThrow(RuntimeException::new);
+
+        assertThat(subjectSearchField.getCheckboxLabelAndValue())
+            .extracting(c -> c._1(), c -> c._2())
+            .containsExactly(
+                    tuple("Chemistry", "Chemistry"),
+                    tuple("Astronomy", "Astronomy"));
+    }
+
+    @Test
+    void createFilesBlock() {
+        // given
+        when(termsOfUseSelectItemsFactory.buildLicenseSelectItems()).thenReturn(ImmutableList.of(
+                new SelectItem("LICENSE:1", "License 1"),
+                new SelectItem("LICENSE:2", "License 2")));
+
+        // when
+        SearchBlock filesBlock = advancedSearchBlocksBuilder.createFilesBlock();
+
+        // then
+        assertThat(filesBlock).extracting(SearchBlock::getBlockName).isEqualTo("files");
+        assertThat(filesBlock.getSearchFields())
+            .extracting(SearchField::getName, SearchField::getSearchFieldType)
+            .containsExactly(
+                    tuple("fileName", SearchFieldType.TEXT),
+                    tuple("fileDescription", SearchFieldType.TEXT),
+                    tuple("fileExtension", SearchFieldType.TEXT),
+                    tuple("filePersistentId", SearchFieldType.TEXT),
+                    tuple("variableName", SearchFieldType.TEXT),
+                    tuple("variableLabel", SearchFieldType.TEXT),
+                    tuple("license", SearchFieldType.CHECKBOX));
+
+        CheckboxSearchField licenseSearchField = filesBlock.getSearchFields().stream()
+                .filter(sfield -> "license".equals(sfield.getName()))
+                .map(sfield -> (CheckboxSearchField)sfield)
+                .findFirst()
+                .orElseThrow(RuntimeException::new);
+
+        assertThat(licenseSearchField.getCheckboxLabelAndValue())
+            .extracting(c -> c._1(), c -> c._2())
+            .containsExactly(
+                    tuple("License 1", "LICENSE:1"),
+                    tuple("License 2", "LICENSE:2"));
+    }
+}

--- a/fairchive-webapp/src/test/java/edu/harvard/iq/dataverse/AdvancedSearchBlocksBuilderTest.java
+++ b/fairchive-webapp/src/test/java/edu/harvard/iq/dataverse/AdvancedSearchBlocksBuilderTest.java
@@ -72,8 +72,8 @@ public class AdvancedSearchBlocksBuilderTest {
         // when
         List<SearchBlock> searchBlocks = advancedSearchBlocksBuilder.createDatasetMetadataBlocks(dataverse);
         // then
-        assertThat(searchBlocks).hasSize(3);
-        assertThat(searchBlocks).extracting(SearchBlock::getBlockName).containsExactly("citation", "block2", "block3");
+        assertThat(searchBlocks).hasSize(2);
+        assertThat(searchBlocks).extracting(SearchBlock::getBlockName).containsExactly("citation", "block2");
         assertThat(searchBlocks.get(0).getSearchFields())
             .extracting(SearchField::getName, SearchField::getSearchFieldType)
             .containsExactly(
@@ -86,7 +86,6 @@ public class AdvancedSearchBlocksBuilderTest {
             .containsExactly(
                     tuple("field3", SearchFieldType.TEXT),
                     tuple("field4", SearchFieldType.TEXT));
-        assertThat(searchBlocks.get(2).getSearchFields()).isEmpty();
     }
     
     @Test


### PR DESCRIPTION
First commit is a little refactor. I've moved building `SearchBlock`s to separate class and added some tests. I've kept `createParentFieldsForSearchFields` in the `AdvancedSearchPage` though. If I moved it also then I would either make it as a `public` method or make return value of `createDatasetMetadataBlocks` more complex.