### PR TITLE
Closes #3370 Geospatial metadata should not be visible via anonimized…

### DIFF
--- a/fairchive-persistence/src/main/resources/db/migration/V97__change_visiblethroughanonymizedurl_default_to_false.sql
+++ b/fairchive-persistence/src/main/resources/db/migration/V97__change_visiblethroughanonymizedurl_default_to_false.sql
@@ -1,0 +1,1 @@
+ALTER TABLE datasetfieldtype ALTER COLUMN visiblethroughanonymizedurl SET DEFAULT false;


### PR DESCRIPTION
… private URL


chanded visiblethroughanonymizedurl for all geospatial data to false on procuction

since geospatial TSV does not specify this for every field,  chcnged default settinh in db to false

it is also safer because ne metadata will be not accidentally visible by anynymized url unless specified so.