### PR TITLE
Closes #3060: Fix NPE introduced when merging on upload files to dataset page

### DIFF
--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/datafile/page/EditDatafilesPage.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/datafile/page/EditDatafilesPage.java
@@ -208,7 +208,8 @@ public class EditDatafilesPage implements java.io.Serializable {
     public EditDatafilesPage() { }
 
     @Inject
-    public EditDatafilesPage(final DataFileServiceBean datafileDao,
+    public EditDatafilesPage(final DatasetDao datasetDao,
+                             final DataFileServiceBean datafileDao,
                              final DataFileCreator dataFileCreator, 
                              final PermissionServiceBean permissionService,
                              final IngestServiceBean ingestService, 
@@ -229,6 +230,7 @@ public class EditDatafilesPage implements java.io.Serializable {
                              final ImageThumbConverter imageThumbConverter,
                              final DuplicatesService duplicatesService,
                              final AsyncExecutionService asyncExecutionService) {
+        this.datasetDao = datasetDao;
         this.datafileDao = datafileDao;
         this.dataFileCreator = dataFileCreator;
         this.permissionService = permissionService;


### PR DESCRIPTION
When I was merging the changes needed in the `release/v1.1.x` branch I've incorrectly resolved one conflict. The assignment of `DatasetDao` in `EditDatafilesPage` was missing.