### PR TITLE
Closes #3043: Allow to modify existing dataset fields for viewing purposes using extension

### DIFF
--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/dataset/DatasetFieldsForViewTransformer.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/dataset/DatasetFieldsForViewTransformer.java
@@ -25,8 +25,8 @@ public class DatasetFieldsForViewTransformer {
      * Transforms dataset fields before presenting them on the UI
      * 
      * @param datasetFields - fields of a dataset or a template
-     * @param isTemplate - if true then dataset fields comes from a template
-     *   otherwise it comes from a dataset
+     * @param isTemplate - if true then dataset fields come from a template
+     *   otherwise they come from a dataset
      */
     public void transformDatasetFields(List<DatasetField> datasetFields, boolean isTemplate) {
         // Empty on purpose, method intended to be overridden in extensions

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/dataset/DatasetFieldsForViewTransformer.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/dataset/DatasetFieldsForViewTransformer.java
@@ -1,0 +1,34 @@
+package edu.harvard.iq.dataverse.dataset;
+
+import java.util.List;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import edu.harvard.iq.dataverse.persistence.dataset.DatasetField;
+
+/**
+ * Class intended to be overridden via extensions.
+ * It modifies dataset fields before showing them for the end user on UI.
+ * <br/>
+ * Extensions can override this class to modify values of existing dataset
+ * fields or add new dataset fields that are not part of dataset fields in DB.
+ * <br/>
+ * Extensions should extend this class and mark them with {@code @Specializes}
+ * and {@code @ApplicationScoped} to use this feature.
+ * 
+ * @author Krzysztof Mądry, Sylwester Niewczas
+ */
+@ApplicationScoped
+public class DatasetFieldsForViewTransformer {
+
+    /**
+     * Transforms dataset fields before presenting them on the UI
+     * 
+     * @param datasetFields - fields of a dataset or a template
+     * @param isTemplate - if true then dataset fields comes from a template
+     *   otherwise it comes from a dataset
+     */
+    public void transformDatasetFields(List<DatasetField> datasetFields, boolean isTemplate) {
+        // Empty on purpose, method intended to be overridden in extensions
+    }
+}

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/dataset/DatasetFieldsInitializer.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/dataset/DatasetFieldsInitializer.java
@@ -28,6 +28,7 @@ import java.util.stream.Collectors;
 public class DatasetFieldsInitializer {
 
     private DataverseFieldTypeInputLevelServiceBean dataverseFieldTypeInputLevelService;
+    private DatasetFieldsForViewTransformer datasetFieldsForViewTransformer;
     private FieldDefaultValueApplier defaultValueApplier = new FieldDefaultValueApplier();
 
 
@@ -38,8 +39,10 @@ public class DatasetFieldsInitializer {
     }
 
     @Inject
-    public DatasetFieldsInitializer(DataverseFieldTypeInputLevelServiceBean dataverseFieldTypeInputLevelService) {
+    public DatasetFieldsInitializer(DataverseFieldTypeInputLevelServiceBean dataverseFieldTypeInputLevelService,
+            DatasetFieldsForViewTransformer datasetFieldsForViewTransformer) {
         this.dataverseFieldTypeInputLevelService = dataverseFieldTypeInputLevelService;
+        this.datasetFieldsForViewTransformer = datasetFieldsForViewTransformer;
     }
 
     // -------------------- LOGIC --------------------
@@ -49,14 +52,20 @@ public class DatasetFieldsInitializer {
      * for metadata view. Preparing consists of following steps:
      * <ul>
      * <li>Filter empty fields</li>
+     * <li>Transform fields using {@link DatasetFieldsForViewTransformer#transformDatasetFields(List, boolean)}</li>
      * <li>Sort fields by {@link DatasetField#getDisplayOrder()} and {@link DatasetFieldType#getDisplayOrder()}</li>
      * </ul>
      *
      * @param datasetFields - initial dataset fields
+     * @param isTemplate - if true then dataset fields comes from a template
+     *   otherwise it comes from a dataset
      * @return dataset fields suitable for view operation
      */
-    public List<DatasetField> prepareDatasetFieldsForView(List<DatasetField> datasetFields) {
+    public List<DatasetField> prepareDatasetFieldsForView(List<DatasetField> datasetFields, boolean isTemplate) {
         List<DatasetField> newDatasetFields = filterEmptyFields(datasetFields);
+
+        datasetFieldsForViewTransformer.transformDatasetFields(newDatasetFields, isTemplate);
+
         newDatasetFields = sortDatasetFieldsRecursively(newDatasetFields);
 
         return newDatasetFields;

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/dataset/DatasetFieldsInitializer.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/dataset/DatasetFieldsInitializer.java
@@ -57,8 +57,8 @@ public class DatasetFieldsInitializer {
      * </ul>
      *
      * @param datasetFields - initial dataset fields
-     * @param isTemplate - if true then dataset fields comes from a template
-     *   otherwise it comes from a dataset
+     * @param isTemplate - if true then dataset fields come from a template
+     *   otherwise they come from a dataset
      * @return dataset fields suitable for view operation
      */
     public List<DatasetField> prepareDatasetFieldsForView(List<DatasetField> datasetFields, boolean isTemplate) {

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/dataset/tab/DatasetMetadataTab.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/dataset/tab/DatasetMetadataTab.java
@@ -93,7 +93,7 @@ public class DatasetMetadataTab implements Serializable {
         this.dataset = datasetVersion.getDataset();
         this.isDatasetLocked = isDatasetLocked;
         
-        List<DatasetField> datasetFields = datasetFieldsInitializer.prepareDatasetFieldsForView(datasetVersion.getDatasetFields());
+        List<DatasetField> datasetFields = datasetFieldsInitializer.prepareDatasetFieldsForView(datasetVersion.getDatasetFields(), false);
         this.metadataBlocks = DatasetFieldUtil.groupByBlockAndType(datasetFields);
     }
 

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/dataverse/template/ManageTemplatesPage.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/dataverse/template/ManageTemplatesPage.java
@@ -148,7 +148,7 @@ public class ManageTemplatesPage implements java.io.Serializable {
     public void viewSelectedTemplate(Template selectedTemplate) {
         this.selectedTemplate = selectedTemplate;
 
-        List<DatasetField> dsfForView = datasetFieldsInitializer.prepareDatasetFieldsForView(selectedTemplate.getDatasetFields());
+        List<DatasetField> dsfForView = datasetFieldsInitializer.prepareDatasetFieldsForView(selectedTemplate.getDatasetFields(), true);
         mdbForView = DatasetFieldUtil.groupByBlockAndType(dsfForView);
     }
 

--- a/fairchive-webapp/src/test/java/edu/harvard/iq/dataverse/dataset/DatasetFieldsInitializerTest.java
+++ b/fairchive-webapp/src/test/java/edu/harvard/iq/dataverse/dataset/DatasetFieldsInitializerTest.java
@@ -45,6 +45,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 
 /**
  * @author madryk
@@ -57,6 +58,9 @@ public class DatasetFieldsInitializerTest {
 
     @Mock
     private DataverseFieldTypeInputLevelServiceBean dataverseFieldTypeInputLevelService;
+
+    @Mock
+    private DatasetFieldsForViewTransformer datasetFieldsForViewTransformer;
 
     // -------------------- TESTS --------------------
 
@@ -86,7 +90,7 @@ public class DatasetFieldsInitializerTest {
         List<DatasetField> datasetFields = Lists.newArrayList(titleField, depositorField, authorField, dateOfDepositField);
 
         // when
-        List<DatasetField> retDatasetFields = datasetFieldsInitializer.prepareDatasetFieldsForView(datasetFields);
+        List<DatasetField> retDatasetFields = datasetFieldsInitializer.prepareDatasetFieldsForView(datasetFields, false);
 
         // then
         assertEquals(2, retDatasetFields.size());
@@ -96,6 +100,8 @@ public class DatasetFieldsInitializerTest {
 
         assertEquals(depositorField.getDatasetFieldType(), retDatasetFields.get(1).getDatasetFieldType());
         assertEquals("John Depositor", retDatasetFields.get(1).getRawValue());
+
+        verify(datasetFieldsForViewTransformer).transformDatasetFields(retDatasetFields, false);
     }
 
     @Test


### PR DESCRIPTION
The solution seems to be a little bit hacky but it works.

The reason of introducting this feature is following:
In one of our extension we have a field `temporal_coverage_end` - this is an end year when data was being collected. But when user do not provide the value for this then we have an assumption that the data collection is ongoing.

So in the extension we have a code that adds `temporal_coverage_end` field with text like `data collection is ongoing` when it is not present in the dataset.

When introducing this change I kind of thinked also that it would be good idea to use this mechanism to add "fake" dataset fields that are presented in the `citation` metadata block. That is: `Dataset Persistent ID` and `Publication Date`:
<img width="1166" height="208" alt="image" src="https://github.com/user-attachments/assets/592f5111-5cfa-4102-a3e3-66785a24a4fe" />
Those are not really part of dataset metadata but they are presented like they are.
But for now I did not do it. Maybe we can make it as a separate task. I didn't want to introduce it right now because there is a PR that is making some changes in that area (https://github.com/CeON/fairchive/pull/2985) and I didn't want to introduce unnecessary conflicts.

