### PR TITLE
Closes #3362 Add column with persistend identifiers to CSV with searc…

### DIFF
--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/search/CSVResultPrinter.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/search/CSVResultPrinter.java
@@ -1,6 +1,7 @@
 package edu.harvard.iq.dataverse.search;
 
 import static java.util.Collections.emptyList;
+import static org.apache.commons.lang3.StringUtils.defaultString;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -50,6 +51,7 @@ public final class CSVResultPrinter {
                     printer.print(result.getId());
                     printer.print(result.getName());
                     printer.print(result.getTitle());
+                    printer.print(defaultString(result.getPersistentId()));
                     if (result.isDataset()) {
                         printMetadata(printer, result);
                     }
@@ -71,6 +73,7 @@ public final class CSVResultPrinter {
         printer.print("Id");
         printer.print("Name");
         printer.print("Title");
+        printer.print("Persistent ID");
         for (final DatasetFieldType type : this.exportedFields) {
             if (type.getParentDatasetFieldType() != null) {
                 printer.print(type.getMetadataBlock().getName() + "->"

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/search/SearchServiceBean.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/search/SearchServiceBean.java
@@ -401,6 +401,7 @@ public class SearchServiceBean {
         String citation = getLocalizedValueWithFallback(solrDocument, SearchFields.DATASET_CITATION);
         String citationPlainHtml = getLocalizedValueWithFallback(solrDocument, SearchFields.DATASET_CITATION_HTML);
         String persistentUrl = (String) solrDocument.getFieldValue(SearchFields.PERSISTENT_URL);
+        String persistentId = (String) solrDocument.getFieldValue(SearchFields.DATASET_PERSISTENT_ID);
         String name = (String) solrDocument.getFieldValue(SearchFields.NAME);
         String nameSort = (String) solrDocument.getFieldValue(SearchFields.NAME_SORT);
         String title = (String) solrDocument.getFirstValue(titleSolrField);
@@ -456,6 +457,7 @@ public class SearchServiceBean {
         solrSearchResult.setEntityId(entityId);
         solrSearchResult.setIdentifier(identifier);
         solrSearchResult.setPersistentUrl(persistentUrl);
+        solrSearchResult.setPersistentId(persistentId);
         solrSearchResult.setType(type);
         solrSearchResult.setScore(score);
         solrSearchResult.setNameSort(nameSort);

--- a/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/search/response/SolrSearchResult.java
+++ b/fairchive-webapp/src/main/java/edu/harvard/iq/dataverse/search/response/SolrSearchResult.java
@@ -27,6 +27,7 @@ public class SolrSearchResult {
     private SearchObjectType type;
     private String htmlUrl;
     private String persistentUrl;
+    private String persistentId;
     private String downloadUrl;
     private String apiUrl;
     /**
@@ -196,7 +197,11 @@ public class SolrSearchResult {
         return persistentUrl;
     }
 
-    public String getDownloadUrl() {
+    public String getPersistentId() {
+		return persistentId;
+	}
+
+	public String getDownloadUrl() {
         return downloadUrl;
     }
 
@@ -378,7 +383,11 @@ public class SolrSearchResult {
         this.persistentUrl = persistentUrl;
     }
 
-    public void setDownloadUrl(String downloadUrl) {
+    public void setPersistentId(String persistentId) {
+		this.persistentId = persistentId;
+	}
+
+	public void setDownloadUrl(String downloadUrl) {
         this.downloadUrl = downloadUrl;
     }
 

--- a/fairchive-webapp/src/test/java/edu/harvard/iq/dataverse/search/SearchIncludeFragmentTest.java
+++ b/fairchive-webapp/src/test/java/edu/harvard/iq/dataverse/search/SearchIncludeFragmentTest.java
@@ -156,6 +156,8 @@ public class SearchIncludeFragmentTest {
         intendedResult.setEntityId(1L);
         intendedResult.setName("name1");
         intendedResult.setTitle("title1");
+        intendedResult.setPersistentId("id,1");
+        
         
         when(this.searchService.search(any(), any(), anyString(), any(), any(), any(),
                 any(), anyInt(), anyInt(), anyBoolean())).thenReturn(responseOf());
@@ -177,8 +179,8 @@ public class SearchIncludeFragmentTest {
 
         List<String> lines = readLines(file.getStream(), "utf-8");
         assertThat(lines.size()).isEqualTo(2);
-        assertThat(lines.get(0)).isEqualTo(BOM + "Id,Name,Title,Block1->def,Block1->compound->ghi");
-        assertThat(lines.get(1)).isEqualTo("id1,name1,title1,one,two");
+        assertThat(lines.get(0)).isEqualTo(BOM + "Id,Name,Title,Persistent ID,Block1->def,Block1->compound->ghi");
+        assertThat(lines.get(1)).isEqualTo("id1,name1,title1,\"id,1\",one,two");
     }
 
     @Test
@@ -198,11 +200,11 @@ public class SearchIncludeFragmentTest {
         assertThat(file.getContentEncoding()).isEqualTo("utf-8");
         assertThat(file.getContentType()).isEqualTo("text/csv");
         assertThat(file.getName()).isEqualTo("searchResults.csv");
-        assertThat(file.getContentLength()).isEqualTo(52);
+        assertThat(file.getContentLength()).isEqualTo(66);
 
         List<String> lines = readLines(file.getStream(), "utf-8");
         assertThat(lines.size()).isEqualTo(1);
-        assertThat(lines.get(0)).isEqualTo(BOM + "Id,Name,Title,Block1->def,Block1->compound->ghi");
+        assertThat(lines.get(0)).isEqualTo(BOM + "Id,Name,Title,Persistent ID,Block1->def,Block1->compound->ghi");
     }
 
     @Test


### PR DESCRIPTION
…h results
https://git.icm.edu.pl/dariah/archeo/-/work_items/224


Some persistent Id's can be urls like http://blabla.com/id, abc , urls can contain comas, thats's why the test verifies it.
