### PR TITLE
Closes #3111: Change tick marks on "Metrics" page

### DIFF
--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/metrics/ChartCreator.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/metrics/ChartCreator.java
@@ -32,6 +32,8 @@ public class ChartCreator {
         BarChartModel model = createBarModel(yearlyMetrics, title, xLabel, yLabel);
         model.addSeries(createYearlySeries(yearlyMetrics, yLabel));
 
+        formatYAxis(model, yearlyMetrics, yLabel);
+
         return model;
     }
 
@@ -50,6 +52,8 @@ public class ChartCreator {
         BarChartModel model = createBarModel(yearlyCumulativeMetrics, title, xLabel, yLabel);
         model.addSeries(createYearlySeries(yearlyCumulativeMetrics, yLabel));
 
+        formatYAxis(model, yearlyCumulativeMetrics, yLabel);
+
         return model;
     }
 
@@ -63,6 +67,8 @@ public class ChartCreator {
 
         BarChartModel model = createBarModel(chartMetrics, title, xLabel, yLabel);
         model.addSeries(createMonthlySeries(chartMetrics, yLabel));
+
+        formatYAxis(model, chartMetrics, yLabel);
 
         return model;
     }
@@ -84,14 +90,7 @@ public class ChartCreator {
         xAxis.setLabel(xAxisLabel);
         xAxis.setTickAngle(45);
 
-        Long maxCountMetric = calculateMaxCountMetric(metrics);
-
-        Axis yAxis = model.getAxis(AxisType.Y);
-        yAxis.setLabel(yAxisLabel);
-        yAxis.setMin(0);
-        yAxis.setTickFormat("%d");
-        yAxis.setMax(retrieveTickForMaxDatasetCountValue(maxCountMetric));
-        yAxis.setTickCount(TICKS_COUNT + 1);
+        formatYAxis(model, metrics, yAxisLabel);
 
         return model;
     }
@@ -149,5 +148,38 @@ public class ChartCreator {
                         metric.getCount()));
 
         return chartSeries;
+    }
+
+    private long roundMaxChartValue(long value) {
+        double exactStep = value / 5.0;
+        double scale = Math.pow(10, Math.floor(Math.log10(exactStep)));
+        double m = exactStep / scale;
+        double roundM;
+
+        if (m <= 1) {
+            roundM = 1.0;
+        } else if (m <= 2) {
+            roundM = 2.0;
+        } else if (m <= 5) {
+            roundM = 5.0;
+        } else {
+            roundM = 10.0;
+        }
+
+        double roundStep = roundM * scale;
+        long maxValue = Math.round(roundStep) * 5;
+
+        return maxValue;
+    }
+
+    private void formatYAxis(BarChartModel model, List<ChartMetrics> metrics, String yAxisLabel) {
+        Long maxCountMetric = calculateMaxCountMetric(metrics);
+
+        Axis yAxis = model.getAxis(AxisType.Y);
+        yAxis.setLabel(yAxisLabel);
+        yAxis.setMin(0);
+        yAxis.setTickFormat("%d");
+        yAxis.setMax(roundMaxChartValue(retrieveTickForMaxDatasetCountValue(maxCountMetric)));
+        yAxis.setTickCount(TICKS_COUNT + 1);
     }
 }

--- a/fairchive-webapp/src/test/java/edu/harvard/iq/dataverse/metrics/ChartCreatorTest.java
+++ b/fairchive-webapp/src/test/java/edu/harvard/iq/dataverse/metrics/ChartCreatorTest.java
@@ -1,14 +1,14 @@
 package edu.harvard.iq.dataverse.metrics;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.primefaces.model.chart.AxisType;
 import org.primefaces.model.chart.BarChartModel;
 import org.primefaces.model.chart.ChartSeries;
 
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -48,43 +48,34 @@ public class ChartCreatorTest {
         );
     }
 
-    @Test
-    public void verifyRoundMaxChartValue() {
+    @ParameterizedTest
+    @CsvSource({
+            "1,     5",
+            "12,    25",
+            "123,   250",
+            "1234,  2500",
+            "12345, 25000",
+            "21,    25",
+            "321,   500",
+            "4321,  5000",
+            "54321, 100000",
+            "2999,  5000",
+            "49999, 100000",
+            "9999,  25000",
+    })
+    public void verifyRoundMaxChartValue(long givenValue, long expectedValue) {
         // given
-
-        List<Map<String, Long>> values = Arrays.asList(
-            createValuepair(1L, 5L),
-            createValuepair(12L, 25L),
-            createValuepair(123L, 250L),
-            createValuepair(1234L, 2500L),
-            createValuepair(12345L, 25000L),
-            createValuepair(21L, 25L),
-            createValuepair(321L, 500L),
-            createValuepair(4321L, 5000L),
-            createValuepair(54321L, 100000L),
-            createValuepair(2999L, 5000L),
-            createValuepair(499999L, 1000000L),
-            createValuepair(9999L, 25000L)
+        ChartCreator chartCreator = new ChartCreator();
+        List<ChartMetrics> chartMetrics = Arrays.asList(
+            new ChartMetrics(2025, 11, givenValue)
         );
 
-        // execute & assert
+        // when
+        BarChartModel createdModel = chartCreator.createYearlyChart(chartMetrics, "publishedDatasets");
 
-        for (Map<String, Long> value : values) {
-            ChartCreator chartCreator = new ChartCreator();
-            List<ChartMetrics> chartMetrics = Arrays.asList(
-                new ChartMetrics(2025, 11, value.get("given"))
-            );
-            BarChartModel createdModel = chartCreator.createYearlyChart(chartMetrics, "publishedDatasets");
-
-            assertEquals(value.get("expected"), getMaximumYaxisHeight(createdModel));
-        }
+        //then
+        assertEquals(expectedValue, getMaximumYaxisHeight(createdModel));
 
     }
 
-    private Map<String, Long> createValuepair(long given, long expected) {
-        Map<String, Long> dict = new HashMap<>(); 
-        dict.put("given", given);
-        dict.put("expected", expected);
-        return dict;
-    }
 }

--- a/fairchive-webapp/src/test/java/edu/harvard/iq/dataverse/metrics/ChartCreatorTest.java
+++ b/fairchive-webapp/src/test/java/edu/harvard/iq/dataverse/metrics/ChartCreatorTest.java
@@ -22,7 +22,7 @@ public class ChartCreatorTest {
         BarChartModel createdModel = chartCreator.createYearlyChart(chartMetrics, "publishedDatasets");
 
         //then
-        assertEquals(84L, getMaximumYaxisHeight(createdModel));
+        assertEquals(100L, getMaximumYaxisHeight(createdModel));
         assertEquals(7, getYearValueFromModel(createdModel, 2018));
         assertEquals(78, getYearValueFromModel(createdModel, 2019));
         assertEquals(8, getYearValueFromModel(createdModel, 2020));

--- a/fairchive-webapp/src/test/java/edu/harvard/iq/dataverse/metrics/ChartCreatorTest.java
+++ b/fairchive-webapp/src/test/java/edu/harvard/iq/dataverse/metrics/ChartCreatorTest.java
@@ -6,7 +6,9 @@ import org.primefaces.model.chart.BarChartModel;
 import org.primefaces.model.chart.ChartSeries;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -44,5 +46,45 @@ public class ChartCreatorTest {
                 new ChartMetrics(2019, 1, 78L),
                 new ChartMetrics(2020, 12, 8L)
         );
+    }
+
+    @Test
+    public void verifyRoundMaxChartValue() {
+        // given
+
+        List<Map<String, Long>> values = Arrays.asList(
+            createValuepair(1L, 5L),
+            createValuepair(12L, 25L),
+            createValuepair(123L, 250L),
+            createValuepair(1234L, 2500L),
+            createValuepair(12345L, 25000L),
+            createValuepair(21L, 25L),
+            createValuepair(321L, 500L),
+            createValuepair(4321L, 5000L),
+            createValuepair(54321L, 100000L),
+            createValuepair(2999L, 5000L),
+            createValuepair(499999L, 1000000L),
+            createValuepair(9999L, 25000L)
+        );
+
+        // execute & assert
+
+        for (Map<String, Long> value : values) {
+            ChartCreator chartCreator = new ChartCreator();
+            List<ChartMetrics> chartMetrics = Arrays.asList(
+                new ChartMetrics(2025, 11, value.get("given"))
+            );
+            BarChartModel createdModel = chartCreator.createYearlyChart(chartMetrics, "publishedDatasets");
+
+            assertEquals(value.get("expected"), getMaximumYaxisHeight(createdModel));
+        }
+
+    }
+
+    private Map<String, Long> createValuepair(long given, long expected) {
+        Map<String, Long> dict = new HashMap<>(); 
+        dict.put("given", given);
+        dict.put("expected", expected);
+        return dict;
     }
 }


### PR DESCRIPTION
The goal was achieved by rounding the max value on the Y axis. The rounding is done using an algorithm provided by @wfenrich 

<img width="983" height="900" alt="image" src="https://github.com/user-attachments/assets/6da02ed9-047a-4251-a6ae-0498777270fc" />


The bug with the values on the Y axis being cut off is not fixed - it was decided it would take too much effort for such a relatively rare and harmless bug. These values are not rendered in plain HTML but rather in `<canvas>`, which means they can't be fixed via simple CSS. Moreover, this bug seems to only manifest itself when the user modifies default font size in browser (our WCAG compliance font size tool does not trigger this issue).