### PR TITLE
Closes #2960 In GeoNames field, alternative names lack a space after …

### DIFF
--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/search/geonames/GeoNamesImporter.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/search/geonames/GeoNamesImporter.java
@@ -190,7 +190,7 @@ final class GeoNamesImporter {
                     final GeoName result = new GeoName();
                     result.setId(cells[0].trim());
                     result.setName(cells[1].trim());
-                    result.setAlternateNames(cells[3].trim());
+                    result.setAlternateNames(cells[3].trim().replaceAll(",", ", "));
                     result.setFeatureCode(cache.deduplicate(cells[7].trim()));
                     result.setCountryCode(cache.deduplicate(cells[8].trim()));
                     result.setAdmin1Code(cache.deduplicateOrNull(cells[10]));

--- a/fairchive-webapp/src/test/java/edu/harvard/iq/dataverse/search/geonames/GeoNamesIT.java
+++ b/fairchive-webapp/src/test/java/edu/harvard/iq/dataverse/search/geonames/GeoNamesIT.java
@@ -91,6 +91,7 @@ public class GeoNamesIT extends WebappArquillianDeployment {
         Optional<GeoName> geoName = this.finder.findById("752942");
         assertThat(geoName).isNotEmpty();
         assertThat(geoName.get().getName()).isEqualTo("Poraj");
+        assertThat(geoName.get().getAlternateNames()).isEqualTo("Kolonia Poraj, Poraj");
         assertThat(geoName.get().getHierarchy())
                 .isEqualTo("PL - Lublin Voivodeship - Powiat hrubieszowski - Poraj");
         // search by name


### PR DESCRIPTION
…a separating comma


