### PR TITLE
Refs #3269: Allow for overriding dataset publication messages

### DIFF
--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
@@ -1326,6 +1326,16 @@ public class DatasetPage implements Serializable {
         return termsOfUse.getIcon().map(this::toStreamedContent);
     }
 
+    /**
+     * Retrieves a localized string from the application bundle. Goes through
+     * the alternate bundles if the primary bundle does not contain the key.
+     * This allows for overriding the message in an extension, as referring to
+     * the bundle directly in the template won't work.
+     */
+    public String getMessage(String key) {
+        return BundleUtil.getStringFromBundle(key);
+    }
+
     // -------------------- PRIVATE ---------------------
     
     private DefaultStreamedContent toStreamedContent(final LicenseIcon icon) {

--- a/fairchive-webapp/src/main/webapp/dataset.xhtml
+++ b/fairchive-webapp/src/main/webapp/dataset.xhtml
@@ -1149,7 +1149,7 @@
                           rendered="#{DatasetPage.canPublishDataset()}">
 
                     <p class="text-warning">
-                        <span class="glyphicon glyphicon-warning-sign"/> #{bundle['dataset.publish.tip']}
+                        <span class="glyphicon glyphicon-warning-sign"/> #{DatasetPage.getMessage('dataset.publish.tip')}
                     </p>
                     <div id="terms-agreement-block" class="well"
                          jsf:rendered="#{DatasetPage.datasetPublishCustomText.length() > 0}">
@@ -1206,7 +1206,7 @@
                                       escape="false"/>
                     </div>
                     <p class="help-block">
-                        #{bundle['dataset.publishBoth.tip']}
+                        #{DatasetPage.getMessage('dataset.publishBoth.tip')}
                     </p>
                     <div class="button-block">
                         <p:commandButton value="#{bundle['dataset.mayNotBePublished.both.button']}"


### PR DESCRIPTION
Obviously, this is a half-measure. I'm only changing the two places with the messages we care about in our extension. I don't think we can afford anything more than this, though. If this gets approved, the task will remain open.