### PR TITLE
Closes #3071: Stylization of metadata translation modal window

### DIFF
--- a/fairchive-webapp/src/main/webapp/resources/vecler/theme-base.scss
+++ b/fairchive-webapp/src/main/webapp/resources/vecler/theme-base.scss
@@ -3849,8 +3849,9 @@ div[id^="datasetForm"] {
 .ui-dialog.ui-widget.ui-widget-content {
 	min-height: 200px;
 	min-width: 320px;
-	max-width: 100vw;
-	max-height: 100vh;
+	max-width: calc(100vw - 2rem);
+	max-height: calc(100vh - 2rem);
+	margin: 1rem;
 	border: none;
 	border-radius: $border-radius;
 	box-shadow: 0 5px 10px rgba(0,0,0,0.2);
@@ -4045,6 +4046,14 @@ div[id^="datasetForm"] {
 	}
 }
 
+@media screen and (max-width: $screen-xs-max) {
+	.ui-dialog.ui-widget.ui-widget-content {
+		max-width: 100vw;
+		max-height: 100vh;
+		margin: 0;
+	}
+}
+
 /* Fixed grid modals mobile view */
 @media screen and (max-width: $screen-xs-max) {
 	@include modal-grid-mobile;
@@ -4141,6 +4150,10 @@ input[type=password].form-control {
 
 #rolesPermissionsForm\:userGroupDialog[style*="width: auto"] {
 	width: 100% !important;
+}
+
+#datasetForm\:tabView\:translateDialog.ui-dialog.ui-widget.ui-widget-content {
+	padding-bottom: 1rem;
 }
 
 .restricted-terms-of-use {


### PR DESCRIPTION
Added margins so that the window doesn't cover the whole browser. Removed padding, because the modal doesn't have any buttons on the bottom.