### PR TITLE
Closes #3116: Fix import core dataverse using json, fix problem with …

### DIFF
--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/api/imports/ImportServiceBean.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/api/imports/ImportServiceBean.java
@@ -148,13 +148,10 @@ public class ImportServiceBean {
             ds.setOwner(owner);
             ds.getLatestVersion().setDatasetFields(ds.getLatestVersion().initDatasetFields());
 
-            // Check data against validation contraints
+            // Check data against validation constraints
             DatasetVersion versionToValidate = ds.getVersions().get(0);
-            List<FieldValidationResult> fieldValidationResults = fieldValidationService.validateFieldsOfDatasetVersion(versionToValidate);
-            if (!fieldValidationResults.isEmpty()) {
-                // For migration and harvest, add NA for missing required values
-                fieldValidationResults.forEach(r -> ((DatasetField) r.getField()).setFieldValue(DatasetField.NA_VALUE));
-            }
+            // For migration and harvest, remove invalid dataset fields
+            removeInvalidFieldsFromDataset(versionToValidate);
 
             // A Global ID is required, in order for us to be able to harvest and import
             // this dataset:
@@ -210,6 +207,27 @@ public class ImportServiceBean {
             logger.fine("Failed to import harvested dataset: " + ex.getClass() + ": " + ex.getMessage());
             throw new ImportException(
                     String.format("Failed to import harvested dataset: %s (%s)", ex.getClass(), ex.getMessage()), ex);
+        }
+    }
+
+    private void removeInvalidFieldsFromDataset(DatasetVersion  datasetVersion) {
+        // We do not expect the validation-removal process to require many iterations.
+        // 10 attempts is a safe upper bound to prevent accidental infinite loops.
+        // Under normal circumstances, all invalid fields should be resolved in first pass
+        // Only dependent fields may use more passes
+        int validationAttemptNumber = 0;
+        while (validationAttemptNumber <= 10) {
+            List<FieldValidationResult> fieldValidationResults = fieldValidationService.validateFieldsOfDatasetVersion(datasetVersion);
+            if (fieldValidationResults.isEmpty()) {
+                break;
+            }
+
+            for (FieldValidationResult fieldValidationResult : fieldValidationResults) {
+                DatasetField invalidField = (DatasetField)fieldValidationResult.getField();
+                datasetVersion.getDatasetFields().remove(invalidField);
+            }
+
+            validationAttemptNumber++;
         }
     }
 

--- a/fairchive-webapp/src/test/java/edu/harvard/iq/dataverse/api/imports/ImportServiceBeanTest.java
+++ b/fairchive-webapp/src/test/java/edu/harvard/iq/dataverse/api/imports/ImportServiceBeanTest.java
@@ -1,0 +1,146 @@
+package edu.harvard.iq.dataverse.api.imports;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.persistence.EntityManager;
+
+import edu.harvard.iq.dataverse.DatasetDao;
+import edu.harvard.iq.dataverse.dataset.DatasetService;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import edu.harvard.iq.dataverse.EjbDataverseEngine;
+import edu.harvard.iq.dataverse.engine.command.DataverseRequest;
+import edu.harvard.iq.dataverse.engine.command.impl.CreateHarvestedDatasetCommand;
+import edu.harvard.iq.dataverse.persistence.GlobalId;
+import edu.harvard.iq.dataverse.persistence.dataset.Dataset;
+import edu.harvard.iq.dataverse.persistence.dataset.DatasetField;
+import edu.harvard.iq.dataverse.persistence.dataset.DatasetFieldType;
+import edu.harvard.iq.dataverse.persistence.dataset.DatasetVersion;
+import edu.harvard.iq.dataverse.persistence.dataverse.Dataverse;
+import edu.harvard.iq.dataverse.persistence.harvest.HarvestingClient;
+import edu.harvard.iq.dataverse.validation.DatasetFieldValidationService;
+import edu.harvard.iq.dataverse.validation.field.FieldValidationResult;
+import edu.harvard.iq.dataverse.validation.field.ValidationDescriptor;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static java.util.Arrays.asList;
+
+@ExtendWith(MockitoExtension.class)
+class ImportServiceBeanTest {
+
+    @Mock
+    private EntityManager em;
+
+    @Mock
+    private EjbDataverseEngine engineSvc;
+
+    @Mock
+    private DatasetService datasetService;
+
+    @Mock
+    private HarvestedJsonParser harvestedJsonParser;
+
+    @Mock
+    private DatasetFieldValidationService fieldValidationService;
+
+    @InjectMocks
+    private ImportServiceBean importServiceBean;
+
+    private DataverseRequest dataverseRequest;
+    private HarvestingClient harvestingClient;
+    private Dataverse dataverse;
+    private String harvestIdentifier;
+    private String jsonMetadata;
+
+    @BeforeEach
+    void setUp() {
+        // Setup common test data
+        dataverseRequest = mock(DataverseRequest.class);
+        dataverse = new Dataverse();
+        dataverse.setId(1L);
+        dataverse.setAlias("testDataverse");
+
+        harvestingClient = new HarvestingClient();
+        harvestingClient.setDataverse(dataverse);
+
+        harvestIdentifier = "test:123";
+        jsonMetadata = "{\"datasetVersion\":{\"metadataBlocks\":{}}}";
+    }
+
+    @Test
+    void shouldRemoveInvalidFieldsWhenImportingDataverseJson() throws Exception {
+        // Given
+        Dataset dataset = createDatasetWithInvalidFields();
+        DatasetVersion datasetVersion = dataset.getLatestVersion();
+
+        DatasetField invalidField = createDatasetField(1L, "invalidField");
+        DatasetField validField = createDatasetField(2L,"fieldName");
+
+        List<DatasetField> datasetFields = new ArrayList<>(asList(validField, invalidField));
+        datasetVersion.setDatasetFields(datasetFields);
+
+        FieldValidationResult invalidFieldResult = mock(FieldValidationResult.class);
+        when(invalidFieldResult.getField()).thenReturn(invalidField);
+        List<FieldValidationResult> validationResults = asList(invalidFieldResult);
+
+        when(harvestedJsonParser.parseDataset(jsonMetadata)).thenReturn(dataset);
+        when(datasetService.findByGlobalId(anyString())).thenReturn(null);
+        when(fieldValidationService.validateFieldsOfDatasetVersion(datasetVersion))
+                .thenReturn(validationResults);
+        when(engineSvc.submit(any(CreateHarvestedDatasetCommand.class))).thenReturn(dataset);
+
+        // When
+        Dataset result = importServiceBean.doImportHarvestedDataset(
+                dataverseRequest,
+                harvestingClient,
+                harvestIdentifier,
+                HarvestImporterType.DATAVERSE_JSON,
+                jsonMetadata
+        );
+
+        // Then
+        Assertions.assertThat(result).isNotNull();
+        Assertions.assertThat(datasetVersion.getDatasetFields())
+                .hasSize(1);
+        Assertions.assertThat(datasetVersion.getDatasetFields())
+                .contains(validField);
+        Assertions.assertThat(datasetVersion.getDatasetFields())
+                .doesNotContain(invalidField);
+    }
+
+    private Dataset createDatasetWithInvalidFields() {
+        Dataset dataset = new Dataset();
+        dataset.setId(100L);
+        dataset.setGlobalId(new GlobalId("doi:10.5072/FK2/TEST123"));
+
+        DatasetVersion version = new DatasetVersion();
+        version.setDataset(dataset);
+        version.setVersionState(DatasetVersion.VersionState.RELEASED);
+
+        dataset.setVersions(new ArrayList<>(asList(version)));
+
+        return dataset;
+    }
+
+    private DatasetField createDatasetField(Long id, String fieldName) {
+        DatasetField field = new DatasetField();
+        field.setId(id);
+        DatasetFieldType fieldType = new DatasetFieldType();
+        fieldType.setId(id);
+        fieldType.setName(fieldName);
+        field.setDatasetFieldType(fieldType);
+        return field;
+    }
+}


### PR DESCRIPTION
…… (#3117)

* Closes #3116: Fix import core dataverse using json, fix problem with validation on required geo localization field. Removed setting NA value for invalid fields and replace it with removing invalid fields from datasets

* Closes #3117: Use recursive validation in case any new errors appears after remove current invalid field

* Closes #3117: Rename variable add comment about validationAttemptNumber

---------


