### PR TITLE
Closes #3131: Add help to map component

### DIFF
--- a/fairchive-webapp/src/main/webapp/resources/js/dvjs.js
+++ b/fairchive-webapp/src/main/webapp/resources/js/dvjs.js
@@ -242,6 +242,10 @@ function initDvJS() {
       }
 
       createTrashBinControl(map, data);
+
+      if (data.drawTools.allowPolygon) {
+        createMapEditInfoControl(map, data);
+      }
     }
 
     function createBaseEditControls() {
@@ -352,6 +356,44 @@ function initDvJS() {
 
        map.addControl(new L.TrashBinControl());
      }
+
+    function createMapEditInfoControl(map, data) {
+      L.MapEditInfoControl = L.EditControl.extend({
+        options: {
+          position: 'topright',
+          callback: function () {
+            var isVisible = map.description.style.display === 'block';
+            map.description.style.display = isVisible ? 'none' : 'block';
+          },
+          title: 'Show/Hide info',
+          html: `
+            <svg width="45" height="45" viewBox="0 0 100 100" style="margin-left:1px">
+              <circle cx="32" cy="32" r="25" fill="none" stroke="black" stroke-width="4"/>
+              <path d="M 26.282 24.445 C 26.282 16.445 39.992 14.308 39.992 24.308 C 39.992 32.308 31.624 31.881 31.624 39.881" fill="none" stroke="black" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+              <circle cx="32" cy="48" r="2.5" fill="black"/>
+            </svg>
+`
+        },
+        onAdd: function (map) {
+          var container = L.DomUtil.create('div', 'map-description-container');
+          var button = L.EditControl.prototype.onAdd.call(this, map);
+          var description = L.DomUtil.create('div', 'map-description', container);
+          container.appendChild(button);
+
+          description.innerHTML = `
+              <div><strong>Instructions</strong></div>
+              <p>To finish creating a polygon, you need to close it. You can do this by placing the final point on the same location as the first point of the polygon.</p>
+              <p>If the polygon turns red while you are drawing it, the new segment would cause the shape to self-intersect. Self-intersecting polygons are not allowed. Move the point to a different location so that the polygon does not cross itself.</p>
+        ` ;
+          description.style.display = 'none';
+          map.description = description;
+
+          return container;
+        }
+      });
+
+      map.addControl(new L.MapEditInfoControl());
+    }
 
     function createdShape(e, data) {
         let layer = e.layer;

--- a/fairchive-webapp/src/main/webapp/resources/vecler/theme-base.scss
+++ b/fairchive-webapp/src/main/webapp/resources/vecler/theme-base.scss
@@ -601,11 +601,35 @@ a[id$=advsearchlink] {
     margin-top: .5em;
 }
 
+.leaflet-control-container .map-description-container {
+    
+    .map-description {
+        background: white;
+        font-family: $font-main;
+        font-size: 2em;
+        padding: 5px;
+        border: 2px solid rgba(0, 0, 0, 0.2);
+        background-clip: padding-box;
+        
+        p:last-child {
+            margin-bottom: 0;
+        }
+    }
+
+    .leaflet-bar {
+        margin: 0;
+    }
+}
+
 @media screen and (max-width: $screen-xs-max) {
 	.geo-map {
 		max-width: calc((100vw - 90px) * 0.75);
 		height: calc((100vw - 90px) * 0.75);
 	}
+
+    .leaflet-control-container .map-description-container .map-description {
+        max-width: calc((100vw - 90px) * 0.75 - 100px);
+    }
 }
 
 @media screen and (min-width: $screen-sm-min) {
@@ -613,6 +637,10 @@ a[id$=advsearchlink] {
 		max-width: 364px;
 		height: 364px;
 	}
+
+    .leaflet-control-container .map-description-container .map-description {
+        max-width: 264px;
+    }
 }
 
 @media screen and (min-width: $screen-md-min) {
@@ -620,6 +648,10 @@ a[id$=advsearchlink] {
 		max-width: 487px;
 		height: 487px;
 	}
+
+    .leaflet-control-container .map-description-container .map-description {
+        max-width: 387px;
+    }
 }
 
 @media screen and (min-width: $screen-lg-min) {
@@ -627,6 +659,10 @@ a[id$=advsearchlink] {
 		max-width: 600px;
 		height: 600px;
 	}
+
+    .leaflet-control-container .map-description-container .map-description {
+        max-width: 500px;
+    }
 }
 
 .leaflet-control-container {


### PR DESCRIPTION
Since info only describe things related to creating a polygon, we render it only on create dataset page and edit dataset metadata page.

The whole thing looks like in below screenshots:

<img width="608" height="633" alt="Zrzut ekranu z 2026-03-03 09-46-02" src="https://github.com/user-attachments/assets/ad671ead-76a0-43ab-9536-50a4e33eb670" />

<img width="608" height="633" alt="Zrzut ekranu z 2026-03-03 09-45-56" src="https://github.com/user-attachments/assets/d5386139-6271-442f-8a47-f016b43b2d83" />
