### PR TITLE
Closes #2906: Dataset metadata fields input are not placed correctly when selectbox is in the left column

### DIFF
--- a/fairchive-webapp/src/main/webapp/resources/vecler/theme-base.scss
+++ b/fairchive-webapp/src/main/webapp/resources/vecler/theme-base.scss
@@ -668,20 +668,20 @@ input:disabled {
 
 .ui-selectonemenu {
 	border: 1px solid #e8e8e8;
-	min-height: calc(1.667em + 10px);
+	min-height: calc(1.16em + 15.44px);
 	min-width: auto !important;
 
 	.ui-selectonemenu-label {
 		margin-right: 1.533em;
-		padding-left: 1em;
-		padding-bottom: 0.333em;
+		padding: 5px 4px 0 1em;
 		background: #fff;
 		box-shadow: none;
 	}
-
 	.ui-selectonemenu-trigger.ui-state-default {
-		width: calc(1.5em + 11px);
-		height: calc(1.5em + 11px);
+		display: flex;
+		align-items: center;
+		min-height: calc(1.16em + 15.44px);
+		min-width: calc(1.16em + 15.44px);
 		top: -1px;
 		right: -1px;
 		border: 1px solid $gray-border-color;
@@ -692,10 +692,14 @@ input:disabled {
 			background: $gray-border-color;
 		}
 
+		.ui-icon {
+			position: static;
+		}
+
 		span.ui-icon.ui-icon-triangle-1-s {
-			width: calc(1.5em + 11px);
-			height: 1.067em;
-			margin-top: calc(0.4em + 2px);
+			width: auto;
+  			height: calc(1.37em - 4.77px);
+			margin: 0;
 			background: none;
 			text-align: center;
 
@@ -3722,6 +3726,13 @@ div.filesTable {
 	transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
 }
 
+div[id^="datasetForm"] {
+    .autocomplete-form-control.ui-autocomplete input.ui-autocomplete-input {
+        font-size: 1em;
+        padding: 0.9em 0.8em;
+    }
+}
+
 .ui-dialog.ui-widget.ui-widget-content {
 	min-height: 200px;
 	min-width: 320px;
@@ -4133,6 +4144,15 @@ body.font-size-percent-150 {
 
 		&:focus {
 			outline-width: 1.333px !important;
+		}
+	}
+
+	.ui-selectonemenu {
+		min-height: 1.91111111111em;
+		
+		.ui-selectonemenu-trigger.ui-state-default {
+			min-height: 1.91111111111em;
+			min-width: 1.91111111111em;
 		}
 	}
 }


### PR DESCRIPTION
The `select` field was too tall, which caused discrepancies in the layout. Their `min-height` value was recalculated.

The dropdown button of the `select` field was also adjusted to have similar height as the `select` field. Flex layout was used, to avoid manually positioning the triangle icon with margins.

Incorrect dropdown input height caused the bottom border to be missing. This was also fixed.

Another related fix was applied for the autocomplete inputs (e.g. "Affiliation ROR"), which had incorrect font size and padding applied, which could also lead to incorrect form layout, especially when using font zoom accessibility setting.