### PR TITLE
Closes #3345: Fix migration adding new role

### DIFF
--- a/fairchive-persistence/src/main/resources/db/migration/V96__add_Collection_Custodian_role.sql
+++ b/fairchive-persistence/src/main/resources/db/migration/V96__add_Collection_Custodian_role.sql
@@ -1,2 +1,2 @@
 INSERT INTO dataverserole (id, alias, description, name, permissionbits, owner_id) 
-    VALUES (10, 'collectionCustodian', 'Allows user to edit a collection, but not to publish it or to publish datasets deposited within this collection.', 'Collection Custodian', 2084, NULL);
+    VALUES (nextval('dataverserole_id_seq'), 'collectionCustodian', 'Allows user to edit a collection, but not to publish it or to publish datasets deposited within this collection.', 'Collection Custodian', 2084, NULL);


### PR DESCRIPTION
We cannot rely on static numbers when inserting roles. Roles can also be created from UI so it can happen that id will be taken