### PR TITLE
3265 upload a file exceeding file size limit

### DIFF
--- a/fairchive-persistence/src/main/resources/Bundle_en.properties
+++ b/fairchive-persistence/src/main/resources/Bundle_en.properties
@@ -1459,6 +1459,7 @@ dataset.configureBtn=Configure
 dataset.pageTitle=Add New Dataset
 dataset.editBtn=Edit
 dataset.editBtn.itemLabel.upload=Files (Upload)
+dataset.editBtn.itemLabel.uploadIgnoringLimit=Files (Upload ingoring limits)
 dataset.editBtn.itemLabel.metadata=Metadata
 dataset.editBtn.itemLabel.selectGuestbook=Select Guestbook
 dataset.editBtn.itemLabel.permissions=Permissions

--- a/fairchive-persistence/src/main/resources/Bundle_en.properties
+++ b/fairchive-persistence/src/main/resources/Bundle_en.properties
@@ -2473,6 +2473,7 @@ dataset.file.uploadWarning=upload warning
 dataset.file.uploadScannerWarning=Found virus in one of uploaded files
 dataset.file.uploadWorked=upload worked
 dataset.file.uploadBatchTooBig=The batch size exceeds the limit of {0}.
+dataset.file.uploadFileTooBig=The file size exceeds the limit of {0}.
 dataset.file.zip.unpack.failure=Failed to unpack Zip file. (Unknown Character Set used in a file name?) Saving the file as is.
 dataset.file.zip.unzip.failure=Failed to unzip the file. Saving the file as is.
 dataset.file.zip.uploadFileSizeLimit.exceeded=One of the unzipped files exceeds the size limit resorting to saving the file as is, zipped.

--- a/fairchive-persistence/src/main/resources/Bundle_pl.properties
+++ b/fairchive-persistence/src/main/resources/Bundle_pl.properties
@@ -2442,6 +2442,7 @@ dataset.file.uploadWarning=b\u0142\u0105d przy przesy\u0142aniu
 dataset.file.uploadScannerWarning=Znaleziono wirusa w jednym z przes\u0142anych plik\u00F3w
 dataset.file.uploadWorked=przesy\u0142anie zako\u0144czone powodzeniem
 dataset.file.uploadBatchTooBig=Rozmiar transzy przekracza limit wynosz\u0105cy {0}.
+dataset.file.uploadFileTooBig=Rozmiar pliku przekracza limit wynosz\u0105cy {0}.
 dataset.file.zip.unpack.failure=Nie uda\u0142o si\u0119 rozpakowa\u0107 archiwum zip (nieznany zestaw znak\u00F3w u\u017Cyty w nazwie pliku?). Plik zapisany w oryginalnym formacie.
 dataset.file.zip.unzip.failure=Nie uda\u0142o si\u0119 rozpakowa\u0107 archiwum zip. Plik zapisany w oryginalnym formacie.
 dataset.file.zip.uploadFileSizeLimit.exceeded=Co najmniej jeden z plik\u00F3w zawarty w archiwum zip po rozpakowaniu przekracza maksymaln\u0105 dozwolon\u0105 wielko\u015B\u0107. Archiwum nie zostanie rozpakowane.

--- a/fairchive-persistence/src/main/resources/Bundle_pl.properties
+++ b/fairchive-persistence/src/main/resources/Bundle_pl.properties
@@ -1438,6 +1438,7 @@ dataset.configureBtn=Skonfiguruj
 dataset.pageTitle=Dodaj nowy zbi\u00F3r danych
 dataset.editBtn=Edytuj
 dataset.editBtn.itemLabel.upload=Pliki (przesy\u0142anie)
+dataset.editBtn.itemLabel.uploadIgnoringLimit=Pliki (przesy\u0142anie bez limit\u00F3w)
 dataset.editBtn.itemLabel.metadata=Metadane
 dataset.editBtn.itemLabel.selectGuestbook=Przypisz Ksi\u0119g\u0119 Go\u015Bci
 dataset.editBtn.itemLabel.permissions=Uprawnienia

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
@@ -363,6 +363,10 @@ public class DatasetPage implements Serializable {
     public boolean isSessionUserAuthenticated() {
         return session.isUserLoggedIn();
     }
+    
+    public boolean isSuperuserLoggedIn() {
+        return this.session.isSuperUserLoggedIn();
+    }
 
     public boolean hasAnythingToUningest() {
         return this.dataset.hasUningestableFiles();

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/datafile/page/EditDatafilesPage.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/datafile/page/EditDatafilesPage.java
@@ -177,8 +177,9 @@ public class EditDatafilesPage implements java.io.Serializable {
 
     private boolean saveEnabled = false;
 
-    private Long maxFileUploadSizeInBytes = null;
-    private Long multipleUploadFilesLimit = null;
+    private long maxFileUploadSizeInBytes = Long.MAX_VALUE;
+    private long multipleUploadFilesLimit = Long.MAX_VALUE;
+    private long singleUploadBatchMaxSize = Long.MAX_VALUE;
 
     private List<SelectItem> termsOfUseSelectItems;
     private List<FileMetadata> selectedFiles;
@@ -284,15 +285,19 @@ public class EditDatafilesPage implements java.io.Serializable {
         return this.mode;
     }
 
-    public Long getMaxFileUploadSizeInBytes() {
+    public long getMaxFileUploadSizeInBytes() {
         return this.maxFileUploadSizeInBytes;
     }
 
     // The number of files the GUI user is allowed to upload in one batch,
     // via drag-and-drop, or through the file select dialog. Now configurable
     // in the Settings table.
-    public Long getMaxNumberOfFiles() {
+    public long getMaxNumberOfFiles() {
         return this.multipleUploadFilesLimit;
+    }
+    
+    public long getSingleUploadBatchMaxSize() {
+        return this.singleUploadBatchMaxSize;
     }
 
     public String getGlobalId() {
@@ -457,25 +462,29 @@ public class EditDatafilesPage implements java.io.Serializable {
      *  This may be null, signifying unlimited download size.
      */
     public String getHumanMaxFileUploadSize() {
-        return getMaxFileUploadSizeInBytes() == null
-                ? EMPTY
-                : bytesToHumanReadable(getMaxFileUploadSizeInBytes());
+        return bytesToHumanReadable(this.maxFileUploadSizeInBytes);
     }
 
     public boolean isUnlimitedUploadFileSize() {
-        return this.maxFileUploadSizeInBytes == null;
+        return this.maxFileUploadSizeInBytes == Long.MAX_VALUE;
+    }
+    
+    public boolean isBatchSizeSet() {
+    	return this.singleUploadBatchMaxSize < Long.MAX_VALUE;
     }
 
     public String getHumanMaxBatchUploadSize() {
-        Long batchSize = getMaxBatchSize();
-        return batchSize == null || batchSize.equals(0L)
-                ? EMPTY
-                : bytesToHumanReadable(batchSize);
+        return bytesToHumanReadable(this.singleUploadBatchMaxSize);
     }
 
     public String getUploadBatchTooBigMessage() {
         return getStringFromBundle("dataset.file.uploadBatchTooBig", 
                 getHumanMaxBatchUploadSize());
+    }
+    
+    public String getUploadFileTooBigMessage() {
+        return getStringFromBundle("dataset.file.uploadFileTooBig", 
+        		getHumanMaxFileUploadSize());
     }
 
     public String getUploadBatchFileCountTooBigMessage() {
@@ -500,8 +509,9 @@ public class EditDatafilesPage implements java.io.Serializable {
             return this.permissionsWrapper.notFound();
         }
 
-        this.maxFileUploadSizeInBytes = this.settings.getValueForKeyAsLong(Key.MaxFileUploadSizeInBytes);
-        this.multipleUploadFilesLimit = this.settings.getValueForKeyAsLong(Key.MultipleUploadFilesLimit);
+        this.maxFileUploadSizeInBytes = this.settings.getValueForKeyAsLong(Key.MaxFileUploadSizeInBytes, Long.MAX_VALUE);
+        this.multipleUploadFilesLimit = this.settings.getValueForKeyAsLong(Key.MultipleUploadFilesLimit, Long.MAX_VALUE);
+        this.singleUploadBatchMaxSize = this.settings.getValueForKeyAsLong(Key.SingleUploadBatchMaxSize, Long.MAX_VALUE);
         this.workingVersion = version;
         this.dataset = version.getDataset();
         this.mode = FileEditMode.CREATE;
@@ -521,8 +531,9 @@ public class EditDatafilesPage implements java.io.Serializable {
         this.uploadedFiles = new ArrayList<>();
         cleanupTempFiles();
 
-        this.maxFileUploadSizeInBytes = this.settings.getValueForKeyAsLong(Key.MaxFileUploadSizeInBytes);
-        this.multipleUploadFilesLimit = this.settings.getValueForKeyAsLong(Key.MultipleUploadFilesLimit);
+        this.maxFileUploadSizeInBytes = this.settings.getValueForKeyAsLong(Key.MaxFileUploadSizeInBytes, Long.MAX_VALUE);
+        this.multipleUploadFilesLimit = this.settings.getValueForKeyAsLong(Key.MultipleUploadFilesLimit, Long.MAX_VALUE);
+        this.singleUploadBatchMaxSize = this.settings.getValueForKeyAsLong(Key.SingleUploadBatchMaxSize, Long.MAX_VALUE);
         this.termsOfUseSelectItems = this.termsOfUseSelectItemsFactory.buildLicenseSelectItems();
 
         if (this.dataset.getId() != null) {
@@ -1049,27 +1060,23 @@ public class EditDatafilesPage implements java.io.Serializable {
         this.hasDuplicates = hasDuplicatesInUploadedFiles(this.newFiles);
         this.hasReplacements = !listReplacements().isEmpty();
     }
-
-    public Long getMaxBatchSize() {
-        return this.settings.getValueForKeyAsLong(Key.SingleUploadBatchMaxSize);
+    
+    private boolean sizeOfFileExceedsLimit(final long fileSize) {
+        return isSuperuserLoggedIn() && this.ignoringMaxUploadLimit
+            ? false
+            : fileSize > this.maxFileUploadSizeInBytes;
     }
     
-    private boolean sizeExceedsLimit(final long fileSize) {
-        if (isSuperuserLoggedIn() && this.ignoringMaxUploadLimit) {
-            return false;
-        } else {
-            return getMaxBatchSize() > 0
-                    && (this.currentBatchSize + fileSize) > getMaxBatchSize();
-        }
+    private boolean sizeOfBatchExceedsLimit(final long fileSize) {
+        return isSuperuserLoggedIn() && this.ignoringMaxUploadLimit
+            ? false
+            : (this.currentBatchSize + fileSize) > this.singleUploadBatchMaxSize;
     }
 
     private boolean numberOfFilesExceedsLimit() {
-        if (isSuperuserLoggedIn() && this.ignoringMaxUploadLimit) {
-            return false;
-        } else {
-            return getMaxNumberOfFiles() > 0
-                    && newFiles.size() >= getMaxNumberOfFiles();
-        }
+        return isSuperuserLoggedIn() && this.ignoringMaxUploadLimit
+            ? false
+            : newFiles.size() >= this.multipleUploadFilesLimit;
     }
 
     /**
@@ -1079,7 +1086,10 @@ public class EditDatafilesPage implements java.io.Serializable {
         final UploadedFile uploadedFile = event.getFile();
         final long fileSize = uploadedFile.getSize();
 
-        if (sizeExceedsLimit(fileSize)) {
+        if (sizeOfFileExceedsLimit(fileSize)) {
+            this.uploadWarningMessage = getUploadFileTooBigMessage();
+            this.uploadComponentId = event.getComponent().getClientId();
+        } else if (sizeOfBatchExceedsLimit(fileSize)) {
             this.uploadWarningMessage = getUploadBatchTooBigMessage();
             this.uploadComponentId = event.getComponent().getClientId();
         } else if (numberOfFilesExceedsLimit()) {
@@ -1727,8 +1737,6 @@ public class EditDatafilesPage implements java.io.Serializable {
             final Long fileId = fileMetadata.getDataFile().getId();
 
             if (selectedFileIds.contains(fileId)) {
-                logger.fine("Success! - found the file id " 
-                        + fileId + " in the edit version.");
                 this.fileMetadatas.add(fileMetadata);
                 selectedFileIds.remove(fileId);
             }

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/datafile/page/EditDatafilesPage.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/datafile/page/EditDatafilesPage.java
@@ -177,9 +177,9 @@ public class EditDatafilesPage implements java.io.Serializable {
 
     private boolean saveEnabled = false;
 
-    private long maxFileUploadSizeInBytes = Long.MAX_VALUE;
-    private int multipleUploadFilesLimit = Integer.MAX_VALUE;
-    private long singleUploadBatchMaxSize = Long.MAX_VALUE;
+    private long maxFileUploadSizeInBytes;
+    private int multipleUploadFilesLimit;
+    private long singleUploadBatchMaxSize;
 
     private List<SelectItem> termsOfUseSelectItems;
     private List<FileMetadata> selectedFiles;
@@ -459,19 +459,19 @@ public class EditDatafilesPage implements java.io.Serializable {
      *  This may be null, signifying unlimited download size.
      */
     public String getHumanMaxFileUploadSize() {
-        return bytesToHumanReadable(this.maxFileUploadSizeInBytes);
+        return bytesToHumanReadable(getMaxFileUploadSizeInBytes());
     }
-
-    public boolean isUnlimitedUploadFileSize() {
-        return this.maxFileUploadSizeInBytes == Long.MAX_VALUE;
+    
+    public boolean isUploadFileSizeSet() {
+        return getMaxFileUploadSizeInBytes() < Long.MAX_VALUE;
     }
     
     public boolean isBatchSizeSet() {
-    	return this.singleUploadBatchMaxSize < Long.MAX_VALUE;
+    	return getSingleUploadBatchMaxSize() < Long.MAX_VALUE;
     }
 
     public String getHumanMaxBatchUploadSize() {
-        return bytesToHumanReadable(this.singleUploadBatchMaxSize);
+        return bytesToHumanReadable(getSingleUploadBatchMaxSize());
     }
 
     public String getUploadBatchTooBigMessage() {
@@ -506,9 +506,7 @@ public class EditDatafilesPage implements java.io.Serializable {
             return this.permissionsWrapper.notFound();
         }
 
-        this.maxFileUploadSizeInBytes = this.settings.getValueForKeyAsLong(Key.MaxFileUploadSizeInBytes, Long.MAX_VALUE);
-        this.multipleUploadFilesLimit = this.settings.getValueForKeyAsInt(Key.MultipleUploadFilesLimit, Integer.MAX_VALUE);
-        this.singleUploadBatchMaxSize = this.settings.getValueForKeyAsLong(Key.SingleUploadBatchMaxSize, Long.MAX_VALUE);
+        initUploadLimits();
         this.workingVersion = version;
         this.dataset = version.getDataset();
         this.mode = FileEditMode.CREATE;
@@ -528,9 +526,7 @@ public class EditDatafilesPage implements java.io.Serializable {
         this.uploadedFiles = new ArrayList<>();
         cleanupTempFiles();
 
-        this.maxFileUploadSizeInBytes = this.settings.getValueForKeyAsLong(Key.MaxFileUploadSizeInBytes, Long.MAX_VALUE);
-        this.multipleUploadFilesLimit = this.settings.getValueForKeyAsInt(Key.MultipleUploadFilesLimit, Integer.MAX_VALUE);
-        this.singleUploadBatchMaxSize = this.settings.getValueForKeyAsLong(Key.SingleUploadBatchMaxSize, Long.MAX_VALUE);
+        initUploadLimits();
         this.termsOfUseSelectItems = this.termsOfUseSelectItemsFactory.buildLicenseSelectItems();
 
         if (this.dataset.getId() != null) {
@@ -580,6 +576,12 @@ public class EditDatafilesPage implements java.io.Serializable {
             setUpRsync();
         }
         return null;
+    }
+    
+    private void initUploadLimits() {
+    	this.maxFileUploadSizeInBytes = this.settings.getValueForKeyAsLong(Key.MaxFileUploadSizeInBytes);
+        this.multipleUploadFilesLimit = this.settings.getValueForKeyAsInt(Key.MultipleUploadFilesLimit);
+        this.singleUploadBatchMaxSize = this.settings.getValueForKeyAsLong(Key.SingleUploadBatchMaxSize);
     }
 
     public boolean isInUploadMode() {
@@ -926,7 +928,7 @@ public class EditDatafilesPage implements java.io.Serializable {
             // Check file size
             //  - Max size NOT specified in db: default is unlimited
             //  - Max size specified in db: check too make sure file is within limits
-            if (!isUnlimitedUploadFileSize() && fileSize > getMaxFileUploadSizeInBytes()) {
+            if (fileSize > getMaxFileUploadSizeInBytes()) {
                 String warningMessage = "Dropbox file \"" + fileName + 
                         "\" exceeded the limit of " + fileSize 
                         + " bytes and was not uploaded.";

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/datafile/page/EditDatafilesPage.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/datafile/page/EditDatafilesPage.java
@@ -178,7 +178,7 @@ public class EditDatafilesPage implements java.io.Serializable {
     private boolean saveEnabled = false;
 
     private long maxFileUploadSizeInBytes = Long.MAX_VALUE;
-    private long multipleUploadFilesLimit = Long.MAX_VALUE;
+    private int multipleUploadFilesLimit = Integer.MAX_VALUE;
     private long singleUploadBatchMaxSize = Long.MAX_VALUE;
 
     private List<SelectItem> termsOfUseSelectItems;
@@ -286,18 +286,15 @@ public class EditDatafilesPage implements java.io.Serializable {
     }
 
     public long getMaxFileUploadSizeInBytes() {
-        return this.maxFileUploadSizeInBytes;
+        return  ignoreLimits() ? Long.MAX_VALUE : this.maxFileUploadSizeInBytes;
     }
 
-    // The number of files the GUI user is allowed to upload in one batch,
-    // via drag-and-drop, or through the file select dialog. Now configurable
-    // in the Settings table.
-    public long getMaxNumberOfFiles() {
-        return this.multipleUploadFilesLimit;
+    public int getMaxNumberOfFiles() {
+        return ignoreLimits() ? Integer.MAX_VALUE : this.multipleUploadFilesLimit;
     }
     
     public long getSingleUploadBatchMaxSize() {
-        return this.singleUploadBatchMaxSize;
+        return ignoreLimits() ? Long.MAX_VALUE : this.singleUploadBatchMaxSize;
     }
 
     public String getGlobalId() {
@@ -510,7 +507,7 @@ public class EditDatafilesPage implements java.io.Serializable {
         }
 
         this.maxFileUploadSizeInBytes = this.settings.getValueForKeyAsLong(Key.MaxFileUploadSizeInBytes, Long.MAX_VALUE);
-        this.multipleUploadFilesLimit = this.settings.getValueForKeyAsLong(Key.MultipleUploadFilesLimit, Long.MAX_VALUE);
+        this.multipleUploadFilesLimit = this.settings.getValueForKeyAsInt(Key.MultipleUploadFilesLimit, Integer.MAX_VALUE);
         this.singleUploadBatchMaxSize = this.settings.getValueForKeyAsLong(Key.SingleUploadBatchMaxSize, Long.MAX_VALUE);
         this.workingVersion = version;
         this.dataset = version.getDataset();
@@ -532,7 +529,7 @@ public class EditDatafilesPage implements java.io.Serializable {
         cleanupTempFiles();
 
         this.maxFileUploadSizeInBytes = this.settings.getValueForKeyAsLong(Key.MaxFileUploadSizeInBytes, Long.MAX_VALUE);
-        this.multipleUploadFilesLimit = this.settings.getValueForKeyAsLong(Key.MultipleUploadFilesLimit, Long.MAX_VALUE);
+        this.multipleUploadFilesLimit = this.settings.getValueForKeyAsInt(Key.MultipleUploadFilesLimit, Integer.MAX_VALUE);
         this.singleUploadBatchMaxSize = this.settings.getValueForKeyAsLong(Key.SingleUploadBatchMaxSize, Long.MAX_VALUE);
         this.termsOfUseSelectItems = this.termsOfUseSelectItemsFactory.buildLicenseSelectItems();
 
@@ -1062,21 +1059,23 @@ public class EditDatafilesPage implements java.io.Serializable {
     }
     
     private boolean sizeOfFileExceedsLimit(final long fileSize) {
-        return isSuperuserLoggedIn() && this.ignoringMaxUploadLimit
-            ? false
-            : fileSize > this.maxFileUploadSizeInBytes;
+        return ignoreLimits() ? false : fileSize > this.maxFileUploadSizeInBytes;
     }
     
     private boolean sizeOfBatchExceedsLimit(final long fileSize) {
-        return isSuperuserLoggedIn() && this.ignoringMaxUploadLimit
-            ? false
-            : (this.currentBatchSize + fileSize) > this.singleUploadBatchMaxSize;
+        return ignoreLimits() 
+        		? false 
+        		: (this.currentBatchSize + fileSize) > this.singleUploadBatchMaxSize;
     }
 
     private boolean numberOfFilesExceedsLimit() {
-        return isSuperuserLoggedIn() && this.ignoringMaxUploadLimit
+        return ignoreLimits()
             ? false
             : newFiles.size() >= this.multipleUploadFilesLimit;
+    }
+    
+    private boolean ignoreLimits() {
+    	return isSuperuserLoggedIn() && this.ignoringMaxUploadLimit;
     }
 
     /**
@@ -1186,7 +1185,6 @@ public class EditDatafilesPage implements java.io.Serializable {
         return this.session.isSuperUserLoggedIn();
     }
     
-
     public boolean isLocked() {
         if (this.dataset != null) {
             logger.log(Level.FINE, "checking lock status of dataset {0}", this.dataset.getId());

--- a/fairchive-webapp/src/main/resources/config/dataverse.default.properties
+++ b/fairchive-webapp/src/main/resources/config/dataverse.default.properties
@@ -63,7 +63,7 @@ MinutesUntilConfirmEmailTokenExpires=1440
 # 100MB
 ZipDownloadLimit=104857600
 ZipUploadFilesLimit=1000
-MultipleUploadFilesLimit=1000
+MultipleUploadFilesLimit=500
 GuestbookResponsesPageDisplayLimit=5000
 TabularIngestSizeLimit=-1
 # Size (in cells, ie. cases times variables) of greatest table that will be ingested in-memory. Above that other method will be used.
@@ -77,7 +77,7 @@ PVCharacterRules=Alphabetical:1,Digit:1
 PVNumberOfCharacteristics=2
 # Integer.MAX_VALUE
 PVNumberOfConsecutiveDigitsAllowed=2147483647
-MaxFileUploadSizeInBytes=
+MaxFileUploadSizeInBytes=5368709120
 CustomDatasetSummaryFields=dsDescription,subject,keyword,publication,notesText
 #Old Jvm options
 DropboxKey=
@@ -173,7 +173,7 @@ GzipMaxOutputFileSizeInBytes=0
 ReadonlyMode=false
 
 # Maximal size (in bytes) of files that can be uploaded in a single batch. If set to 0 then there's no limit.
-SingleUploadBatchMaxSize=0
+SingleUploadBatchMaxSize=21474836480
 
 # Path for saml service provider properties
 SamlPropertiesPath=

--- a/fairchive-webapp/src/main/webapp/dataset.xhtml
+++ b/fairchive-webapp/src/main/webapp/dataset.xhtml
@@ -425,6 +425,12 @@
                                                     <h:outputText value="#{bundle['dataset.editBtn.itemLabel.upload']}"/>
                                                 </h:outputLink>
                                             </li>
+                                            <li jsf:rendered="#{DatasetPage.superuserLoggedIn}">
+                                                <h:outputLink
+                                                        value="/editdatafiles.xhtml?datasetId=#{DatasetPage.dataset.id}&#38;mode=UPLOAD&#38;ignoringMaxUploadLimit=true">
+                                                    <h:outputText value="#{bundle['dataset.editBtn.itemLabel.uploadIgnoringLimit']}"/>
+                                                </h:outputLink>
+                                            </li>
                                             <li>
                                                 <h:outputLink
                                                         value="/editDatasetMetadata.xhtml?datasetId=#{DatasetPage.dataset.id}">

--- a/fairchive-webapp/src/main/webapp/editFilesFragment.xhtml
+++ b/fairchive-webapp/src/main/webapp/editFilesFragment.xhtml
@@ -114,7 +114,7 @@
                                         <f:param value="#{EditDatafilesPage.multipleUploadFilesLimit}"/>
                                     </h:outputFormat>
                                     <h:outputFormat value=" #{bundle['file.selectToAdd.tipLimit']}" escape="false"
-                                                    rendered="#{!EditDatafilesPage.unlimitedUploadFileSize}">
+                                                    rendered="#{EditDatafilesPage.uploadFileSizeSet}">
                                         <f:param value="#{EditDatafilesPage.humanMaxFileUploadSize}"/>
                                     </h:outputFormat>
                                     <h:outputFormat value=" #{bundle['file.selectToAdd.tipBatchLimit']}" escape="false"

--- a/fairchive-webapp/src/main/webapp/editFilesFragment.xhtml
+++ b/fairchive-webapp/src/main/webapp/editFilesFragment.xhtml
@@ -121,12 +121,6 @@
                                                     rendered="#{EditDatafilesPage.batchSizeSet}">
                                         <f:param value="#{EditDatafilesPage.humanMaxBatchUploadSize}"/>
                                     </h:outputFormat>
-                                    <p:selectBooleanCheckbox 
-                                        rendered="#{EditDatafilesPage.superuserLoggedIn}"
-                                        value="#{EditDatafilesPage.ignoringMaxUploadLimit}"
-                                        itemLabel="#{bundle['file.selectToAdd.ignoreLimits']}"> 
-                                            <p:ajax/>
-                                        </p:selectBooleanCheckbox>
                                 </p>
 
                                 <script>
@@ -188,15 +182,15 @@
                                               oncomplete="uploadFinished(PF('fileUploadWidget'));"
                                               onstart="javascript:uploadWidgetDropRemoveMsg();uploadStarted();"
                                               onerror="javascript:uploadFailure();"
-                                              invalidSizeMessage="#{bundle['file.edit.error.file_exceeds_limit']}"
+                                              invalidSizeMessage="#{EditDatafilesPage.uploadFileTooBigMessage}"
+                                              fileLimitMessage="#{EditDatafilesPage.uploadBatchFileCountTooBigMessage}"
                                               sequential="true"
-                                              widgetVar="fileUploadWidget"/>
-                                              <!-- 
+                                              widgetVar="fileUploadWidget"
                                               fileLimit="#{EditDatafilesPage.maxNumberOfFiles}"
                                               sizeLimit="#{EditDatafilesPage.maxFileUploadSizeInBytes}"
                                               pt:data-maxBatchSize="#{EditDatafilesPage.singleUploadBatchMaxSize}"
                                               pt:data-uploadBatchTooBigMessage="#{EditDatafilesPage.uploadBatchTooBigMessage}"
-                                              -->
+                                              />
                                 <div jsf:id="dropboxBlock"
                                      jsf:rendered="#{settingsWrapper.isHasDropBoxKey() and !lockedFromEdits }"
                                      class="margin-top">

--- a/fairchive-webapp/src/main/webapp/editFilesFragment.xhtml
+++ b/fairchive-webapp/src/main/webapp/editFilesFragment.xhtml
@@ -118,7 +118,7 @@
                                         <f:param value="#{EditDatafilesPage.humanMaxFileUploadSize}"/>
                                     </h:outputFormat>
                                     <h:outputFormat value=" #{bundle['file.selectToAdd.tipBatchLimit']}" escape="false"
-                                                    rendered="#{EditDatafilesPage.maxBatchSize > 0}">
+                                                    rendered="#{EditDatafilesPage.batchSizeSet}">
                                         <f:param value="#{EditDatafilesPage.humanMaxBatchUploadSize}"/>
                                     </h:outputFormat>
                                     <p:selectBooleanCheckbox 
@@ -188,13 +188,15 @@
                                               oncomplete="uploadFinished(PF('fileUploadWidget'));"
                                               onstart="javascript:uploadWidgetDropRemoveMsg();uploadStarted();"
                                               onerror="javascript:uploadFailure();"
-                                              fileLimit="#{EditDatafilesPage.getMaxNumberOfFiles()}"
                                               invalidSizeMessage="#{bundle['file.edit.error.file_exceeds_limit']}"
                                               sequential="true"
-                                              pt:data-maxBatchSize="#{EditDatafilesPage.maxBatchSize}"
-                                              pt:data-uploadBatchTooBigMessage="#{EditDatafilesPage.uploadBatchTooBigMessage}"
                                               widgetVar="fileUploadWidget"/>
-
+                                              <!-- 
+                                              fileLimit="#{EditDatafilesPage.maxNumberOfFiles}"
+                                              sizeLimit="#{EditDatafilesPage.maxFileUploadSizeInBytes}"
+                                              pt:data-maxBatchSize="#{EditDatafilesPage.singleUploadBatchMaxSize}"
+                                              pt:data-uploadBatchTooBigMessage="#{EditDatafilesPage.uploadBatchTooBigMessage}"
+                                              -->
                                 <div jsf:id="dropboxBlock"
                                      jsf:rendered="#{settingsWrapper.isHasDropBoxKey() and !lockedFromEdits }"
                                      class="margin-top">

--- a/fairchive-webapp/src/main/webapp/editdatafiles.xhtml
+++ b/fairchive-webapp/src/main/webapp/editdatafiles.xhtml
@@ -25,6 +25,7 @@
                 <f:metadata>
                     <f:viewParam name="datasetId" value="#{EditDatafilesPage.dataset.id}"/>
                     <f:viewParam name="mode" value="#{EditDatafilesPage.mode}"/>
+                    <f:viewParam name="ignoringMaxUploadLimit" value="#{EditDatafilesPage.ignoringMaxUploadLimit}"/>
                     <!-- f:viewParam name="versionId" value="#.EditDatafilesPage.versionId."/ -->
                     <f:viewParam name="selectedFileIds" value="#{EditDatafilesPage.selectedFileIds}"/>
                     <f:viewParam name="versionString" value="#{EditDatafilesPage.versionString}"/>


### PR DESCRIPTION
The decision was to remove the "ignore limists" check box from the view and to provide a separate option "Upload witout limits" in an "Edit" menu of a dataset wchich runs the view in an limitless mode.