### PR TITLE
Closes #3095: Creating datasets hang because geolocalization map was …

### DIFF
--- a/fairchive-webapp/src/main/webapp/resources/js/dvjs.js
+++ b/fairchive-webapp/src/main/webapp/resources/js/dvjs.js
@@ -140,6 +140,11 @@ function initDvJS() {
     }
 
     function initializeMapInView(key, data) {
+      const el = document.getElementById(key);
+      const mapVisible = el && el.offsetParent !== null;
+      if (!mapVisible) {
+        return;
+      }
       data.leafMap = L.map(key, INIT_MAP_OPTS);
       let map = data.leafMap;
       map.invalidateSize();


### PR DESCRIPTION
…initialized to early during saving


