### PR TITLE
Closes #2943: Fix not dissapearing overlay on dataset create page when there are validation errors

### DIFF
--- a/fairchive-webapp/src/main/webapp/createDataset.xhtml
+++ b/fairchive-webapp/src/main/webapp/createDataset.xhtml
@@ -141,6 +141,7 @@
                                      update="formContent"
                                      onstart="PF('datasetFormBlockUI').show();"
                                      onerror="PF('saveStatusPoll').start();"
+                                     onsuccess="PF('datasetFormBlockUI').hide();"
                                      oncomplete="$(document).scrollTop(0);"
                                      />
                     <p:button id="cancelCreate" value="#{bundle.cancel}"

--- a/fairchive-webapp/src/main/webapp/editdatafiles.xhtml
+++ b/fairchive-webapp/src/main/webapp/editdatafiles.xhtml
@@ -111,6 +111,7 @@
                                                      process="@form"
                                                      onstart="PF('blockFileForm').show();"
                                                      onerror="PF('saveStatusPoll').start();"
+                                                     onsuccess="PF('blockFileForm').hide();"
                                                      oncomplete="$(document).scrollTop(0);" />
                                     <p:commandButton id="cancel" 
                                                      value="#{bundle.cancel}" 


### PR DESCRIPTION
At first I thought that bug occurs only in extensions. But I was deploying the older version of fairchive when the issue was not introduced yet. Bug is reproductible from the base fairchive as well as in extensions.

The problem was that in `createDataset.xhtml` there is a `p:blockUI` element. This `blockUI` defines also whether the overlay should be shown using `blocked="#{CreateDatasetPage.isSaveRunning}"` property.

When we click on save however the `blockUI` do not refreshes because `update` property of save button updates only `formContent` (`blockUI` is outside of `formContent`) and we do not even check whether `CreateDatasetPage.isSaveRunning` is true or not. I've tried to change the update param to the whole form but this caused some other issues (although the overlay was hiding properly) like for some reason we ended up with two sets of `save` and `cancel` buttons. I've decided in the end to just hide the overlay using javascript (200 is returned from backend also when there are validation errors).

I did not removed `blocked="#{CreateDatasetPage.isSaveRunning}"` param from the `blockUI` since it still seems to be used/relevant when we go through `onerror="PF('saveStatusPoll').start();"` path. 