### PR TITLE
Closes #2909: Fix empty dataset field values on dataset summary page and template details page

### DIFF
--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/dataset/metadata/valueRenderer/DatasetFieldValueRenderer.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/dataset/metadata/valueRenderer/DatasetFieldValueRenderer.java
@@ -1,0 +1,22 @@
+package edu.harvard.iq.dataverse.dataset.metadata.valueRenderer;
+
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import edu.harvard.iq.dataverse.persistence.dataset.DatasetField;
+
+@RequestScoped
+@Named("datasetFieldValueRenderer")
+public class DatasetFieldValueRenderer {
+    private ValueRendererRepository valueRenderes;
+
+    @Inject
+    public DatasetFieldValueRenderer(ValueRendererRepository valueRenderes) {
+        this.valueRenderes = valueRenderes;
+    }
+
+    public ValueRenderer getRendererFor(final DatasetField field) {
+        return valueRenderes.getRendererFor(field);
+    }
+}

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/dataset/tab/DatasetMetadataTab.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/dataset/tab/DatasetMetadataTab.java
@@ -14,8 +14,6 @@ import edu.harvard.iq.dataverse.DatasetDao;
 import edu.harvard.iq.dataverse.DataverseSession;
 import edu.harvard.iq.dataverse.PermissionsWrapper;
 import edu.harvard.iq.dataverse.dataset.DatasetFieldsInitializer;
-import edu.harvard.iq.dataverse.dataset.metadata.valueRenderer.ValueRenderer;
-import edu.harvard.iq.dataverse.dataset.metadata.valueRenderer.ValueRendererRepository;
 import edu.harvard.iq.dataverse.export.ExportService;
 import edu.harvard.iq.dataverse.export.spi.Exporter;
 import edu.harvard.iq.dataverse.persistence.dataset.Dataset;
@@ -24,7 +22,6 @@ import edu.harvard.iq.dataverse.persistence.dataset.DatasetFieldUtil;
 import edu.harvard.iq.dataverse.persistence.dataset.DatasetFieldsByType;
 import edu.harvard.iq.dataverse.persistence.dataset.DatasetVersion;
 import edu.harvard.iq.dataverse.persistence.dataset.MetadataBlock;
-import edu.harvard.iq.dataverse.search.geonames.GeoNameDataFinder;
 import edu.harvard.iq.dataverse.util.SystemConfig;
 import io.vavr.Tuple;
 import io.vavr.Tuple2;
@@ -39,7 +36,6 @@ public class DatasetMetadataTab implements Serializable {
     private DatasetFieldsInitializer datasetFieldsInitializer;
     private DatasetDao datasetDao;
     private DataverseSession session;
-    private ValueRendererRepository valueRenderes;
 
     private Dataset dataset;
     private boolean isDatasetLocked;
@@ -57,15 +53,13 @@ public class DatasetMetadataTab implements Serializable {
                               ExportService exportService,
                               SystemConfig systemConfig,
                               DatasetFieldsInitializer datasetVersionUI,
-                              DatasetDao datasetDao,
-                              ValueRendererRepository valueRenderes) {
+                              DatasetDao datasetDao) {
         this.permissionsWrapper = permissionsWrapper;
         this.session = session;
         this.exportService = exportService;
         this.systemConfig = systemConfig;
         this.datasetFieldsInitializer = datasetVersionUI;
         this.datasetDao = datasetDao;
-        this.valueRenderes = valueRenderes;
     }
 
     // -------------------- GETTERS --------------------
@@ -129,10 +123,6 @@ public class DatasetMetadataTab implements Serializable {
 
     public String getAlternativePersistentIdentifier() {
         return datasetDao.find(dataset.getId()).getAlternativePersistentIdentifier();
-    }
-    
-    public ValueRenderer getRendererFor(final DatasetField field) {
-        return this.valueRenderes.getRendererFor(field);
     }
 
     // -------------------- PRIVATE --------------------

--- a/fairchive-webapp/src/main/webapp/metadataTab.xhtml
+++ b/fairchive-webapp/src/main/webapp/metadataTab.xhtml
@@ -42,7 +42,5 @@
                   value="#{DatasetMetadataTab.dataset.publicationDateFormattedYYYYMMDD}"/>
         <ui:param name="isViewedFromAnonymizedPrivateUrl" 
                   value="#{DatasetPage.isViewedFromAnonymizedPrivateUrl()}"/>
-        <ui:param name="rendererFactory"
-                  value="#{DatasetMetadataTab}"/>
     </ui:include>
 </ui:composition>

--- a/fairchive-webapp/src/main/webapp/viewMetadataField.xhtml
+++ b/fairchive-webapp/src/main/webapp/viewMetadataField.xhtml
@@ -22,7 +22,7 @@
             <div style="#{fieldsLoop.last ? '': 'padding-bottom: 10px;'}" 
                  class="datasetfield-value #{datasetField.datasetFieldType.separableOnGui ? 'datasetfield-separable' : ''}">
                 <ui:repeat var="value" value="#{datasetField.values}" varStatus="valuesLoop">
-                        <c:set var="valueToDisplay" value="#{rendererFactory.getRendererFor(datasetField).render(value)}"/>
+                        <c:set var="valueToDisplay" value="#{datasetFieldValueRenderer.getRendererFor(datasetField).render(value)}"/>
                         <h:outputText value="#{valuesLoop.first?'':'; '}#{ valueToDisplay }"
                                 escape="false"/>
                 </ui:repeat>
@@ -38,7 +38,7 @@
 
                     <div jsf:rendered="#{childField.parentDisplayFormatIsNewLine}">
                             <ui:repeat value="#{childField.values}" var="value" varStatus="valuesLoop">
-                                <c:set var="valueToDisplay" value="#{rendererFactory.getRendererFor(childField).render(value)}"/>
+                                <c:set var="valueToDisplay" value="#{datasetFieldValueRenderer.getRendererFor(childField).render(value)}"/>
                                 <h:outputText value="#{valuesLoop.first?'':'; '}#{ valueToDisplay }"
                                         escape="false"/>
                             </ui:repeat>


### PR DESCRIPTION
The problem was that we did not always included `rendererFactory` param into `viewMetadataField.xhtml`.

I've decided to separate it into the separate service.

IMO the whole solution for rendering dataset field values would need a bit of refactor.

Right now we have some two places where we render the dataset field values. One is in `ValueRendererRepository` and the second one is in `DatasetField.getFieldDisplayValue`. I don't see a point of such separation. We should keep it one place.