### PR TITLE
Closes #3069: Fix displaying ORCiD number twice when logged in through ORCiD service

### DIFF
--- a/fairchive-persistence/src/main/resources/Bundle_en.properties
+++ b/fairchive-persistence/src/main/resources/Bundle_en.properties
@@ -459,10 +459,6 @@ auth.providers.title.orcid=ORCID
 auth.providers.title.google=Google
 auth.providers.title.github=GitHub
 auth.providers.blurb=Log in or sign up with your {0} account &mdash; <a href="{1}/{2}/user/account.html" target="_blank">learn more</a>. Having trouble? Please contact {3} for assistance.
-auth.providers.persistentUserIdName.orcid=ORCID iD
-auth.providers.persistentUserIdName.github=ID
-auth.providers.persistentUserIdTooltip.orcid=ORCID provides a persistent digital identifier that distinguishes you from other researchers.
-auth.providers.persistentUserIdTooltip.github=GitHub assigns a unique number to every user.
 auth.providers.orcid.insufficientScope=Dataverse was not granted the permission to read user data from ORCID.
 auth.providers.orcid.helpmessage1=ORCID is an open, non-profit, community-based effort to provide a registry of unique researcher identifiers and a transparent method of linking research activities and outputs to these identifiers. ORCID is unique in its ability to reach across disciplines, research sectors, and national boundaries and its cooperation with other identifier systems. Find out more at <a href="https://orcid.org/about" target="_blank">orcid.org/about</a>.
 auth.providers.orcid.helpmessage2=This repository uses your ORCID for authentication (so you don't need another username/password combination).  Having your ORCID associated with your datasets also makes it easier for people to find the datasets you have published.  

--- a/fairchive-persistence/src/main/resources/Bundle_pl.properties
+++ b/fairchive-persistence/src/main/resources/Bundle_pl.properties
@@ -439,10 +439,6 @@ auth.providers.title.orcid=ORCiD
 auth.providers.title.google=Google
 auth.providers.title.github=GitHub
 auth.providers.blurb=Zaloguj si\u0119 lub zarejestruj u\u017Cywaj\u0105c swojego konta {0}&mdash; <a href="{1}/{2}/user/account.html" target="_blank">dowiedz si\u0119 wi\u0119cej</a>. Masz problemy? Skontaktuj si\u0119 z {3} w celu uzyskania pomocy.
-auth.providers.persistentUserIdName.orcid=Identyfikator ORCiD
-auth.providers.persistentUserIdName.github=Identyfikator 
-auth.providers.persistentUserIdTooltip.orcid=ORCiD zapewnia trwa\u0142y cyfrowy identyfikator pozwalaj\u0105cy odr\u00F3\u017Cni\u0107 Ci\u0119 od innych naukowc\u00F3w.
-auth.providers.persistentUserIdTooltip.github=GitHub przydziela ka\u017Cdemu u\u017Cytkownikowi niepowtarzalny numer.
 auth.providers.orcid.insufficientScope=Repozytorium nie uzyska\u0142o pozwolenia na odczytanie danych u\u017Cytkownika z ORCiD.
 auth.providers.orcid.helpmessage1=ORCiD to otwarta, spo\u0142eczno\u015Bciowa inicjatywa non-profit, tworz\u0105ca rejestr niepowtarzalnych identyfikator\u00F3w badaczy oraz gwarantuj\u0105ca przejrzysty spos\u00F3b \u0142\u0105czenia z nimi aktywno\u015Bci badawczych i dorobku naukowego. ORCiD to wyj\u0105tkowy projekt, gdy\u017C pozwala wykracza\u0107 poza ramy dyscyplin, obszar\u00F3w badawczych i granic pa\u0144stwowych i wsp\u00F3\u0142pracuje z innymi systemami identyfikacyjnymi. Wi\u0119cej informacji znajdziesz na <a href="https://orcid.org/about" target="_blank">orcid.org/about</a>.
 auth.providers.orcid.helpmessage2=To repozytorium wykorzystuje Tw\u00F3j identyfikator ORCiD w celach uwierzytelniania (nie potrzebujesz wi\u0119c kolejnej nazwy u\u017Cytkownika oraz has\u0142a). Powi\u0105zanie ORCID z Twoimi zbiorami danych u\u0142atwi te\u017C innym osobom znalezienie opublikowanych przez Ciebie zbior\u00F3w.

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/authorization/AuthenticationProvider.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/authorization/AuthenticationProvider.java
@@ -48,39 +48,6 @@ public interface AuthenticationProvider {
         return false;
     }
 
-    /** @todo Consider moving some or all of these to AuthenticationProviderDisplayInfo.*/
-    /**
-     * The identifier is only displayed in the UI if it's meaningful, such as an ORCID iD.
-     */
-    default boolean isDisplayIdentifier() {
-        return false;
-    }
-
-    /**
-     * ORCID calls their persistent id an "ORCID iD".
-     */
-    default String getPersistentIdName() {
-        return null;
-    }
-
-    /**
-     * ORCID has special language to describe their ID: http://members.orcid.org/logos-web-graphics
-     */
-    default String getPersistentIdDescription() {
-        return null;
-    }
-
-    /**
-     * An ORCID example would be the "http://orcid.org/" part of http://orcid.org/0000-0002-7874-374X
-     */
-    default String getPersistentIdUrlPrefix() {
-        return null;
-    }
-
-    default String getLogo() {
-        return null;
-    }
-
 
     /**
      * Some providers (e.g organizational ones) provide verified email addresses.

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/authorization/providers/builtin/BuiltinAuthenticationProvider.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/authorization/providers/builtin/BuiltinAuthenticationProvider.java
@@ -161,9 +161,4 @@ public class BuiltinAuthenticationProvider implements CredentialsAuthenticationP
         return false;
     }
 
-    @Override
-    public boolean isDisplayIdentifier() {
-        return false;
-    }
-
 }

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/authorization/providers/common/ExternalIdpFirstLoginPage.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/authorization/providers/common/ExternalIdpFirstLoginPage.java
@@ -130,7 +130,7 @@ public class ExternalIdpFirstLoginPage extends BaseUserPage {
 
     private boolean isSamlUser;
 
-    private boolean disableOrcidEdit = false;
+    private boolean orcidEditDisabled = false;
 
     // -------------------- GETTERS --------------------
 
@@ -170,8 +170,8 @@ public class ExternalIdpFirstLoginPage extends BaseUserPage {
         return disableSamlFilledFields;
     }
 
-    public boolean isDisableOrcidEdit() {
-        return disableOrcidEdit;
+    public boolean isOrcidEditDisabled() {
+        return orcidEditDisabled;
     }
 
     // -------------------- LOGIC --------------------
@@ -236,7 +236,7 @@ public class ExternalIdpFirstLoginPage extends BaseUserPage {
         installationName = installationConfigService.getNameOfInstallation();
         consents = consentService.prepareConsentsForView(session.getLocale());
 
-        disableOrcidEdit = !authProvider.getEditableFields().contains(EditableAccountField.ORCID)
+        orcidEditDisabled = !authProvider.getEditableFields().contains(EditableAccountField.ORCID)
                 && StringUtils.isNotBlank(newUser.getDisplayInfo().getOrcid());
 
         return StringUtils.EMPTY;

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/authorization/providers/common/ExternalIdpFirstLoginPage.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/authorization/providers/common/ExternalIdpFirstLoginPage.java
@@ -6,6 +6,7 @@ import edu.harvard.iq.dataverse.authorization.AuthenticationProvider;
 import edu.harvard.iq.dataverse.authorization.AuthenticationRequest;
 import edu.harvard.iq.dataverse.authorization.AuthenticationServiceBean;
 import edu.harvard.iq.dataverse.authorization.CredentialsAuthenticationProvider;
+import edu.harvard.iq.dataverse.authorization.EditableAccountField;
 import edu.harvard.iq.dataverse.authorization.common.ExternalIdpUserRecord;
 import edu.harvard.iq.dataverse.authorization.exceptions.AuthenticationFailedException;
 import edu.harvard.iq.dataverse.authorization.providers.builtin.BuiltinAuthenticationProvider;
@@ -129,6 +130,8 @@ public class ExternalIdpFirstLoginPage extends BaseUserPage {
 
     private boolean isSamlUser;
 
+    private boolean disableOrcidEdit = false;
+
     // -------------------- GETTERS --------------------
 
     public AuthenticationProvider getAuthProvider() {
@@ -165,6 +168,10 @@ public class ExternalIdpFirstLoginPage extends BaseUserPage {
 
     public Boolean getDisableSamlFilledFields() {
         return disableSamlFilledFields;
+    }
+
+    public boolean isDisableOrcidEdit() {
+        return disableOrcidEdit;
     }
 
     // -------------------- LOGIC --------------------
@@ -228,6 +235,9 @@ public class ExternalIdpFirstLoginPage extends BaseUserPage {
         authProvider = authenticationSvc.getAuthenticationProvider(newUser.getServiceId());
         installationName = installationConfigService.getNameOfInstallation();
         consents = consentService.prepareConsentsForView(session.getLocale());
+
+        disableOrcidEdit = !authProvider.getEditableFields().contains(EditableAccountField.ORCID)
+                && StringUtils.isNotBlank(newUser.getDisplayInfo().getOrcid());
 
         return StringUtils.EMPTY;
     }

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/authorization/providers/oauth2/OIDCAuthenticationProvider.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/authorization/providers/oauth2/OIDCAuthenticationProvider.java
@@ -161,12 +161,6 @@ public class OIDCAuthenticationProvider implements OAuth2AuthenticationProvider 
 
     /* Must be present as EL has problems with default implementations */
     @Override
-    public boolean isDisplayIdentifier() {
-        return false;
-    }
-
-    /* Must be present as EL has problems with default implementations */
-    @Override
     public boolean isOAuthProvider() {
         return true;
     }

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/authorization/providers/oauth2/impl/GitHubOAuth2AP.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/authorization/providers/oauth2/impl/GitHubOAuth2AP.java
@@ -63,29 +63,4 @@ public class GitHubOAuth2AP extends AbstractOAuth2AuthenticationProvider {
 
     }
 
-    @Override
-    public boolean isDisplayIdentifier() {
-        return false;
-    }
-
-    @Override
-    public String getPersistentIdName() {
-        return BundleUtil.getStringFromBundle("auth.providers.persistentUserIdName.github");
-    }
-
-    @Override
-    public String getPersistentIdDescription() {
-        return BundleUtil.getStringFromBundle("auth.providers.persistentUserIdTooltip.github");
-    }
-
-    @Override
-    public String getPersistentIdUrlPrefix() {
-        return null;
-    }
-
-    @Override
-    public String getLogo() {
-        return null;
-    }
-
 }

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/authorization/providers/oauth2/impl/GoogleOAuth2AP.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/authorization/providers/oauth2/impl/GoogleOAuth2AP.java
@@ -69,9 +69,4 @@ public class GoogleOAuth2AP extends AbstractOAuth2AuthenticationProvider {
         }
     }
 
-    @Override
-    public boolean isDisplayIdentifier() {
-        return false;
-    }
-
 }

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/authorization/providers/oauth2/impl/OrcidOAuth2AP.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/authorization/providers/oauth2/impl/OrcidOAuth2AP.java
@@ -7,6 +7,7 @@ import com.github.scribejava.core.model.Response;
 import com.github.scribejava.core.model.Verb;
 import com.github.scribejava.core.oauth.OAuth20Service;
 import edu.harvard.iq.dataverse.authorization.AuthenticationProviderDisplayInfo;
+import edu.harvard.iq.dataverse.authorization.EditableAccountField;
 import edu.harvard.iq.dataverse.authorization.providers.oauth2.AbstractOAuth2AuthenticationProvider;
 import edu.harvard.iq.dataverse.authorization.providers.oauth2.OAuth2Exception;
 import edu.harvard.iq.dataverse.authorization.common.ExternalIdpUserRecord;
@@ -36,8 +37,10 @@ import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -45,9 +48,11 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import static java.util.Collections.unmodifiableSet;
 import static java.util.stream.Collectors.joining;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.apache.commons.lang3.StringUtils.SPACE;
+import static edu.harvard.iq.dataverse.authorization.EditableAccountField.*;
 
 /**
  * OAuth2 identity provider for ORCiD. Note that ORCiD has two systems: sandbox
@@ -59,6 +64,9 @@ import static org.apache.commons.lang3.StringUtils.SPACE;
 public class OrcidOAuth2AP extends AbstractOAuth2AuthenticationProvider {
 
     final static Logger logger = Logger.getLogger(OrcidOAuth2AP.class.getName());
+
+    private static final Set<EditableAccountField> ORCID_EDITABLE_FIELDS = unmodifiableSet(
+            EnumSet.of(AFFILIATION, POSITION, NOTIFICATIONS_LANG, AFFILIATION_ROR));
 
     public static final String PROVIDER_ID_PRODUCTION = AuthenticatedUserLookup.ORCID_PROVIDER_ID_PRODUCTION;
     public static final String PROVIDER_ID_SANDBOX = AuthenticatedUserLookup.ORCID_PROVIDER_ID_SANDBOX;
@@ -100,6 +108,11 @@ public class OrcidOAuth2AP extends AbstractOAuth2AuthenticationProvider {
     @Override
     public BaseApi<OAuth20Service> getApiInstance() {
         return OrcidApi.instance(!isUsingSandboxEnv());
+    }
+
+    @Override
+    public Set<EditableAccountField> getEditableFields() {
+        return ORCID_EDITABLE_FIELDS;
     }
 
     @Override
@@ -278,31 +291,6 @@ public class OrcidOAuth2AP extends AbstractOAuth2AuthenticationProvider {
             return new AuthenticationProviderDisplayInfo(getId(), BundleUtil.getStringFromBundle("auth.providers.title.orcid"), "ORCID user repository");
         }
         return new AuthenticationProviderDisplayInfo(getId(), "ORCID Sandbox", "ORCID dev sandbox ");
-    }
-
-    @Override
-    public boolean isDisplayIdentifier() {
-        return true;
-    }
-
-    @Override
-    public String getPersistentIdName() {
-        return BundleUtil.getStringFromBundle("auth.providers.persistentUserIdName.orcid");
-    }
-
-    @Override
-    public String getPersistentIdDescription() {
-        return BundleUtil.getStringFromBundle("auth.providers.persistentUserIdTooltip.orcid");
-    }
-
-    @Override
-    public String getPersistentIdUrlPrefix() {
-        return "https://orcid.org/";
-    }
-
-    @Override
-    public String getLogo() {
-        return "/resources/images/orcid_16x16.png";
     }
 
     protected String extractOrcidNumber(String rawResponse) throws OAuth2Exception {

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/authorization/providers/oauth2/impl/PBIOauth2AP.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/authorization/providers/oauth2/impl/PBIOauth2AP.java
@@ -113,11 +113,6 @@ public class PBIOauth2AP extends AbstractOAuth2AuthenticationProvider {
     }
 
     @Override
-    public boolean isDisplayIdentifier() {
-        return false;
-    }
-
-    @Override
     protected ParsedUserResponse parseUserResponse(String responseBody) {
         throw new RuntimeException("Not implemented.");
     }

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/authorization/providers/saml/SamlAuthenticationProvider.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/authorization/providers/saml/SamlAuthenticationProvider.java
@@ -45,12 +45,6 @@ public class SamlAuthenticationProvider implements AuthenticationProvider {
 
     /* Must be present as EL has problems with default implementations */
     @Override
-    public boolean isDisplayIdentifier() {
-        return false;
-    }
-
-    /* Must be present as EL has problems with default implementations */
-    @Override
     public boolean isOAuthProvider() {
         return false;
     }

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/authorization/providers/shib/ShibAuthenticationProvider.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/authorization/providers/shib/ShibAuthenticationProvider.java
@@ -23,9 +23,4 @@ public class ShibAuthenticationProvider implements AuthenticationProvider {
         return false;
     }
 
-    @Override
-    public boolean isDisplayIdentifier() {
-        return false;
-    }
-
 }

--- a/fairchive-webapp/src/main/webapp/dataverseuser.xhtml
+++ b/fairchive-webapp/src/main/webapp/dataverseuser.xhtml
@@ -541,27 +541,14 @@
                                         </div>
                                     </div>
                                 </div>
-                                <!-- ORCID iD, for example -->
-                                <div class="form-group" jsf:rendered="#{DataverseUserPage.userAuthProvider.displayIdentifier}">
-                                    <label for="userPersistentId" class="col-sm-3 control-label">
-                                        #{DataverseUserPage.userAuthProvider.persistentIdName}
-                                    </label>
-                                    <div class="col-sm-9">
-                                        <p class="form-control-static">
-                                            <h:graphicImage value="#{DataverseUserPage.userAuthProvider.logo}" height="16" width="16"/>&#160;
-                                            <h:outputLink value="#{DataverseUserPage.userAuthProvider.persistentIdUrlPrefix}#{DataverseUserPage.currentUser.authenticatedUserLookup.persistentUserId}" title="#{DataverseUserPage.userAuthProvider.persistentIdName}" target="_blank">
-                                                <h:outputText value="#{DataverseUserPage.userAuthProvider.persistentIdUrlPrefix}#{DataverseUserPage.currentUser.authenticatedUserLookup.persistentUserId}"/>
-                                            </h:outputLink>
-                                        </p>
-                                    </div>
-                                </div>
                                 <!-- ORCID -->
                                 <div class="form-group" jsf:rendered="#{!empty DataverseUserPage.currentUser.orcid}">
-                                    <label for="affiliation" class="col-sm-3 control-label">
+                                    <label for="orcid" class="col-sm-3 control-label">
                                         #{bundle['user.orcid']}
                                     </label>
                                     <div class="col-sm-9">
                                         <p class="form-control-static">
+                                            <h:graphicImage value="/resources/images/orcid_16x16.png" height="16" width="16"/>&#160;
                                             <h:outputLink value="https://orcid.org/#{DataverseUserPage.currentUser.orcid}" target="_blank">
                                                 <h:outputText value="#{DataverseUserPage.currentUser.orcid}"/>
                                             </h:outputLink>
@@ -766,23 +753,6 @@
                                                      value="#{DataverseUserPage.userDisplayInfo.emailAddress}"
                                                      disabled="#{DataverseUserPage.editMode == 'EDIT' and DataverseUserPage.isDisabledForEdit(editableField.EMAIL)}"/>
                                         <p:message for="email" display="text" />
-                                    </div>
-                                </div>
-                                <!--FIXME: refactor to remove need for EDIT? userAuthProvider is null on CREATE-->
-                                <div class="form-group" jsf:rendered="#{DataverseUserPage.editMode == 'EDIT' and DataverseUserPage.userAuthProvider.displayIdentifier}">
-                                    <!-- ORCID iD, for example -->
-                                    <label for="userPersistentId" class="col-sm-3 control-label">
-                                        #{DataverseUserPage.userAuthProvider.persistentIdName}
-                                        <span class="glyphicon glyphicon-question-sign tooltip-icon" tabindex="0" role="button"
-                                              data-toggle="tooltip" data-placement="auto right" data-original-title="#{DataverseUserPage.userAuthProvider.persistentIdDescription}"></span>
-                                    </label>
-                                    <div class="col-sm-4">
-                                        <p class="form-control-static">
-                                            <h:graphicImage value="#{DataverseUserPage.userAuthProvider.logo}" height="16" width="16"/>&#160;
-                                            <h:outputLink value="#{DataverseUserPage.userAuthProvider.persistentIdUrlPrefix}#{DataverseUserPage.currentUser.authenticatedUserLookup.persistentUserId}" title="#{DataverseUserPage.userAuthProvider.persistentIdName}" target="_blank">
-                                                <h:outputText value="#{DataverseUserPage.userAuthProvider.persistentIdUrlPrefix}#{DataverseUserPage.currentUser.authenticatedUserLookup.persistentUserId}"/>
-                                            </h:outputLink>
-                                        </p>
                                     </div>
                                 </div>
                                 <div class="form-group" jsf:rendered="#{DataverseUserPage.editMode == 'CREATE' or DataverseUserPage.editMode == 'EDIT'}">

--- a/fairchive-webapp/src/main/webapp/firstLogin.xhtml
+++ b/fairchive-webapp/src/main/webapp/firstLogin.xhtml
@@ -100,24 +100,23 @@
                                     <p:message for="selectedEmailMoreThanOneToPickFrom" display="text"/>
                                 </div>
                             </div>
-                            <div class="form-group" jsf:rendered="#{ExternalIdpFirstLoginPage.authProvider.displayIdentifier}">
-                                <label for="persistentUserId" class="col-sm-3 control-label">
-                                    #{ExternalIdpFirstLoginPage.authProvider.persistentIdName}
+                            <div class="form-group" jsf:rendered="#{ExternalIdpFirstLoginPage.disableOrcidEdit}">
+                                <label for="orcid" class="col-sm-3 control-label">
+                                    #{bundle['user.orcid']}
                                     <span class="glyphicon glyphicon-question-sign tooltip-icon" tabindex="0" role="button"
-                                          data-toggle="tooltip" data-placement="auto right" data-original-title="#{ExternalIdpFirstLoginPage.authProvider.persistentIdDescription}"></span>
+                                          data-toggle="tooltip" data-placement="auto right" data-original-title="#{bundle['user.orcid.tip']}"></span>
                                 </label>
                                 <div class="col-sm-4">
                                     <p class="form-control-static">
-                                        <h:graphicImage value="#{ExternalIdpFirstLoginPage.authProvider.logo}" height="16" width="16" rendered="#{ExternalIdpFirstLoginPage.authProvider.logo != null}"/>&#160;
-                                        <h:outputLink value="#{ExternalIdpFirstLoginPage.authProvider.persistentIdUrlPrefix}#{ExternalIdpFirstLoginPage.newUser.idInService}" title="#{ExternalIdpFirstLoginPage.authProvider.persistentIdName}" target="_blank" rendered="#{ExternalIdpFirstLoginPage.authProvider.persistentIdUrlPrefix != null}">
-                                            <h:outputText value="#{ExternalIdpFirstLoginPage.authProvider.persistentIdUrlPrefix}#{ExternalIdpFirstLoginPage.newUser.idInService}"/>
+                                        <h:graphicImage value="/resources/images/orcid_16x16.png" height="16" width="16"/>&#160;
+                                        <h:outputLink value="https://orcid.org/#{ExternalIdpFirstLoginPage.newUser.displayInfo.orcid}" target="_blank">
+                                            <h:outputText value="#{ExternalIdpFirstLoginPage.newUser.displayInfo.orcid}"/>
                                         </h:outputLink>
-                                        <h:outputText value="#{ExternalIdpFirstLoginPage.authProvider.persistentIdUrlPrefix}#{ExternalIdpFirstLoginPage.newUser.idInService}" rendered="#{ExternalIdpFirstLoginPage.authProvider.persistentIdUrlPrefix == null}"/>
                                     </p>
                                 </div>
                             </div>
-                            <div class="form-group">
-                                <label for="ocrid" class="col-sm-3 control-label">
+                            <div class="form-group" jsf:rendered="#{not ExternalIdpFirstLoginPage.disableOrcidEdit}">
+                                <label for="orcid" class="col-sm-3 control-label">
                                     #{bundle['user.orcid']}
                                     <span class="glyphicon glyphicon-question-sign tooltip-icon" tabindex="0" role="button"
                                           data-toggle="tooltip" data-placement="auto right" data-original-title="#{bundle['user.orcid.tip']}"></span>

--- a/fairchive-webapp/src/main/webapp/firstLogin.xhtml
+++ b/fairchive-webapp/src/main/webapp/firstLogin.xhtml
@@ -100,7 +100,7 @@
                                     <p:message for="selectedEmailMoreThanOneToPickFrom" display="text"/>
                                 </div>
                             </div>
-                            <div class="form-group" jsf:rendered="#{ExternalIdpFirstLoginPage.disableOrcidEdit}">
+                            <div class="form-group" jsf:rendered="#{ExternalIdpFirstLoginPage.orcidEditDisabled}">
                                 <label for="orcid" class="col-sm-3 control-label">
                                     #{bundle['user.orcid']}
                                     <span class="glyphicon glyphicon-question-sign tooltip-icon" tabindex="0" role="button"
@@ -115,7 +115,7 @@
                                     </p>
                                 </div>
                             </div>
-                            <div class="form-group" jsf:rendered="#{not ExternalIdpFirstLoginPage.disableOrcidEdit}">
+                            <div class="form-group" jsf:rendered="#{not ExternalIdpFirstLoginPage.orcidEditDisabled}">
                                 <label for="orcid" class="col-sm-3 control-label">
                                     #{bundle['user.orcid']}
                                     <span class="glyphicon glyphicon-question-sign tooltip-icon" tabindex="0" role="button"


### PR DESCRIPTION
I've also removed some methods from the AuthenticationProvider interface. They were used only by ORCiD provider and now they are obsolete.