### PR TITLE
Closes #2892: Add config property to disable collection form pre-fill

### DIFF
--- a/conf/glassfish/dataverse.properties
+++ b/conf/glassfish/dataverse.properties
@@ -184,3 +184,9 @@ LoginInfo=
 
 # Show dataset search results on map as markers (if set to 'true').
 ShowSearchResultOnMap=false
+
+# If set to true (the default) or any other truthy value, the collection name,
+# affiliation, and contact email fields will be pre-filled on the collection
+# creation form. If set to false or any value other non-truthy value, the fields
+# will be blank.
+CollectionFormPrefillEnabled=true

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/dataverse/CreateEditDataversePage.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/dataverse/CreateEditDataversePage.java
@@ -14,7 +14,7 @@ import edu.harvard.iq.dataverse.persistence.dataverse.Dataverse;
 import edu.harvard.iq.dataverse.persistence.dataverse.DataverseContact;
 import edu.harvard.iq.dataverse.persistence.dataverse.DataverseFacet;
 import edu.harvard.iq.dataverse.persistence.dataverse.DataverseFieldTypeInputLevel;
-import edu.harvard.iq.dataverse.settings.SettingsWrapper;
+import edu.harvard.iq.dataverse.settings.SettingsServiceBean;
 import edu.harvard.iq.dataverse.util.JsfHelper;
 import edu.harvard.iq.dataverse.util.SystemConfig;
 import io.vavr.control.Either;
@@ -62,7 +62,7 @@ public class CreateEditDataversePage implements Serializable {
     private DataverseSession session;
 
     @Inject
-    private SettingsWrapper settingsWrapper;
+    private SettingsServiceBean settingsServiceBean;
 
     @Inject
     private SystemConfig systemConfig;
@@ -318,7 +318,8 @@ public class CreateEditDataversePage implements Serializable {
 
     private void showSuccessMessage() {
         JsfHelper.addFlashSuccessMessage(BundleUtil.getStringFromBundle("dataverse.create.success",
-                                                                        settingsWrapper.getGuidesBaseUrl(), systemConfig.getGuidesVersion()));
+                                                                        systemConfig.getGuidesBaseUrl(this.session.getLocale()),
+                                                                        systemConfig.getGuidesVersion()));
     }
 
     private String setupViewForDataverseEdit() {
@@ -343,13 +344,21 @@ public class CreateEditDataversePage implements Serializable {
             return permissionsWrapper.notAuthorized();
         }
 
-        dataverse.getDataverseContacts().add(new DataverseContact(dataverse, session.getUser().getDisplayInfo().getEmailAddress()));
-        dataverse.setAffiliation(session.getUser().getDisplayInfo().getAffiliation());
+        if (isPrefillEnabled()) {
+            dataverse.getDataverseContacts().add(new DataverseContact(dataverse, session.getUser().getDisplayInfo().getEmailAddress()));
+            dataverse.setAffiliation(session.getUser().getDisplayInfo().getAffiliation());
+            dataverse.setName(DataverseUtil.getSuggestedDataverseNameOnCreate(session.getUser()));
+        } else {
+            dataverse.getDataverseContacts().add(new DataverseContact(dataverse, ""));
+        }
+
         setupForGeneralInfoEdit();
 
-        dataverse.setName(DataverseUtil.getSuggestedDataverseNameOnCreate(session.getUser()));
-
         return StringUtils.EMPTY;
+    }
+
+    private boolean isPrefillEnabled() {
+        return settingsServiceBean.isTrueForKey(SettingsServiceBean.Key.CollectionFormPrefillEnabled);
     }
 
     private void setupForGeneralInfoEdit() {

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
@@ -767,7 +767,7 @@ public class SettingsServiceBean {
          */
         CustomSearchLocationsSolrFields,
         /**
-         * Specifies maximum number of search results axported to CSV file
+         * Specifies maximum number of search results exported to CSV file
          */
         MaxResultsCountSavedToFile,
         /**
@@ -783,16 +783,22 @@ public class SettingsServiceBean {
          */
         AuthenticatedSessionTimeout,
         /**
-         * a commond to be executed in order to ORC images
+         * a command to be executed in order to ORC images
          * (eg. "tesseract stdin stdout")
          */
         OcrCommand,
         /**
          * a limit for images to be ocr'red in bytes
          */
-        OcrImageSizeLimit;
+        OcrImageSizeLimit,
 
-
+        /**
+         * If set to {@code true} (the default) or any other truthy value, the
+         * collection name, affiliation, and contact email fields will be
+         * pre-filled on the collection creation form. If set to {@code false}
+         * or any value other non-truthy value, the fields will be blank.
+         */
+        CollectionFormPrefillEnabled;
 
         @Override
         public String toString() {


### PR DESCRIPTION
Adding `CollectionFormPrefillEnabled` configuration property - when set to `false`, the collection form pre-filling of collection name, affiliation and contact email will be disabled. When set to `true` or not set, the current behaviour remains.