### PR TITLE
Closes #3343: Fix error when removing multiplicable compound metadata fields

### DIFF
--- a/fairchive-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/dataset/DatasetFieldsOfType.java
+++ b/fairchive-persistence/src/main/java/edu/harvard/iq/dataverse/persistence/dataset/DatasetFieldsOfType.java
@@ -95,6 +95,10 @@ public final class DatasetFieldsOfType implements Iterable<DatasetField> {
     	this.fields.clear();
         return addEmpty();
     }
+
+    public void removeDatasetField(int position) {
+        fields.remove(position);
+    }
     
     public DatasetField getLast() {
         return this.fields.isEmpty()? addEmpty() : this.fields.get(size() - 1);


### PR DESCRIPTION
Bug was introduced with one of the refactorings.

When class `DatasetFieldsOfType` changed the name from `DatasetFieldsByType` method `removeDatasetField` was removed. But this method is used on the template `editMetadata.xhtml`.

This PR restores the missing method
