### PR TITLE
Closes #3075: Expand `RangeValidator` to support decimal numbers and exclusive bounds

### DIFF
--- a/fairchive-persistence/src/main/resources/Bundle_en.properties
+++ b/fairchive-persistence/src/main/resources/Bundle_en.properties
@@ -2801,9 +2801,14 @@ isNotValidInteger={0} is not a valid integer.
 isNotValidUrl={0} {1} is not a valid URL.
 isNotValidValue={0} is not valid value.
 isGreaterThanField="{0}" must not be greater than "{1}".
-isGreaterThanValue={0} must be less than or equal to {1}.
-isLessThanValue={0} must be greater than or equal to {1}.
-isNotBetweenValues={0} must be between {1} and {2}.
+isNotLessThanValue={0} must be less than {1}.
+isNotLessThanOrEqualToValue={0} must be less than or equal to {1}.
+isNotGreaterThanValue={0} must be greater than {1}.
+isNotGreaterThanOrEqualToValue={0} must be greater than or equal to {1}.
+isNotBetweenValuesBothBoundsExclusive={0} must be greater than {1} and less than {2}.
+isNotBetweenValuesBothBoundsInclusive={0} must be greater than or equal to {1} and less than or equal to {2}.
+isNotBetweenValuesLowerBoundInclusive={0} must be greater than or equal to {1} and less than {2}.
+isNotBetweenValuesUpperBoundInclusive={0} must be greater than {1} and less than or equal to {2}.
 isNotAcceptable={0} is not acceptable value.
 
 noFilesSelected=No files were selected.

--- a/fairchive-persistence/src/main/resources/Bundle_pl.properties
+++ b/fairchive-persistence/src/main/resources/Bundle_pl.properties
@@ -2751,9 +2751,14 @@ isNotValidInteger=Pole "{0}" nie zawiera poprawnej liczby ca\u0142kowitej.
 isNotValidUrl=Warto\u015B\u0107 {1} pola "{0}" nie jest poprawnym adresem URL.
 isNotValidValue={0} nie jest poprawn\u0105 warto\u015bci\u0105.
 isGreaterThanField=Pole "{0}" zawiera wi\u0119ksz\u0105 warto\u015B\u0107 ni\u017C pole "{1}".
-isGreaterThanValue=Pole "{0}" zawiera warto\u015B\u0107 wi\u0119ksz\u0105 ni\u017C {1}.
-isLessThanValue=Pole "{0}" zawiera warto\u015B\u0107 mniejsz\u0105 ni\u017C {1}.
-isNotBetweenValues=Pole "{0}" nie mie\u015Bci si\u0119 w zakresie od {1} do {2}.
+isNotLessThanValue=Warto\u015B\u0107 pola {0} musi by\u0107 mniejsza ni\u017C {1}.
+isNotLessThanOrEqualToValue=Warto\u015B\u0107 pola {0} must be less than or equal to {1}.
+isNotGreaterThanValue=Warto\u015B\u0107 pola {0} must be greater than {1}.
+isNotGreaterThanOrEqualToValue=Warto\u015B\u0107 pola {0} must be greater than or equal to {1}.
+isNotBetweenValuesBothBoundsExclusive=Warto\u015B\u0107 pola {0} musi by\u0107 wi\u0119ksza ni\u017C {1} i mniejsza ni\u017C {2}.
+isNotBetweenValuesBothBoundsInclusive=Warto\u015B\u0107 pola {0} musi by\u0107 wi\u0119ksza lub r\u00F3wna {1} i mniejsza lub r\u00F3wna {2}.
+isNotBetweenValuesLowerBoundInclusive=Warto\u015B\u0107 pola {0} musi by\u0107 wi\u0119ksza lub r\u00F3wna {1} i mniejsza {2}.
+isNotBetweenValuesUpperBoundInclusive=Warto\u015B\u0107 pola {0} musi by\u0107 wi\u0119ksza ni\u017C {1} i mniejsza lub r\u00F3wna {2}.
 isNotAcceptable=Warto\u015B\u0107 {0} nie jest akceptowalna.
 
 noFilesSelected=Nie zaznaczono \u017Cadnego pliku.

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/validators/RangeValidator.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/validation/field/validators/RangeValidator.java
@@ -1,9 +1,9 @@
 package edu.harvard.iq.dataverse.validation.field.validators;
 
 import static edu.harvard.iq.dataverse.validation.field.FieldValidationResult.invalid;
-import static java.lang.Long.parseLong;
 import static org.apache.commons.lang.StringUtils.isBlank;
 
+import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Year;
 import java.util.List;
@@ -19,19 +19,38 @@ import edu.harvard.iq.dataverse.validation.field.FieldValidationResult;
  * Validator that checks whether a field value is within the range defined
  * in validator's configuration.<br>
  * Validator accepts configuration parameters `min` and `max`. Values of these
- * parameters must contain a string that is parseable to `long`. Both range ends
- * are optional, and if none is provided, the validator will accept any value<br>
+ * parameters must contain a string that is parseable to a number. Both range ends
+ * are optional, and if none is provided, the validator will accept any value.<br>
  * Both `min` and `max` additionally support the macro `#NOW_YEAR` that will
  * validate the field value against the current year.
+ * <br>
+ * Additionally, parameters `min_exclusive` and `max_exclusive` allow configuring
+ * exclusivity of the lower and upper bound respectively. If not provided, bounds
+ * are inclusive by default.
  *
- * For example:
- * <pre>[{"name":"range_validator", parameters:{"min": 199, "max": "200"}}]</pre>
- * will allow values: 199, 200 and will not allow values: 198, 201<br>
- * <br>
- * <pre>[{"name":"range_validator", parameters:{"max": "#NOW_YEAR"}}]</pre>
- * will allow value less than or equal to the current year and will not allow
- * years greater than the current year<br>
- * <br>
+ * <p>
+ * Examples:
+ * <ul>
+ *     <li>
+ *         <pre>[{"name":"range_validator", parameters:{"min": 199, "max": "200"}}]</pre>
+ *         will allow values: 199, 200 and will not allow values: 198, 201
+ *     </li>
+ *     <li>
+ *         <pre>[{"name":"range_validator", parameters:{"min": 0, "max": "1", "min_exclusive": "true"}}]</pre>
+ *         will allow values: 0.1, 1.0 and will not allow values: -0.1, 0, 1.1
+ *     </li>
+ *     <li>
+ *         <pre>[{"name":"range_validator", parameters:{"max": "#NOW_YEAR"}}]</pre>
+ *         will allow value less than or equal to the current year and will not
+ *         allow years greater than the current year
+ *     </li>
+ *     <li>
+ *         <pre>[{"name":"range_validator", parameters:{"max": "#NOW_YEAR", "max_exclusive": "true"}}]</pre>
+ *         will allow value less than to the current year and will not allow
+ *         years equal to or greater than the current year
+ *     </li>
+ * </ul>
+ * </p>
  *
  * @author Krzysztof Mądry
  * @author Sylwester Niewczas
@@ -42,6 +61,8 @@ public class RangeValidator extends FieldValidatorBase {
 
     static final String MIN_PARAM = "min";
     static final String MAX_PARAM = "max";
+    static final String MIN_EXCLUSIVE_PARAM = "min_exclusive";
+    static final String MAX_EXCLUSIVE_PARAM = "max_exclusive";
     private static final String NOW_YEAR_MACRO = "#NOW_YEAR";
 
     @Override
@@ -54,49 +75,83 @@ public class RangeValidator extends FieldValidatorBase {
             final Map<String, Object> params,
             final Map<String, ? extends List<? extends ValidatableField>> fieldIndex) {
 
-        String value = field.getSingleValue();
-        long valueLong = parseLong(value);
+        BigDecimal valueNumber = new BigDecimal(field.getSingleValue());
 
-        String minParam = (String) params.get(MIN_PARAM);
-        String maxParam = (String) params.get(MAX_PARAM);
+        Object minParamObj = params.get(MIN_PARAM);
+        Object maxParamObj = params.get(MAX_PARAM);
+
+        String minParam = minParamObj != null ? String.valueOf(minParamObj) : null;
+        String maxParam = maxParamObj != null ? String.valueOf(maxParamObj) : null;
 
         if (isBlank(minParam) && isBlank(maxParam)) {
             return FieldValidationResult.ok();
         }
 
-        Long minValue = minParam != null ? parseValue(minParam) : null;
-        Long maxValue = maxParam != null ? parseValue(maxParam) : null;
+        BigDecimal minValue = minParam != null ? parseValue(minParam) : null;
+        BigDecimal maxValue = maxParam != null ? parseValue(maxParam) : null;
 
-        boolean belowMin = minValue != null && valueLong < minValue;
-        boolean aboveMax = maxValue != null && valueLong > maxValue;
+        boolean minExclusive = parseBoolean(params.get(MIN_EXCLUSIVE_PARAM));
+        boolean maxExclusive = parseBoolean(params.get(MAX_EXCLUSIVE_PARAM));
+
+        boolean belowMin = false;
+        if (minValue != null) {
+            int cmp = valueNumber.compareTo(minValue);
+            belowMin = minExclusive ? (cmp <= 0) : (cmp < 0);
+        }
+
+        boolean aboveMax = false;
+        if (maxValue != null) {
+            int cmp = valueNumber.compareTo(maxValue);
+            aboveMax = maxExclusive ? (cmp >= 0) : (cmp > 0);
+        }
 
         if (belowMin || aboveMax) {
-            return buildValidationResult(field, minValue, maxValue);
+            return buildValidationResult(field, minValue, maxValue, minExclusive, maxExclusive);
         }
 
         return FieldValidationResult.ok();
     }
 
-    private long parseValue(final String value) {
-        return parseLong(value.replace(NOW_YEAR_MACRO, 
-                Year.now(Clock.systemUTC()).toString()));
+    private BigDecimal parseValue(final String value) {
+        return new BigDecimal(value.replace(NOW_YEAR_MACRO,
+                                            Year.now(Clock.systemUTC()).toString()));
+    }
+
+    private boolean parseBoolean(final Object param) {
+        return param != null && Boolean.parseBoolean(String.valueOf(param));
     }
 
     private FieldValidationResult buildValidationResult(final ValidatableField field, 
-            final Long min, final Long max) {
+            final BigDecimal min, final BigDecimal max,
+            final boolean minExclusive, final boolean maxExclusive) {
         if (min == null && max == null) {
             throw new IllegalArgumentException("Both min and max cannot be null");
         }
 
         final String displayName = field.getDatasetFieldType().getDisplayName();
         if (min == null) {
-            return invalid(field, "isGreaterThanValue", displayName, max.toString());
+            final String errorCode = maxExclusive ? "isNotLessThanValue" : "isNotLessThanOrEqualToValue";
+            return invalid(field, errorCode, displayName, max.toString());
         }
         if (max == null) {
-            return invalid(field, "isLessThanValue", displayName, min.toString());
+            final String errorCode = minExclusive ? "isNotGreaterThanValue" : "isNotGreaterThanOrEqualToValue";
+            return invalid(field, errorCode, displayName, min.toString());
         }
 
-        return invalid(field, "isNotBetweenValues", displayName, min.toString(), 
+        final String errorCode = getErrorCodeForBothBounds(minExclusive, maxExclusive);
+        return invalid(field, errorCode, displayName, min.toString(),
                 max.toString());
+    }
+
+    private String getErrorCodeForBothBounds(final boolean minExclusive, final boolean maxExclusive) {
+        if (minExclusive && maxExclusive) {
+            return "isNotBetweenValuesBothBoundsExclusive";
+        } else if (minExclusive) {
+            return "isNotBetweenValuesUpperBoundInclusive";
+        } else if (maxExclusive) {
+            return "isNotBetweenValuesLowerBoundInclusive";
+        } else {
+            return "isNotBetweenValuesBothBoundsInclusive";
+        }
     }
 }

--- a/fairchive-webapp/src/test/java/edu/harvard/iq/dataverse/validation/field/validators/RangeValidatorTest.java
+++ b/fairchive-webapp/src/test/java/edu/harvard/iq/dataverse/validation/field/validators/RangeValidatorTest.java
@@ -15,6 +15,9 @@ import edu.harvard.iq.dataverse.persistence.dataset.DatasetFieldType;
 import edu.harvard.iq.dataverse.validation.field.FieldValidationResult;
 
 public class RangeValidatorTest {
+    
+    private static final String FIELD_TYPE_NAME = "foo";
+    private static final String FIELD_TYPE_TITLE = "FOO";
 
     private RangeValidator validator;
 
@@ -29,7 +32,7 @@ public class RangeValidatorTest {
         Map<String, Object> params = new HashMap<>();
         params.put(RangeValidator.MAX_PARAM, "2000");
 
-        DatasetField field = buildSimpleField("from", "1999");
+        DatasetField field = buildSimpleField("1999");
 
         // when
         FieldValidationResult result = validator.validate(field, params, null);
@@ -44,7 +47,7 @@ public class RangeValidatorTest {
         Map<String, Object> params = new HashMap<>();
         params.put(RangeValidator.MAX_PARAM, "1999");
 
-        DatasetField field = buildSimpleField("from", "1999");
+        DatasetField field = buildSimpleField("1999");
 
         // when
         FieldValidationResult result = validator.validate(field, params, null);
@@ -59,15 +62,15 @@ public class RangeValidatorTest {
         Map<String, Object> params = new HashMap<>();
         params.put(RangeValidator.MAX_PARAM, "1998");
 
-        DatasetField field = buildSimpleField("from", "1999");
+        DatasetField field = buildSimpleField("1999");
 
         // when
         FieldValidationResult result = validator.validate(field, params, null);
 
         // then
         assertThat(result.isOk()).isFalse();
-        assertThat(result.getErrorCode()).isEqualTo("isGreaterThanValue");
-        assertThat(result.getErrorArgs()).containsExactly("FROM", "1998");
+        assertThat(result.getErrorCode()).isEqualTo("isNotLessThanOrEqualToValue");
+        assertThat(result.getErrorArgs()).containsExactly(FIELD_TYPE_TITLE, "1998");
     }
 
     @Test
@@ -76,7 +79,7 @@ public class RangeValidatorTest {
         Map<String, Object> params = new HashMap<>();
         params.put(RangeValidator.MAX_PARAM, "#NOW_YEAR");
 
-        DatasetField field = buildSimpleField("from", Year.now(Clock.systemUTC()).minusYears(1).toString());
+        DatasetField field = buildSimpleField(Year.now(Clock.systemUTC()).minusYears(1).toString());
 
         // when
         FieldValidationResult result = validator.validate(field, params, null);
@@ -91,7 +94,7 @@ public class RangeValidatorTest {
         Map<String, Object> params = new HashMap<>();
         params.put(RangeValidator.MAX_PARAM, "#NOW_YEAR");
 
-        DatasetField field = buildSimpleField("from", Year.now(Clock.systemUTC()).toString());
+        DatasetField field = buildSimpleField(Year.now(Clock.systemUTC()).toString());
 
         // when
         FieldValidationResult result = validator.validate(field, params, null);
@@ -106,15 +109,15 @@ public class RangeValidatorTest {
         Map<String, Object> params = new HashMap<>();
         params.put(RangeValidator.MAX_PARAM, "#NOW_YEAR");
 
-        DatasetField field = buildSimpleField("from", Year.now(Clock.systemUTC()).plusYears(1).toString());
+        DatasetField field = buildSimpleField(Year.now(Clock.systemUTC()).plusYears(1).toString());
 
         // when
         FieldValidationResult result = validator.validate(field, params, null);
 
         // then
         assertThat(result.isOk()).isFalse();
-        assertThat(result.getErrorCode()).isEqualTo("isGreaterThanValue");
-        assertThat(result.getErrorArgs()).containsExactly("FROM", Year.now(Clock.systemUTC()).toString());
+        assertThat(result.getErrorCode()).isEqualTo("isNotLessThanOrEqualToValue");
+        assertThat(result.getErrorArgs()).containsExactly(FIELD_TYPE_TITLE, Year.now(Clock.systemUTC()).toString());
     }
 
     @Test
@@ -123,7 +126,7 @@ public class RangeValidatorTest {
         Map<String, Object> params = new HashMap<>();
         params.put(RangeValidator.MIN_PARAM, "1999");
 
-        DatasetField field = buildSimpleField("from", "2000");
+        DatasetField field = buildSimpleField("2000");
 
         // when
         FieldValidationResult result = validator.validate(field, params, null);
@@ -138,7 +141,7 @@ public class RangeValidatorTest {
         Map<String, Object> params = new HashMap<>();
         params.put(RangeValidator.MIN_PARAM, "1999");
 
-        DatasetField field = buildSimpleField("from", "1999");
+        DatasetField field = buildSimpleField("1999");
 
         // when
         FieldValidationResult result = validator.validate(field, params, null);
@@ -153,15 +156,15 @@ public class RangeValidatorTest {
         Map<String, Object> params = new HashMap<>();
         params.put(RangeValidator.MIN_PARAM, "1999");
 
-        DatasetField field = buildSimpleField("from", "1998");
+        DatasetField field = buildSimpleField("1998");
 
         // when
         FieldValidationResult result = validator.validate(field, params, null);
 
         // then
         assertThat(result.isOk()).isFalse();
-        assertThat(result.getErrorCode()).isEqualTo("isLessThanValue");
-        assertThat(result.getErrorArgs()).containsExactly("FROM", "1999");
+        assertThat(result.getErrorCode()).isEqualTo("isNotGreaterThanOrEqualToValue");
+        assertThat(result.getErrorArgs()).containsExactly(FIELD_TYPE_TITLE, "1999");
     }
 
     @Test
@@ -170,7 +173,7 @@ public class RangeValidatorTest {
         Map<String, Object> params = new HashMap<>();
         params.put(RangeValidator.MIN_PARAM, "#NOW_YEAR");
 
-        DatasetField field = buildSimpleField("from", Year.now(Clock.systemUTC()).plusYears(1).toString());
+        DatasetField field = buildSimpleField(Year.now(Clock.systemUTC()).plusYears(1).toString());
 
         // when
         FieldValidationResult result = validator.validate(field, params, null);
@@ -185,7 +188,7 @@ public class RangeValidatorTest {
         Map<String, Object> params = new HashMap<>();
         params.put(RangeValidator.MIN_PARAM, "#NOW_YEAR");
 
-        DatasetField field = buildSimpleField("from", Year.now(Clock.systemUTC()).toString());
+        DatasetField field = buildSimpleField(Year.now(Clock.systemUTC()).toString());
 
         // when
         FieldValidationResult result = validator.validate(field, params, null);
@@ -200,15 +203,15 @@ public class RangeValidatorTest {
         Map<String, Object> params = new HashMap<>();
         params.put(RangeValidator.MIN_PARAM, "#NOW_YEAR");
 
-        DatasetField field = buildSimpleField("from", Year.now(Clock.systemUTC()).minusYears(1).toString());
+        DatasetField field = buildSimpleField(Year.now(Clock.systemUTC()).minusYears(1).toString());
 
         // when
         FieldValidationResult result = validator.validate(field, params, null);
 
         // then
         assertThat(result.isOk()).isFalse();
-        assertThat(result.getErrorCode()).isEqualTo("isLessThanValue");
-        assertThat(result.getErrorArgs()).containsExactly("FROM", Year.now(Clock.systemUTC()).toString());
+        assertThat(result.getErrorCode()).isEqualTo("isNotGreaterThanOrEqualToValue");
+        assertThat(result.getErrorArgs()).containsExactly(FIELD_TYPE_TITLE, Year.now(Clock.systemUTC()).toString());
     }
 
     @Test
@@ -218,7 +221,7 @@ public class RangeValidatorTest {
         params.put(RangeValidator.MIN_PARAM, "1999");
         params.put(RangeValidator.MAX_PARAM, "2001");
 
-        DatasetField field = buildSimpleField("from", "2000");
+        DatasetField field = buildSimpleField("2000");
 
         // when
         FieldValidationResult result = validator.validate(field, params, null);
@@ -234,15 +237,15 @@ public class RangeValidatorTest {
         params.put(RangeValidator.MIN_PARAM, "1999");
         params.put(RangeValidator.MAX_PARAM, "2001");
 
-        DatasetField field = buildSimpleField("from", "2002");
+        DatasetField field = buildSimpleField("2002");
 
         // when
         FieldValidationResult result = validator.validate(field, params, null);
 
         // then
         assertThat(result.isOk()).isFalse();
-        assertThat(result.getErrorCode()).isEqualTo("isNotBetweenValues");
-        assertThat(result.getErrorArgs()).containsExactly("FROM", "1999", "2001");
+        assertThat(result.getErrorCode()).isEqualTo("isNotBetweenValuesBothBoundsInclusive");
+        assertThat(result.getErrorArgs()).containsExactly(FIELD_TYPE_TITLE, "1999", "2001");
     }
 
     @Test
@@ -252,22 +255,164 @@ public class RangeValidatorTest {
         params.put(RangeValidator.MIN_PARAM, "1999");
         params.put(RangeValidator.MAX_PARAM, "2001");
 
-        DatasetField field = buildSimpleField("from", "1998");
+        DatasetField field = buildSimpleField("1998");
 
         // when
         FieldValidationResult result = validator.validate(field, params, null);
 
         // then
         assertThat(result.isOk()).isFalse();
-        assertThat(result.getErrorCode()).isEqualTo("isNotBetweenValues");
-        assertThat(result.getErrorArgs()).containsExactly("FROM", "1999", "2001");
+        assertThat(result.getErrorCode()).isEqualTo("isNotBetweenValuesBothBoundsInclusive");
+        assertThat(result.getErrorArgs()).containsExactly(FIELD_TYPE_TITLE, "1999", "2001");
     }
 
-    private DatasetField buildSimpleField(String typeName, String value) {
+    @Test
+    public void validate__decimal_within_inclusive_range() {
+        // given
+        Map<String, Object> params = new HashMap<>();
+        params.put(RangeValidator.MIN_PARAM, "0.5");
+        params.put(RangeValidator.MAX_PARAM, "10.5");
+
+        DatasetField field = buildSimpleField("3.14");
+
+        // when
+        FieldValidationResult result = validator.validate(field, params, null);
+
+        // then
+        assertThat(result.isOk()).isTrue();
+    }
+
+    @Test
+    public void validate__decimal_equal_to_min_inclusive() {
+        // given
+        Map<String, Object> params = new HashMap<>();
+        params.put(RangeValidator.MIN_PARAM, "1.23");
+
+        DatasetField field = buildSimpleField("1.23");
+
+        // when
+        FieldValidationResult result = validator.validate(field, params, null);
+
+        // then
+        assertThat(result.isOk()).isTrue();
+    }
+
+    @Test
+    public void validate__decimal_equal_to_max_inclusive() {
+        // given
+        Map<String, Object> params = new HashMap<>();
+        params.put(RangeValidator.MAX_PARAM, "4.56");
+
+        DatasetField field = buildSimpleField("4.56");
+
+        // when
+        FieldValidationResult result = validator.validate(field, params, null);
+
+        // then
+        assertThat(result.isOk()).isTrue();
+    }
+
+    @Test
+    public void validate__equal_to_min_when_min_exclusive() {
+        // given
+        Map<String, Object> params = new HashMap<>();
+        params.put(RangeValidator.MIN_PARAM, "5.0");
+        params.put("min_exclusive", true);
+
+        DatasetField field = buildSimpleField("5.0");
+
+        // when
+        FieldValidationResult result = validator.validate(field, params, null);
+
+        // then
+        assertThat(result.isOk()).isFalse();
+        assertThat(result.getErrorCode()).isEqualTo("isNotGreaterThanValue");
+        assertThat(result.getErrorArgs()).containsExactly(FIELD_TYPE_TITLE, "5.0");
+    }
+
+    @Test
+    public void validate__equal_to_max_when_max_exclusive() {
+        // given
+        Map<String, Object> params = new HashMap<>();
+        params.put(RangeValidator.MAX_PARAM, "7.7");
+        params.put("max_exclusive", true);
+
+        DatasetField field = buildSimpleField("7.7");
+
+        // when
+        FieldValidationResult result = validator.validate(field, params, null);
+
+        // then
+        assertThat(result.isOk()).isFalse();
+        assertThat(result.getErrorCode()).isEqualTo("isNotLessThanValue");
+        assertThat(result.getErrorArgs()).containsExactly(FIELD_TYPE_TITLE, "7.7");
+    }
+
+    @Test
+    public void validate__equal_to_bounds_when_both_exclusive() {
+        // given
+        Map<String, Object> params = new HashMap<>();
+        params.put(RangeValidator.MIN_PARAM, "1.0");
+        params.put(RangeValidator.MAX_PARAM, "2.0");
+        params.put("min_exclusive", true);
+        params.put("max_exclusive", true);
+
+        DatasetField field = buildSimpleField("1.0");
+
+        // when
+        FieldValidationResult result = validator.validate(field, params, null);
+
+        // then
+        assertThat(result.isOk()).isFalse();
+        assertThat(result.getErrorCode()).isEqualTo("isNotBetweenValuesBothBoundsExclusive");
+        assertThat(result.getErrorArgs()).containsExactly(FIELD_TYPE_TITLE, "1.0", "2.0");
+    }
+
+    @Test
+    public void validate__not_in_range_max_exclusive() {
+        // given
+        Map<String, Object> params = new HashMap<>();
+        params.put(RangeValidator.MIN_PARAM, "1.0");
+        params.put(RangeValidator.MAX_PARAM, "2.0");
+        params.put("min_exclusive", false);
+        params.put("max_exclusive", true);
+
+        DatasetField field = buildSimpleField("2.1");
+
+        // when
+        FieldValidationResult result = validator.validate(field, params, null);
+
+        // then
+        assertThat(result.isOk()).isFalse();
+        assertThat(result.getErrorCode()).isEqualTo("isNotBetweenValuesLowerBoundInclusive");
+        assertThat(result.getErrorArgs()).containsExactly(FIELD_TYPE_TITLE, "1.0", "2.0");
+    }
+
+    @Test
+    public void validate__not_in_range_min_exclusive() {
+        // given
+        Map<String, Object> params = new HashMap<>();
+        params.put(RangeValidator.MIN_PARAM, "1.0");
+        params.put(RangeValidator.MAX_PARAM, "2.0");
+        params.put("min_exclusive", true);
+        params.put("max_exclusive", false);
+
+        DatasetField field = buildSimpleField("2.1");
+
+        // when
+        FieldValidationResult result = validator.validate(field, params, null);
+
+        // then
+        assertThat(result.isOk()).isFalse();
+        assertThat(result.getErrorCode()).isEqualTo("isNotBetweenValuesUpperBoundInclusive");
+        assertThat(result.getErrorArgs()).containsExactly(FIELD_TYPE_TITLE, "1.0", "2.0");
+    }
+    
+    private DatasetField buildSimpleField(String value) {
         DatasetField datasetField = new DatasetField();
         DatasetFieldType datasetFieldType = new DatasetFieldType();
-        datasetFieldType.setName(typeName);
-        datasetFieldType.setTitle(typeName.toUpperCase());
+        datasetFieldType.setName(FIELD_TYPE_NAME);
+        datasetFieldType.setTitle(FIELD_TYPE_TITLE);
         datasetField.setDatasetFieldType(datasetFieldType);
         datasetField.setValue(value);
         return datasetField;


### PR DESCRIPTION
`RangeValidator` not supports:
* decimal numbers (previously only integers),
* setting the exclusivity of bounds, each bound separately (prevously bounds were inclusive without the ability to change it).
